### PR TITLE
Broker: serve relay city/country/coordinates for client display

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -30,12 +30,14 @@ func run() error {
 	relayStore := flag.String("relay-store", envDefault("OPENRUNG_RELAY_STORE", "memory"), "relay state backend: memory or postgres")
 	relayDatabaseURL := flag.String("relay-database-url", os.Getenv("OPENRUNG_RELAY_DATABASE_URL"), "PostgreSQL database URL for relay state")
 	relayRanking := flag.String("relay-ranking", envDefault("OPENRUNG_RELAY_RANKING", "global"), "relay ranking mode: global or legacy")
+	geoIPEndpoint := flag.String("geoip-endpoint", envDefault("OPENRUNG_GEOIP_ENDPOINT", broker.DefaultGeoIPEndpoint), "IP geolocation HTTP endpoint for relay city/country lookups (relay host is appended); 'off' disables")
 	flag.Parse()
 
 	rankingMode, err := broker.ParseRankingMode(*relayRanking)
 	if err != nil {
 		return err
 	}
+	geoResolver := newGeoIPResolver(*geoIPEndpoint)
 	store, err := newRelayStore(*relayStore, *relayDatabaseURL, rankingMode)
 	if err != nil {
 		return err
@@ -55,6 +57,7 @@ func run() error {
 		DashboardToken:    os.Getenv("OPENRUNG_DASHBOARD_TOKEN"),
 		// Cloudflare's published ranges are trusted by default; add more (e.g. an upstream LB) here.
 		TrustedProxyCIDRs: splitAndTrim(os.Getenv("OPENRUNG_TRUSTED_PROXY_CIDRS")),
+		GeoIP:             geoResolver,
 	})
 	maintenanceInterval := *statusInterval
 	if maintenanceInterval <= 0 {
@@ -77,7 +80,7 @@ func run() error {
 		close(shutdownDone)
 	}()
 
-	slog.Info("starting broker", "addr", *addr, "lease_ttl", leaseTTL.String(), "telemetry_file", *telemetryFile, "relay_store", *relayStore, "relay_ranking", rankingMode, "dashboard_enabled", os.Getenv("OPENRUNG_DASHBOARD_TOKEN") != "", "status_interval", statusInterval.String())
+	slog.Info("starting broker", "addr", *addr, "lease_ttl", leaseTTL.String(), "telemetry_file", *telemetryFile, "relay_store", *relayStore, "relay_ranking", rankingMode, "dashboard_enabled", os.Getenv("OPENRUNG_DASHBOARD_TOKEN") != "", "status_interval", statusInterval.String(), "geoip_enabled", geoResolver != nil)
 	err = server.ListenAndServe()
 	if errors.Is(err, http.ErrServerClosed) {
 		<-shutdownDone
@@ -99,6 +102,17 @@ func newRelayStore(storeMode, databaseURL string, rankingMode broker.RankingMode
 		return broker.NewPostgresStore(ctx, databaseURL, rankingMode)
 	default:
 		return nil, errors.New("relay-store must be memory or postgres")
+	}
+}
+
+// newGeoIPResolver returns nil (geo lookups disabled) for "off"-style values
+// so operators can opt out without leaving the flag empty.
+func newGeoIPResolver(endpoint string) broker.GeoIPResolver {
+	switch strings.ToLower(strings.TrimSpace(endpoint)) {
+	case "", "off", "disabled", "none":
+		return nil
+	default:
+		return broker.NewHTTPGeoIPResolver(endpoint)
 	}
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -187,6 +187,13 @@ Request:
 volunteers with `transport: "tunnel"` and a `public_host`/`public_port` pointing
 at the hub; clients treat both the same.
 
+For tunnel registrations the hub also sends `exit_host`: the volunteer's public
+source IP as observed on its control connection, i.e. where tunneled traffic
+actually exits. The broker uses it only to geolocate the relay and never
+exposes it through any public endpoint, so a CGNAT volunteer's real IP stays
+private. `exit_host` is rejected for direct transport, where `public_host`
+already is the exit.
+
 Response:
 
 ```json
@@ -194,6 +201,11 @@ Response:
   "id": "relay_...",
   "public_host": "2001:db8::1",
   "public_port": 443,
+  "city": "Tokyo",
+  "country": "Japan",
+  "country_code": "JP",
+  "latitude": 35.6895,
+  "longitude": 139.6917,
   "protocol": "vless-reality-vision",
   "client_id": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff",
   "reality_public_key": "xray-public-key",
@@ -209,6 +221,13 @@ Response:
   "expires_at": "2026-06-09T07:03:00Z"
 }
 ```
+
+`city`, `country`, and `country_code` are resolved by the broker (never taken
+from the volunteer request) so clients can show where a relay's traffic
+physically exits: from `exit_host` for tunnel relays and from `public_host`
+for direct relays. The lookup is best-effort: when it has not succeeded yet
+the fields are omitted, and the broker retries on heartbeats until it
+resolves.
 
 ## Heartbeat
 
@@ -254,6 +273,11 @@ Response:
       "id": "relay_...",
       "public_host": "2001:db8::1",
       "public_port": 443,
+      "city": "Tokyo",
+      "country": "Japan",
+      "country_code": "JP",
+      "latitude": 35.6895,
+      "longitude": 139.6917,
       "protocol": "vless-reality-vision",
       "client_id": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff",
       "reality_public_key": "xray-public-key",

--- a/internal/broker/geoip.go
+++ b/internal/broker/geoip.go
@@ -1,0 +1,192 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+// DefaultGeoIPEndpoint matches the provider the Android client and CLI already
+// use for their own public-IP geo (see internal/clienttelemetry). The looked-up
+// host is appended to the endpoint path.
+const DefaultGeoIPEndpoint = "https://ipwho.is/"
+
+const (
+	geoIPLookupTimeout    = 4 * time.Second
+	geoIPSuccessCacheTTL  = 24 * time.Hour
+	geoIPFailureCacheTTL  = 10 * time.Minute
+	geoIPMaxCacheEntries  = 4096
+	geoIPMaxResponseBytes = 64 << 10
+)
+
+// GeoIPResolver resolves the physical location of a relay's public endpoint.
+// Lookups are best-effort: the broker registers and heartbeats relays normally
+// when a lookup fails.
+type GeoIPResolver interface {
+	Lookup(ctx context.Context, host string) (relay.GeoLocation, error)
+}
+
+// HTTPGeoIPResolver queries an ip-geolocation HTTP endpoint (ipwho.is by
+// default; ip-api.com-style responses are understood too) and caches results
+// per host so registrations and heartbeat backfills do not hammer the
+// provider's rate limits.
+type HTTPGeoIPResolver struct {
+	endpoint string
+	client   *http.Client
+	now      func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]geoCacheEntry
+}
+
+type geoCacheEntry struct {
+	geo       relay.GeoLocation
+	err       error
+	expiresAt time.Time
+}
+
+func NewHTTPGeoIPResolver(endpoint string) *HTTPGeoIPResolver {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		endpoint = DefaultGeoIPEndpoint
+	}
+	if !strings.HasSuffix(endpoint, "/") {
+		endpoint += "/"
+	}
+	return &HTTPGeoIPResolver{
+		endpoint: endpoint,
+		client:   &http.Client{Timeout: geoIPLookupTimeout},
+		now:      time.Now,
+		cache:    make(map[string]geoCacheEntry),
+	}
+}
+
+func (r *HTTPGeoIPResolver) Lookup(ctx context.Context, host string) (relay.GeoLocation, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return relay.GeoLocation{}, errors.New("geoip lookup requires a host")
+	}
+
+	if entry, ok := r.cached(host); ok {
+		return entry.geo, entry.err
+	}
+
+	geo, err := r.fetch(ctx, host)
+	// Context cancellations describe the caller, not the host; retrying later
+	// may well succeed, so don't poison the cache with them.
+	if err == nil || !errors.Is(err, context.Canceled) {
+		r.store(host, geo, err)
+	}
+	return geo, err
+}
+
+func (r *HTTPGeoIPResolver) cached(host string) (geoCacheEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.cache[host]
+	if !ok || r.now().After(entry.expiresAt) {
+		return geoCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (r *HTTPGeoIPResolver) store(host string, geo relay.GeoLocation, err error) {
+	ttl := geoIPSuccessCacheTTL
+	if err != nil {
+		ttl = geoIPFailureCacheTTL
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.now()
+	if len(r.cache) >= geoIPMaxCacheEntries {
+		for key, entry := range r.cache {
+			if now.After(entry.expiresAt) {
+				delete(r.cache, key)
+			}
+		}
+		if len(r.cache) >= geoIPMaxCacheEntries {
+			r.cache = make(map[string]geoCacheEntry)
+		}
+	}
+	r.cache[host] = geoCacheEntry{geo: geo, err: err, expiresAt: now.Add(ttl)}
+}
+
+func (r *HTTPGeoIPResolver) fetch(ctx context.Context, host string) (relay.GeoLocation, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint+url.PathEscape(host), nil)
+	if err != nil {
+		return relay.GeoLocation{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return relay.GeoLocation{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return relay.GeoLocation{}, fmt.Errorf("geoip endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, geoIPMaxResponseBytes))
+	if err != nil {
+		return relay.GeoLocation{}, err
+	}
+	return decodeGeoLocation(body)
+}
+
+// geoIPLookupResponse covers both ipwho.is ("success"/"country_code"/
+// "latitude") and ip-api.com ("status"/"countryCode"/"lat") response shapes.
+type geoIPLookupResponse struct {
+	Success          *bool   `json:"success"`
+	Status           string  `json:"status"`
+	Message          string  `json:"message"`
+	City             string  `json:"city"`
+	Country          string  `json:"country"`
+	CountryCode      string  `json:"country_code"`
+	CountryCodeCamel string  `json:"countryCode"`
+	Latitude         float64 `json:"latitude"`
+	Longitude        float64 `json:"longitude"`
+	Lat              float64 `json:"lat"`
+	Lon              float64 `json:"lon"`
+}
+
+func decodeGeoLocation(body []byte) (relay.GeoLocation, error) {
+	var parsed geoIPLookupResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return relay.GeoLocation{}, fmt.Errorf("decode geoip response: %w", err)
+	}
+	failed := (parsed.Success != nil && !*parsed.Success) ||
+		(parsed.Status != "" && parsed.Status != "success")
+	if failed {
+		message := strings.TrimSpace(parsed.Message)
+		if message == "" {
+			message = "lookup failed"
+		}
+		return relay.GeoLocation{}, fmt.Errorf("geoip endpoint rejected lookup: %s", message)
+	}
+
+	geo := relay.GeoLocation{
+		City:        strings.TrimSpace(parsed.City),
+		Country:     strings.TrimSpace(parsed.Country),
+		CountryCode: strings.TrimSpace(firstNonEmpty(parsed.CountryCode, parsed.CountryCodeCamel)),
+		Latitude:    parsed.Latitude,
+		Longitude:   parsed.Longitude,
+	}
+	if geo.Latitude == 0 && geo.Longitude == 0 {
+		geo.Latitude, geo.Longitude = parsed.Lat, parsed.Lon
+	}
+	if geo == (relay.GeoLocation{}) {
+		return relay.GeoLocation{}, errors.New("geoip endpoint returned no location fields")
+	}
+	return geo, nil
+}

--- a/internal/broker/geoip_test.go
+++ b/internal/broker/geoip_test.go
@@ -1,0 +1,99 @@
+package broker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+func TestHTTPGeoIPResolverParsesIpwhoisAndCaches(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/203.0.113.10" {
+			t.Errorf("unexpected lookup path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ip":"203.0.113.10","success":true,"country":"Japan","country_code":"JP","city":"Tokyo","latitude":35.6895,"longitude":139.6917}`))
+	}))
+	defer server.Close()
+
+	resolver := NewHTTPGeoIPResolver(server.URL)
+	want := relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP", Latitude: 35.6895, Longitude: 139.6917}
+	for attempt := 0; attempt < 2; attempt++ {
+		geo, err := resolver.Lookup(context.Background(), "203.0.113.10")
+		if err != nil {
+			t.Fatalf("lookup attempt %d: %v", attempt, err)
+		}
+		if geo != want {
+			t.Fatalf("lookup attempt %d = %+v, want %+v", attempt, geo, want)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("expected second lookup to hit the cache, got %d requests", requests)
+	}
+}
+
+func TestHTTPGeoIPResolverParsesIPAPIShape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","country":"Germany","countryCode":"DE","city":"Berlin","lat":52.52,"lon":13.405}`))
+	}))
+	defer server.Close()
+
+	geo, err := NewHTTPGeoIPResolver(server.URL).Lookup(context.Background(), "198.51.100.7")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	want := relay.GeoLocation{City: "Berlin", Country: "Germany", CountryCode: "DE", Latitude: 52.52, Longitude: 13.405}
+	if geo != want {
+		t.Fatalf("lookup = %+v, want %+v", geo, want)
+	}
+}
+
+func TestHTTPGeoIPResolverCachesFailuresUntilTTL(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":false,"message":"reserved range"}`))
+	}))
+	defer server.Close()
+
+	resolver := NewHTTPGeoIPResolver(server.URL)
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	resolver.now = func() time.Time { return now }
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if _, err := resolver.Lookup(context.Background(), "192.168.1.1"); err == nil {
+			t.Fatalf("expected rejected lookup to fail on attempt %d", attempt)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("expected failure to be cached, got %d requests", requests)
+	}
+
+	now = now.Add(geoIPFailureCacheTTL + time.Second)
+	if _, err := resolver.Lookup(context.Background(), "192.168.1.1"); err == nil {
+		t.Fatal("expected retried lookup to fail")
+	}
+	if requests != 2 {
+		t.Fatalf("expected failure cache to expire, got %d requests", requests)
+	}
+}
+
+func TestHTTPGeoIPResolverRejectsEmptyLocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer server.Close()
+
+	if _, err := NewHTTPGeoIPResolver(server.URL).Lookup(context.Background(), "203.0.113.10"); err == nil {
+		t.Fatal("expected lookup without location fields to fail")
+	}
+}

