### PR TITLE
Re-register tunnel relays when the broker forgets them

### DIFF
--- a/internal/tunnel/punch_test.go
+++ b/internal/tunnel/punch_test.go
@@ -18,7 +18,7 @@ import (
 func TestTypedRelayStillEchoes(t *testing.T) {
 	echoHost, echoPort := startEchoServer(t)
 	registrar := &fakeRegistrar{relayID: "relay_typed"}
-	controlAddr, _ := startTestHub(t, registrar, "secret") // hub has no reflector → punch unavailable
+	_, controlAddr, _ := startTestHub(t, registrar, "secret") // hub has no reflector → punch unavailable
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,6 +12,11 @@ import (
 
 	"openrung/internal/relay"
 )
+
+// ErrRelayNotFound is returned (wrapped) by Heartbeat when the broker no
+// longer knows the relay — e.g. an in-memory store lost it across a broker
+// restart. The caller should re-register rather than keep heartbeating.
+var ErrRelayNotFound = errors.New("relay not found")
 
 // RelayRegistration is the result of registering a tunneled relay with the broker.
 type RelayRegistration struct {
@@ -89,6 +95,9 @@ func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out a
 		_ = json.NewDecoder(resp.Body).Decode(&apiErr)
 		if apiErr.Error == "" {
 			apiErr.Error = resp.Status
+		}
+		if resp.StatusCode == http.StatusNotFound && apiErr.Error == "relay not found" {
+			return fmt.Errorf("broker %s: %w", path, ErrRelayNotFound)
 		}
 		return fmt.Errorf("broker %s: %s", path, apiErr.Error)
 	}

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -119,7 +120,8 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	registration, err := h.Registrar.Register(ctx, h.registerRequest(hello, port, remoteHost(conn.RemoteAddr())))
+	regReq := h.registerRequest(hello, port, remoteHost(conn.RemoteAddr()))
+	registration, err := h.Registrar.Register(ctx, regReq)
 	if err != nil {
 		_ = publicListener.Close()
 		h.Allocator.Release(port)
@@ -165,13 +167,16 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 		publicListener: publicListener,
 		port:           port,
 		relayID:        registration.RelayID,
+		registerReq:    regReq,
 		streamTyping:   streamTyping,
 		logger:         logger.With("relay_id", registration.RelayID, "public_port", port, "remote", remote),
 	}
 	// Publish before the blocking accept loop so the punch coordinator can find
 	// this volunteer as soon as it is registered.
 	h.addTunnel(registration.RelayID, t)
-	defer h.removeTunnel(registration.RelayID, t)
+	// The relay ID can change if the heartbeat loop re-registers (broker forgot
+	// us), so remove whatever ID the tunnel holds at teardown time.
+	defer func() { h.removeTunnel(t.currentRelayID(), t) }()
 	t.run(ctx)
 }
 
@@ -262,9 +267,29 @@ type tunnel struct {
 	session        *yamux.Session
 	publicListener net.Listener
 	port           int
-	relayID        string
 	streamTyping   bool
 	logger         *slog.Logger
+
+	// registerReq is the request the tunnel was registered with, kept so the
+	// heartbeat loop can re-register verbatim if the broker forgets the relay.
+	registerReq relay.RegisterRequest
+
+	// relayID is the broker-assigned ID; it changes on re-registration, so it
+	// is guarded for the teardown path that reads it after the heartbeat loop.
+	relayIDMu sync.Mutex
+	relayID   string
+}
+
+func (t *tunnel) currentRelayID() string {
+	t.relayIDMu.Lock()
+	defer t.relayIDMu.Unlock()
+	return t.relayID
+}
+
+func (t *tunnel) setRelayID(id string) {
+	t.relayIDMu.Lock()
+	defer t.relayIDMu.Unlock()
+	t.relayID = id
 }
 
 func (t *tunnel) run(parent context.Context) {
@@ -340,11 +365,38 @@ func (t *tunnel) heartbeatLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			hbCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			err := t.hub.Registrar.Heartbeat(hbCtx, t.relayID)
+			err := t.hub.Registrar.Heartbeat(hbCtx, t.currentRelayID())
 			cancel()
-			if err != nil {
-				t.logger.Warn("relay heartbeat failed", "error", err)
+			if err == nil {
+				continue
 			}
+			if !errors.Is(err, ErrRelayNotFound) {
+				t.logger.Warn("relay heartbeat failed", "error", err)
+				continue
+			}
+			t.reregister(ctx)
 		}
 	}
+}
+
+// reregister refreshes the broker registration after the broker forgot the
+// relay (e.g. its in-memory store was lost across a restart). The public
+// listener and yamux session stay untouched — only the broker-side identity
+// changes — but the broker assigns a fresh relay ID, so the hub registry
+// (which the punch coordinator keys by relay ID) is re-keyed. On failure the
+// next heartbeat gets not-found again and retries.
+func (t *tunnel) reregister(ctx context.Context) {
+	regCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	registration, err := t.hub.Registrar.Register(regCtx, t.registerReq)
+	cancel()
+	if err != nil {
+		t.logger.Warn("relay re-registration failed", "error", err)
+		return
+	}
+	oldID := t.currentRelayID()
+	t.setRelayID(registration.RelayID)
+	t.hub.removeTunnel(oldID, t)
+	t.hub.addTunnel(registration.RelayID, t)
+	t.logger.Info("relay re-registered after broker forgot it",
+		"old_relay_id", oldID, "new_relay_id", registration.RelayID)
 }

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -24,6 +24,11 @@ type fakeRegistrar struct {
 	heartbeats    int
 	lastReq       relay.RegisterRequest
 	relayID       string
+	// relayIDs, when non-empty, are consumed one per Register call before
+	// falling back to relayID.
+	relayIDs []string
+	// failHeartbeatOnce is returned by the next Heartbeat call, then cleared.
+	failHeartbeatOnce error
 }
 
 func (f *fakeRegistrar) Register(_ context.Context, req relay.RegisterRequest) (RelayRegistration, error) {
@@ -32,6 +37,10 @@ func (f *fakeRegistrar) Register(_ context.Context, req relay.RegisterRequest) (
 	f.registerCount++
 	f.lastReq = req
 	id := f.relayID
+	if len(f.relayIDs) > 0 {
+		id = f.relayIDs[0]
+		f.relayIDs = f.relayIDs[1:]
+	}
 	if id == "" {
 		id = "relay_test"
 	}
@@ -42,6 +51,11 @@ func (f *fakeRegistrar) Heartbeat(_ context.Context, _ string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.heartbeats++
+	if f.failHeartbeatOnce != nil {
+		err := f.failHeartbeatOnce
+		f.failHeartbeatOnce = nil
+		return err
+	}
 	return nil
 }
 
@@ -76,7 +90,7 @@ func startEchoServer(t *testing.T) (string, int) {
 
 // startTestHub spins up a hub on a plaintext loopback control listener with a
 // single-port allocator and returns the control address and allocator.
-func startTestHub(t *testing.T, registrar Registrar, token string) (string, *PortAllocator) {
+func startTestHub(t *testing.T, registrar Registrar, token string) (*Hub, string, *PortAllocator) {
 	t.Helper()
 	controlLn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -101,7 +115,7 @@ func startTestHub(t *testing.T, registrar Registrar, token string) (string, *Por
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() { _ = hub.Serve(ctx) }()
 	t.Cleanup(cancel)
-	return controlLn.Addr().String(), alloc
+	return hub, controlLn.Addr().String(), alloc
 }
 
 func eventually(timeout time.Duration, cond func() bool) bool {
@@ -146,7 +160,7 @@ func dialEchoThroughTunnel(port int) error {
 func TestHubClientEndToEnd(t *testing.T) {
 	echoHost, echoPort := startEchoServer(t)
 	registrar := &fakeRegistrar{relayID: "relay_abc"}
-	controlAddr, alloc := startTestHub(t, registrar, "secret")
+	_, controlAddr, alloc := startTestHub(t, registrar, "secret")
 
 	clientCtx, clientCancel := context.WithCancel(context.Background())
 	defer clientCancel()
@@ -228,9 +242,99 @@ func TestHubClientEndToEnd(t *testing.T) {
 	}
 }
 
+func TestHubReregistersWhenBrokerForgetsRelay(t *testing.T) {
+	echoHost, echoPort := startEchoServer(t)
+	registrar := &fakeRegistrar{
+		relayIDs:          []string{"relay_old", "relay_new"},
+		failHeartbeatOnce: fmt.Errorf("broker /api/v1/volunteers/relay_old/heartbeat: %w", ErrRelayNotFound),
+	}
+	hub, controlAddr, _ := startTestHub(t, registrar, "secret")
+
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	defer clientCancel()
+
+	ackCh := make(chan HelloAckFrame, 1)
+	client := &Client{
+		HubAddr: controlAddr,
+		Hello: HelloFrame{
+			Token:            "secret",
+			RealityPublicKey: "pk",
+			ShortID:          "sid",
+			ServerName:       "www.example.com",
+			ClientID:         "cid",
+			Flow:             relay.FlowVision,
+			ExitMode:         relay.ExitModeDirect,
+		},
+		TargetHost:   echoHost,
+		TargetPort:   echoPort,
+		ReconnectMin: 10 * time.Millisecond,
+		Logger:       discardLogger(),
+		OnRegistered: func(a HelloAckFrame) {
+			select {
+			case ackCh <- a:
+			default:
+			}
+		},
+	}
+	go func() { _ = client.Run(clientCtx) }()
+
+	var ack HelloAckFrame
+	select {
+	case ack = <-ackCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for tunnel establishment")
+	}
+	if ack.RelayID != "relay_old" {
+		t.Fatalf("relay_id = %q, want relay_old", ack.RelayID)
+	}
+	if hub.lookupTunnel("relay_old") == nil {
+		t.Fatal("registry missing initial relay_old entry")
+	}
+
+	// The first heartbeat returns not-found; the hub must re-register.
+	if !eventually(3*time.Second, func() bool {
+		registers, _, _ := registrar.stats()
+		return registers == 2
+	}) {
+		registers, hb, _ := registrar.stats()
+		t.Fatalf("no re-registration after not-found heartbeat (registers=%d heartbeats=%d)", registers, hb)
+	}
+
+	// Re-registration reuses the original request, including the exit host.
+	_, _, lastReq := registrar.stats()
+	if lastReq.ExitHost != "127.0.0.1" || lastReq.PublicPort != ack.PublicPort {
+		t.Fatalf("re-register request mismatch: exit_host=%q port=%d", lastReq.ExitHost, lastReq.PublicPort)
+	}
+
+	// The registry is re-keyed to the new relay ID.
+	if !eventually(2*time.Second, func() bool { return hub.lookupTunnel("relay_new") != nil }) {
+		t.Fatal("registry not re-keyed to relay_new")
+	}
+	if hub.lookupTunnel("relay_old") != nil {
+		t.Fatal("stale relay_old entry left in registry")
+	}
+
+	// The public listener and yamux session were untouched: traffic still flows,
+	// and subsequent heartbeats (now against the new ID) succeed.
+	if err := dialEchoThroughTunnel(ack.PublicPort); err != nil {
+		t.Fatalf("echo through tunnel after re-registration: %v", err)
+	}
+	_, hbBefore, _ := registrar.stats()
+	if !eventually(2*time.Second, func() bool {
+		_, hb, _ := registrar.stats()
+		return hb > hbBefore
+	}) {
+		t.Fatal("heartbeats stopped after re-registration")
+	}
+	registers, _, _ := registrar.stats()
+	if registers != 2 {
+		t.Fatalf("register count = %d, want exactly 2", registers)
+	}
+}
+
 func TestHubRejectsBadToken(t *testing.T) {
 	registrar := &fakeRegistrar{}
-	controlAddr, alloc := startTestHub(t, registrar, "secret")
+	_, controlAddr, alloc := startTestHub(t, registrar, "secret")
 
 	conn, err := net.Dial("tcp", controlAddr)
 	if err != nil {
@@ -259,7 +363,7 @@ func TestHubRejectsBadToken(t *testing.T) {
 
 func TestHubRejectsProtocolMismatch(t *testing.T) {
 	registrar := &fakeRegistrar{}
-	controlAddr, _ := startTestHub(t, registrar, "")
+	_, controlAddr, _ := startTestHub(t, registrar, "")
 
 	conn, err := net.Dial("tcp", controlAddr)
 	if err != nil {


### PR DESCRIPTION
## What

When a hub heartbeat gets a 404 `relay not found` from the broker, the hub now re-registers the tunnel relay instead of logging warnings forever.

- `internal/tunnel/registrar.go`: `brokerRegistrar` surfaces the broker's 404 `relay not found` response as a typed `ErrRelayNotFound` (mirrors `isRelayNotFound` in `cmd/volunteer/main.go`).
- `internal/tunnel/server.go`: the tunnel keeps the original `RegisterRequest` (including `exit_host`, the volunteer's control-connection source IP). On `ErrRelayNotFound`, the heartbeat loop calls `Register` again with that request, updates `tunnel.relayID`, and re-keys the hub registry — preserving the compare-and-delete semantics of `addTunnel`/`removeTunnel`. The public listener and yamux session are untouched. Failed re-registrations retry on the next heartbeat tick (that heartbeat 404s again).
- Because the relay ID now changes mid-lifetime, `relayID` is mutex-guarded and teardown removes the tunnel's *current* ID rather than the one captured at registration, so a re-keyed punch-coordinator registry entry cannot leak.
- `internal/tunnel/server_test.go`: `TestHubReregistersWhenBrokerForgetsRelay` — `fakeRegistrar` returns not-found on one heartbeat, then the test asserts a second `Register` with the original request (same exit host and port), the registry re-keyed to the new relay ID with the old entry gone, traffic still flowing, and heartbeats resuming with no extra registrations.

## Why

The production broker runs with the in-memory store (`-addr :8080` only), so a broker restart drops all relay records. Standalone volunteers recover via `heartbeatOrRegister`, but the hub only logged `relay heartbeat failed` — the tunnel relay disappeared from `/api/v1/relays` until the volunteer's control connection happened to reconnect. Observed in production on 2026-07-05: a broker restart orphaned the cgnat-test tunnel relay until the hub was redeployed.

## Notes for reviewers

- The broker assigns a fresh relay ID on re-register; anything keyed by relay ID (punch coordinator registry) is re-keyed. Clients holding the old ID get a 404/`relay not connected` and should re-fetch relays, same as after a volunteer reconnect.
- `go test ./... -count=1` passes; the tunnel package also passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)