--- a/internal/broker/postgres_store.go
+++ b/internal/broker/postgres_store.go
@@ -34,7 +34,13 @@ const descriptorColumns = `
 	label,
 	transport,
 	punch_capable,
-	punch_endpoint
+	punch_endpoint,
+	city,
+	country,
+	country_code,
+	latitude,
+	longitude,
+	exit_host
 `
 
 const postgresOperationTimeout = 5 * time.Second
@@ -62,6 +68,12 @@ CREATE TABLE IF NOT EXISTS relay_descriptors (
 	transport text NOT NULL DEFAULT 'direct',
 	punch_capable boolean NOT NULL DEFAULT false,
 	punch_endpoint text NOT NULL DEFAULT '',
+	city text NOT NULL DEFAULT '',
+	country text NOT NULL DEFAULT '',
+	country_code text NOT NULL DEFAULT '',
+	latitude double precision NOT NULL DEFAULT 0,
+	longitude double precision NOT NULL DEFAULT 0,
+	exit_host text NOT NULL DEFAULT '',
 	attributes jsonb NOT NULL DEFAULT '{}'::jsonb,
 	UNIQUE (public_host, public_port)
 );
@@ -80,6 +92,24 @@ ALTER TABLE relay_descriptors
 
 ALTER TABLE relay_descriptors
 	ADD COLUMN IF NOT EXISTS punch_endpoint text NOT NULL DEFAULT '';
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS city text NOT NULL DEFAULT '';
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS country text NOT NULL DEFAULT '';
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS country_code text NOT NULL DEFAULT '';
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS latitude double precision NOT NULL DEFAULT 0;
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS longitude double precision NOT NULL DEFAULT 0;
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS exit_host text NOT NULL DEFAULT '';
 
 CREATE INDEX IF NOT EXISTS relay_descriptors_active_idx
 	ON relay_descriptors (expires_at DESC, last_heartbeat_at DESC);
@@ -161,6 +191,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		Label:            req.Label,
 		PublicHost:       req.PublicHost,
 		PublicPort:       req.PublicPort,
+		ExitHost:         req.ExitHost,
 		Protocol:         req.Protocol,
 		ClientID:         req.ClientID,
 		RealityPublicKey: req.RealityPublicKey,
@@ -179,6 +210,11 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		ExpiresAt:        now.Add(ttl),
 	}
 
+	// Geo columns are deliberately absent from the INSERT: a re-registration
+	// at the same host:port keeps its previously resolved location until the
+	// handler's next successful UpdateGeo — except when the exit host changed
+	// (a hub port reused by a different volunteer), where the upsert clears
+	// the stale location so the handler resolves the new exit.
 	return scanDescriptor(s.pool.QueryRow(ctx, `
 		INSERT INTO relay_descriptors (
 			id,
@@ -201,9 +237,10 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			label,
 			transport,
 			punch_capable,
-			punch_endpoint
+			punch_endpoint,
+			exit_host
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22
 		)
 		ON CONFLICT (public_host, public_port) DO UPDATE SET
 			id = EXCLUDED.id,
@@ -224,7 +261,13 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			label = EXCLUDED.label,
 			transport = EXCLUDED.transport,
 			punch_capable = EXCLUDED.punch_capable,
-			punch_endpoint = EXCLUDED.punch_endpoint
+			punch_endpoint = EXCLUDED.punch_endpoint,
+			city = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.city ELSE '' END,
+			country = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.country ELSE '' END,
+			country_code = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.country_code ELSE '' END,
+			latitude = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.latitude ELSE 0 END,
+			longitude = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.longitude ELSE 0 END,
+			exit_host = EXCLUDED.exit_host
 		RETURNING `+descriptorColumns,
 		desc.ID,
 		desc.PublicHost,
@@ -247,6 +290,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		desc.Transport,
 		desc.PunchCapable,
 		desc.PunchEndpoint,
+		desc.ExitHost,
 	))
 }
 
@@ -267,6 +311,24 @@ func (s *PostgresStore) Heartbeat(id string, now time.Time, ttl time.Duration) (
 		return relay.Descriptor{}, ErrRelayNotFound
 	}
 	return desc, err
+}
+
+func (s *PostgresStore) UpdateGeo(id string, geo relay.GeoLocation) error {
+	ctx, cancel := postgresOperationContext()
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE relay_descriptors
+		SET city = $2, country = $3, country_code = $4, latitude = $5, longitude = $6
+		WHERE id = $1
+	`, id, geo.City, geo.Country, geo.CountryCode, geo.Latitude, geo.Longitude)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrRelayNotFound
+	}
+	return nil
 }
 
 func (s *PostgresStore) List(now time.Time, limit int) ([]relay.Descriptor, error) {
@@ -625,6 +687,12 @@ func scanDescriptor(row pgx.Row) (relay.Descriptor, error) {
 		&desc.Transport,
 		&desc.PunchCapable,
 		&desc.PunchEndpoint,
+		&desc.City,
+		&desc.Country,
+		&desc.CountryCode,
+		&desc.Latitude,
+		&desc.Longitude,
+		&desc.ExitHost,
 	)
 	return desc, err
 }

--- a/internal/broker/postgres_store_test.go
+++ b/internal/broker/postgres_store_test.go
@@ -140,6 +140,82 @@ func TestPostgresStoreGlobalRankingUsesSharedMetrics(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreGeoSurvivesReRegistration(t *testing.T) {
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	store := newTestPostgresStore(t, RankingModeGlobal)
+
+	desc, err := store.Register(validRegisterRequest(), now, time.Minute)
+	if err != nil {
+		t.Fatalf("register relay: %v", err)
+	}
+	geo := relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP"}
+	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+		t.Fatalf("update geo: %v", err)
+	}
+	listed, err := store.List(now.Add(time.Second), 10)
+	if err != nil {
+		t.Fatalf("list relays: %v", err)
+	}
+	if len(listed) != 1 || listed[0].GeoLocation != geo {
+		t.Fatalf("expected listed relay to carry geo, got %+v", listed)
+	}
+
+	// Re-registering the same host:port must keep the resolved location.
+	replacement, err := store.Register(validRegisterRequest(), now.Add(2*time.Second), time.Minute)
+	if err != nil {
+		t.Fatalf("re-register relay: %v", err)
+	}
+	if replacement.GeoLocation != geo {
+		t.Fatalf("expected re-registered relay to keep geo, got %+v", replacement.GeoLocation)
+	}
+
+	if err := store.UpdateGeo("relay_missing", geo); !errors.Is(err, ErrRelayNotFound) {
+		t.Fatalf("expected ErrRelayNotFound for unknown relay, got %v", err)
+	}
+}
+
+func TestPostgresStoreExitHostChangeClearsGeo(t *testing.T) {
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	store := newTestPostgresStore(t, RankingModeGlobal)
+
+	req := validRegisterRequest()
+	req.Transport = relay.TransportTunnel
+	req.ExitHost = "198.51.100.7"
+	desc, err := store.Register(req, now, time.Minute)
+	if err != nil {
+		t.Fatalf("register tunnel relay: %v", err)
+	}
+	if desc.ExitHost != "198.51.100.7" {
+		t.Fatalf("expected stored exit host, got %q", desc.ExitHost)
+	}
+	geo := relay.GeoLocation{City: "Tehran", Country: "Iran", CountryCode: "IR"}
+	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+		t.Fatalf("update geo: %v", err)
+	}
+
+	// Same hub endpoint, same exit host: the location sticks.
+	sameExit, err := store.Register(req, now.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatalf("re-register same exit: %v", err)
+	}
+	if sameExit.GeoLocation != geo {
+		t.Fatalf("expected geo to survive same-exit re-registration, got %+v", sameExit.GeoLocation)
+	}
+
+	// Same hub endpoint reused by a different volunteer: stale location cleared.
+	req.ExitHost = "198.51.100.99"
+	newExit, err := store.Register(req, now.Add(2*time.Second), time.Minute)
+	if err != nil {
+		t.Fatalf("re-register new exit: %v", err)
+	}
+	if newExit.GeoLocation != (relay.GeoLocation{}) {
+		t.Fatalf("expected geo cleared after exit host change, got %+v", newExit.GeoLocation)
+	}
+	if newExit.ExitHost != "198.51.100.99" {
+		t.Fatalf("expected updated exit host, got %q", newExit.ExitHost)
+	}
+}
+
 func newTestPostgresStore(t *testing.T, rankingMode RankingMode) *PostgresStore {
 	t.Helper()
 	store := newTestPostgresStoreWithoutCleanup(t, rankingMode)

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -21,6 +22,10 @@ type Config struct {
 	// TrustedProxyCIDRs are additional CIDRs (beyond Cloudflare's published ranges) whose forwarded
 	// CF-Connecting-IP / X-Forwarded-For headers the broker will trust for the real client IP.
 	TrustedProxyCIDRs []string
+	// GeoIP resolves the city/country of a relay's public endpoint so clients
+	// can show where volunteer relays are located. Nil disables lookups;
+	// descriptors then carry empty geo fields.
+	GeoIP GeoIPResolver
 }
 
 func NewServer(store RelayStore, cfg Config) http.Handler {
@@ -83,7 +88,8 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 			writeError(w, http.StatusServiceUnavailable, "could not register relay")
 			return
 		}
-		slog.Info("volunteer registered", "relay_id", desc.ID, "public", desc.PublicHost, "port", desc.PublicPort, "max_sessions", desc.MaxSessions, "version", desc.VolunteerVersion)
+		resolveRelayGeo(r.Context(), store, cfg.GeoIP, &desc)
+		slog.Info("volunteer registered", "relay_id", desc.ID, "public", desc.PublicHost, "port", desc.PublicPort, "city", desc.City, "country", desc.Country, "max_sessions", desc.MaxSessions, "version", desc.VolunteerVersion)
 
 		writeJSON(w, http.StatusCreated, desc)
 	}
@@ -113,8 +119,45 @@ func heartbeatHandler(store RelayStore, cfg Config) http.HandlerFunc {
 			return
 		}
 
+		// Backfill relays whose registration-time lookup failed (or that
+		// registered before the broker resolved locations at all).
+		resolveRelayGeo(r.Context(), store, cfg.GeoIP, &desc)
+
 		writeJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true, ExpiresAt: desc.ExpiresAt})
 	}
+}
+
+// resolveRelayGeo best-effort resolves and persists the location of a relay's
+// public endpoint. It only performs a lookup when the descriptor has no geo
+// yet, and never fails the surrounding request: on lookup or store errors the
+// descriptor simply keeps its empty geo until a later attempt succeeds. The
+// resolver caches failures, so heartbeat-driven retries stay rate-limited.
+func resolveRelayGeo(ctx context.Context, store RelayStore, resolver GeoIPResolver, desc *relay.Descriptor) {
+	if resolver == nil || desc.GeoLocation != (relay.GeoLocation{}) {
+		return
+	}
+	host := geoLookupHost(desc)
+	geo, err := resolver.Lookup(ctx, host)
+	if err != nil {
+		slog.Warn("could not resolve relay location", "relay_id", desc.ID, "host", host, "error", err)
+		return
+	}
+	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+		slog.Warn("could not store relay location", "relay_id", desc.ID, "error", err)
+		return
+	}
+	desc.GeoLocation = geo
+	slog.Info("relay location resolved", "relay_id", desc.ID, "city", geo.City, "country", geo.Country)
+}
+
+// geoLookupHost picks the address whose location clients care about: the
+// volunteer's exit IP when the hub reported one (tunnel transport), otherwise
+// the advertised public endpoint (direct transport, where they coincide).
+func geoLookupHost(desc *relay.Descriptor) string {
+	if desc.ExitHost != "" {
+		return desc.ExitHost
+	}
+	return desc.PublicHost
 }
 
 func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *clientIPResolver) http.HandlerFunc {
@@ -167,6 +210,8 @@ func validateRegisterRequest(req relay.RegisterRequest) error {
 		return errors.New("exit_mode must be direct or dedicated")
 	case req.Transport != "" && req.Transport != relay.TransportDirect && req.Transport != relay.TransportTunnel:
 		return errors.New("transport must be direct or tunnel")
+	case req.ExitHost != "" && req.Transport != relay.TransportTunnel:
+		return errors.New("exit_host is only allowed for tunnel transport")
 	case req.MaxSessions < 1:
 		return errors.New("max_sessions must be at least 1")
 	case req.MaxMbps < 1:

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -60,6 +60,19 @@ func TestValidateTransport(t *testing.T) {
 	}
 }
 
+func TestValidateExitHostRequiresTunnelTransport(t *testing.T) {
+	req := validRegisterRequest()
+	req.ExitHost = "198.51.100.7"
+	if err := validateRegisterRequest(req); err == nil {
+		t.Fatal("expected exit_host on direct transport to be rejected")
+	}
+
+	req.Transport = relay.TransportTunnel
+	if err := validateRegisterRequest(req); err != nil {
+		t.Fatalf("expected exit_host on tunnel transport to be valid: %v", err)
+	}
+}
+
 func TestRegisterDefaultsTransportDirect(t *testing.T) {
 	store := NewStore()
 	desc, err := store.Register(validRegisterRequest(), time.Now().UTC(), time.Minute)
@@ -110,6 +123,109 @@ func TestRegisterRejectsUnsafeLabel(t *testing.T) {
 	}
 }
 
+func TestRegisterResolvesRelayLocation(t *testing.T) {
+	resolver := &stubGeoResolver{geo: relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP", Latitude: 35.6895, Longitude: 139.6917}}
+	server := NewServer(NewStore(), Config{GeoIP: resolver})
+
+	body, _ := json.Marshal(validRegisterRequest())
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var desc relay.Descriptor
+	if err := json.Unmarshal(recorder.Body.Bytes(), &desc); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+	if desc.GeoLocation != resolver.geo {
+		t.Fatalf("expected register response to carry geo, got %+v", desc.GeoLocation)
+	}
+
+	listRecorder := httptest.NewRecorder()
+	server.ServeHTTP(listRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	listBody := listRecorder.Body.String()
+	for _, want := range []string{`"city":"Tokyo"`, `"country":"Japan"`, `"country_code":"JP"`, `"latitude":35.6895`, `"longitude":139.6917`} {
+		if !strings.Contains(listBody, want) {
+			t.Fatalf("expected %s in list response: %s", want, listBody)
+		}
+	}
+}
+
+func TestRegisterGeolocatesTunnelRelayByExitHostWithoutExposingIt(t *testing.T) {
+	resolver := &stubGeoResolver{geo: relay.GeoLocation{City: "Tehran", Country: "Iran", CountryCode: "IR"}}
+	server := NewServer(NewStore(), Config{GeoIP: resolver})
+
+	req := validRegisterRequest()
+	req.PublicHost = "203.0.113.1" // relay hub
+	req.Transport = relay.TransportTunnel
+	req.ExitHost = "198.51.100.7" // volunteer's real IP
+	body, _ := json.Marshal(req)
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(resolver.hosts) != 1 || resolver.hosts[0] != "198.51.100.7" {
+		t.Fatalf("expected geo lookup against the exit host, got %v", resolver.hosts)
+	}
+
+	listRecorder := httptest.NewRecorder()
+	server.ServeHTTP(listRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	listBody := listRecorder.Body.String()
+	if !strings.Contains(listBody, `"city":"Tehran"`) {
+		t.Fatalf("expected exit-host geo in list response: %s", listBody)
+	}
+	// The volunteer's real IP must never leak through the public API.
+	for _, response := range []string{recorder.Body.String(), listBody} {
+		if strings.Contains(response, "198.51.100.7") {
+			t.Fatalf("exit host leaked into API response: %s", response)
+		}
+	}
+}
+
+func TestHeartbeatBackfillsRelayLocation(t *testing.T) {
+	resolver := &stubGeoResolver{err: errors.New("geoip endpoint down")}
+	server := NewServer(NewStore(), Config{GeoIP: resolver})
+
+	body, _ := json.Marshal(validRegisterRequest())
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var desc relay.Descriptor
+	if err := json.Unmarshal(recorder.Body.Bytes(), &desc); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+	if desc.GeoLocation != (relay.GeoLocation{}) {
+		t.Fatalf("expected failed lookup to leave geo empty, got %+v", desc.GeoLocation)
+	}
+
+	resolver.err = nil
+	resolver.geo = relay.GeoLocation{City: "Osaka", Country: "Japan", CountryCode: "JP"}
+	heartbeat := func() {
+		t.Helper()
+		heartbeatRecorder := httptest.NewRecorder()
+		server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/"+desc.ID+"/heartbeat", nil))
+		if heartbeatRecorder.Code != http.StatusOK {
+			t.Fatalf("expected 200 heartbeat, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
+		}
+	}
+	heartbeat()
+
+	listRecorder := httptest.NewRecorder()
+	server.ServeHTTP(listRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	if !strings.Contains(listRecorder.Body.String(), `"city":"Osaka"`) {
+		t.Fatalf("expected heartbeat to backfill geo: %s", listRecorder.Body.String())
+	}
+
+	lookupsAfterBackfill := resolver.lookups
+	heartbeat()
+	if resolver.lookups != lookupsAfterBackfill {
+		t.Fatalf("expected no further lookups once geo is stored, got %d after %d", resolver.lookups, lookupsAfterBackfill)
+	}
+}
+
 func TestHealthzReportsStoreFailure(t *testing.T) {
 	server := NewServer(failingStore{Store: NewStore(), pingErr: errors.New("database down")}, Config{})
 	recorder := httptest.NewRecorder()
@@ -138,6 +254,19 @@ func TestHeartbeatMissingRelayStillReturnsNotFound(t *testing.T) {
 	if recorder.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", recorder.Code, recorder.Body.String())
 	}
+}
+
+type stubGeoResolver struct {
+	geo     relay.GeoLocation
+	err     error
+	lookups int
+	hosts   []string
+}
+
+func (s *stubGeoResolver) Lookup(_ context.Context, host string) (relay.GeoLocation, error) {
+	s.lookups++
+	s.hosts = append(s.hosts, host)
+	return s.geo, s.err
 }
 
 type failingStore struct {

--- a/internal/broker/store.go
+++ b/internal/broker/store.go
@@ -23,6 +23,7 @@ const (
 type RelayStore interface {
 	Register(relay.RegisterRequest, time.Time, time.Duration) (relay.Descriptor, error)
 	Heartbeat(string, time.Time, time.Duration) (relay.Descriptor, error)
+	UpdateGeo(string, relay.GeoLocation) error
 	List(time.Time, int) ([]relay.Descriptor, error)
 	Stats(time.Time) (StoreStats, error)
 	Prune(time.Time) ([]relay.Descriptor, error)
@@ -67,6 +68,7 @@ func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Dura
 		Label:            req.Label,
 		PublicHost:       req.PublicHost,
 		PublicPort:       req.PublicPort,
+		ExitHost:         req.ExitHost,
 		Protocol:         req.Protocol,
 		ClientID:         req.ClientID,
 		RealityPublicKey: req.RealityPublicKey,
@@ -106,6 +108,19 @@ func (s *Store) Heartbeat(id string, now time.Time, ttl time.Duration) (relay.De
 	s.relays[id] = desc
 
 	return desc, nil
+}
+
+func (s *Store) UpdateGeo(id string, geo relay.GeoLocation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	desc, ok := s.relays[id]
+	if !ok {
+		return ErrRelayNotFound
+	}
+	desc.GeoLocation = geo
+	s.relays[id] = desc
+	return nil
 }
 
 func (s *Store) List(now time.Time, limit int) ([]relay.Descriptor, error) {

--- a/internal/broker/store_test.go
+++ b/internal/broker/store_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -86,6 +87,35 @@ func TestHeartbeatExtendsRelayLease(t *testing.T) {
 
 	if !updated.ExpiresAt.Equal(heartbeatAt.Add(time.Minute)) {
 		t.Fatalf("expected expiration %s, got %s", heartbeatAt.Add(time.Minute), updated.ExpiresAt)
+	}
+}
+
+func TestStoreUpdateGeo(t *testing.T) {
+	store := NewStore()
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+
+	desc, err := store.Register(validRegisterRequest(), now, time.Minute)
+	if err != nil {
+		t.Fatalf("register relay: %v", err)
+	}
+	if desc.GeoLocation != (relay.GeoLocation{}) {
+		t.Fatalf("expected freshly registered relay without geo, got %+v", desc.GeoLocation)
+	}
+
+	geo := relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP"}
+	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+		t.Fatalf("update geo: %v", err)
+	}
+	listed, err := store.List(now.Add(time.Second), 10)
+	if err != nil {
+		t.Fatalf("list relays: %v", err)
+	}
+	if len(listed) != 1 || listed[0].GeoLocation != geo {
+		t.Fatalf("expected listed relay to carry geo, got %+v", listed)
+	}
+
+	if err := store.UpdateGeo("relay_missing", geo); !errors.Is(err, ErrRelayNotFound) {
+		t.Fatalf("expected ErrRelayNotFound for unknown relay, got %v", err)
 	}
 }
 

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -47,13 +47,41 @@ type RegisterRequest struct {
 	// deriving one from PublicHost, so the scheme/host/port match the hub's
 	// actual listener. Empty means "derive http://PublicHost:9444".
 	PunchEndpoint string `json:"punch_endpoint,omitempty"`
+	// ExitHost is set by the relay hub for tunnel-transport registrations: the
+	// volunteer's source IP as observed on its control connection, i.e. where
+	// tunneled traffic actually exits. The broker uses it only to geolocate the
+	// relay (instead of PublicHost, which is the hub for tunnel transport) and
+	// never serves it to clients. Rejected for direct transport, where
+	// PublicHost already is the exit.
+	ExitHost string `json:"exit_host,omitempty"`
+}
+
+// GeoLocation is the broker-resolved physical location of the relay's exit:
+// exit_host for tunnel relays, public_host for direct relays. It is derived by
+// the broker, never supplied by the volunteer, and is best-effort: all fields
+// are empty when the lookup has not succeeded (yet).
+type GeoLocation struct {
+	City        string `json:"city,omitempty"`
+	Country     string `json:"country,omitempty"`
+	CountryCode string `json:"country_code,omitempty"`
+	// Latitude/Longitude let clients place the relay on a map. Zero values are
+	// omitted, so "no coordinates" and "0,0" (open ocean) are indistinguishable
+	// by design.
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
 }
 
 type Descriptor struct {
-	ID               string    `json:"id"`
-	Label            string    `json:"label,omitempty"`
-	PublicHost       string    `json:"public_host"`
-	PublicPort       int       `json:"public_port"`
+	ID         string `json:"id"`
+	Label      string `json:"label,omitempty"`
+	PublicHost string `json:"public_host"`
+	PublicPort int    `json:"public_port"`
+	GeoLocation
+	// ExitHost is stored so heartbeat-time geo backfills keep resolving the
+	// true exit location of tunnel relays, but it is never serialized: exposing
+	// a CGNAT volunteer's real IP through the public API would defeat the
+	// privacy the hub provides.
+	ExitHost         string    `json:"-"`
 	Protocol         string    `json:"protocol"`
 	ClientID         string    `json:"client_id"`
 	RealityPublicKey string    `json:"reality_public_key"`

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -119,7 +119,7 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	registration, err := h.Registrar.Register(ctx, h.registerRequest(hello, port))
+	registration, err := h.Registrar.Register(ctx, h.registerRequest(hello, port, remoteHost(conn.RemoteAddr())))
 	if err != nil {
 		_ = publicListener.Close()
 		h.Allocator.Release(port)
@@ -175,7 +175,7 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 	t.run(ctx)
 }
 
-func (h *Hub) registerRequest(hello HelloFrame, port int) relay.RegisterRequest {
+func (h *Hub) registerRequest(hello HelloFrame, port int, exitHost string) relay.RegisterRequest {
 	punchOn := h.punchAvailable() && hello.StreamTyping && hello.PunchCapable
 	punchEndpoint := ""
 	if punchOn {
@@ -184,6 +184,7 @@ func (h *Hub) registerRequest(hello HelloFrame, port int) relay.RegisterRequest 
 	return relay.RegisterRequest{
 		PublicHost:       h.PublicHost,
 		PublicPort:       port,
+		ExitHost:         exitHost,
 		Protocol:         relay.ProtocolVLESSRealityVision,
 		ClientID:         hello.ClientID,
 		RealityPublicKey: hello.RealityPublicKey,
@@ -199,6 +200,21 @@ func (h *Hub) registerRequest(hello HelloFrame, port int) relay.RegisterRequest 
 		PunchCapable:     punchOn,
 		PunchEndpoint:    punchEndpoint,
 	}
+}
+
+// remoteHost extracts the bare IP of the volunteer's control connection — its
+// public (post-NAT) source address, which is where tunneled traffic exits.
+// Returns "" when the address cannot be parsed so registration proceeds
+// without an exit host rather than sending junk to the broker.
+func remoteHost(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return ""
+	}
+	return host
 }
 
 // punchAvailable reports whether this hub is configured to coordinate punches.

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -210,6 +210,9 @@ func TestHubClientEndToEnd(t *testing.T) {
 	if lastReq.PublicPort != ack.PublicPort || lastReq.PublicHost != "127.0.0.1" {
 		t.Fatalf("register endpoint mismatch: host=%q port=%d", lastReq.PublicHost, lastReq.PublicPort)
 	}
+	if lastReq.ExitHost != "127.0.0.1" {
+		t.Fatalf("exit_host = %q, want the volunteer's source IP 127.0.0.1", lastReq.ExitHost)
+	}
 
 	if !eventually(2*time.Second, func() bool {
 		_, hb, _ := registrar.stats()


### PR DESCRIPTION
## What

The broker now resolves and serves each relay's physical exit location in `/api/v1/relays` (and the register response): `city`, `country`, `country_code`, `latitude`, `longitude`. All five are optional (`omitempty`) and appear once the broker's geo lookup succeeds, so the mobile app can show users where volunteer relays are located and place them on the map.

## How

- **Resolver** (`internal/broker/geoip.go`): HTTP lookup against ipwho.is by default — the same provider the Android client and CLI already use for client-side geo. Configurable via `-geoip-endpoint` / `OPENRUNG_GEOIP_ENDPOINT` (`off` disables); ip-api.com-style responses are also parsed. Per-host cache (24h success / 10min failure) keeps traffic within free-tier rate limits.
- **Best-effort by design**: registration and heartbeats never fail because of geo. A failed registration-time lookup is retried on heartbeats, which also backfills relays registered before this change — the currently deployed relay gets its location automatically after broker redeploy, no volunteer restart needed.
- **True exit location for tunnel relays**: the relay hub now passes the volunteer's observed control-connection source IP as a hub-only `exit_host` registration field, so CGNAT relays geolocate to where traffic actually exits rather than to the hub.
- **Postgres**: new columns via the existing `ADD COLUMN IF NOT EXISTS` auto-migration at startup; re-registration at the same host:port keeps its resolved location, except when `exit_host` changed (hub port reused by a different volunteer), which clears the stale geo for re-resolution.

## Security / privacy notes for review

- Geo is always broker-derived; volunteers cannot supply it.
- `exit_host` is rejected for `direct` transport, so a self-registering volunteer gains no location-spoofing ability beyond the existing `public_host` trust.
- `exit_host` is stored (needed for heartbeat backfill) but tagged `json:"-"` — it is never serialized through any public endpoint, so CGNAT volunteers' real IPs stay private. A test asserts non-leakage on both register and list responses.
- Trade-off: the broker (and ipwho.is) now learn tunnel volunteers' exit IPs, which the broker previously never saw. This is inherent to the feature.

## Testing

- Unit tests: resolver parsing (both provider shapes), success/failure caching and TTL expiry, register/heartbeat-backfill handler paths, exit-host lookup targeting, IP non-leakage, memory + postgres geo persistence, hub passing the volunteer source IP, upsert geo invalidation on exit-host change.
- Full `go test ./...` passes. Postgres tests require `OPENRUNG_TEST_POSTGRES_URL` and were skipped locally.
- Smoke-tested the real broker binary against a local geoip stub: direct and tunnel registrations, exit-host rejection on direct transport, and coordinate passthrough all verified via curl.

## Deployment

Both the **broker** and the **relay hub** need redeploying. Old hubs against the new broker are fine (tunnel relays just geolocate to the hub as before). Docs updated in `docs/api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)