### PR TITLE
Bound broker resource use against anonymous abuse

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -65,7 +65,20 @@ func run() error {
 	}
 	go maintainBroker(store, telemetrySink, maintenanceInterval, *statusInterval > 0)
 
-	server := &http.Server{Addr: *addr, Handler: handler}
+	server := &http.Server{
+		Addr:    *addr,
+		Handler: handler,
+		// Bound every phase of a connection so slow-drip (slowloris-style)
+		// clients cannot pin goroutines and file descriptors indefinitely. The
+		// read window still fits a full 512 KiB telemetry upload on a very slow
+		// link; the speed-test handler extends its own write deadline because a
+		// 25 MB download legitimately needs longer than the write timeout.
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       2 * time.Minute,
+		WriteTimeout:      2 * time.Minute,
+		IdleTimeout:       2 * time.Minute,
+		MaxHeaderBytes:    64 << 10,
+	}
 	shutdownContext, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignals()
 	shutdownDone := make(chan struct{})

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,17 @@
 
 All API paths are currently versioned under `/api/v1`.
 
+## Abuse limits
+
+The unauthenticated endpoints (`GET /api/v1/relays`, `POST
+/api/v1/telemetry/events`, `GET /api/v1/speed-test`) are rate limited per
+client IP. Requests over the budget receive `429 Too Many Requests` with a
+`Retry-After` header (seconds); clients should back off and retry. The budgets
+are far above normal client behavior — relay-list polling, telemetry batching,
+and an occasional speed test never hit them — and they apply to the real client
+IP resolved through trusted proxies, so one abusive source behind Cloudflare
+does not exhaust anyone else's budget.
+
 ## Client telemetry
 
 Android clients attach a persistent installation identifier and a per-connection
@@ -15,9 +26,12 @@ X-OpenRung-Android-API: 35
 ```
 
 The broker writes a `client_seen` record containing the request source IP before
-returning the relay list. The default broker command stores telemetry as
-append-only JSON Lines in `openrung-telemetry.jsonl`; change the path with
-`-telemetry-file`.
+returning the relay list, at most once per client session every four minutes —
+repeat polling inside that window does not produce more records. The default
+broker command stores telemetry as JSON Lines in `openrung-telemetry.jsonl`;
+change the path with `-telemetry-file`. The file is compacted in place once it
+outgrows its size budget (256 MiB), keeping the retained recent records, so disk
+usage stays bounded.
 
 When the request arrives through a trusted proxy, the source IP is taken from the
 `CF-Connecting-IP` header (falling back to the left-most `X-Forwarded-For` entry)
@@ -52,7 +66,11 @@ Content-Type: application/json
 }
 ```
 
-The endpoint accepts at most 200 events and 512 KiB per request. Package
+The endpoint accepts at most 200 events and 512 KiB per request. Events dated
+more than one hour into the future are rejected (retention and dashboards key
+off the server's receipt time, so client clocks cannot extend either), and
+free-form fields are length-capped: attribute/measurement keys at 64
+characters, attribute values and `application_package` at 256. Package
 attribution is collected on Android 10 and newer. This first implementation
 records connection starts and destinations, not per-flow byte counters or flow
 completion times.
@@ -98,7 +116,10 @@ GET /api/v1/speed-test?bytes=10000000
 ```
 
 The broker streams the requested number of bytes with caching disabled and
-rejects requests larger than 25 MB.
+rejects requests larger than 25 MB. Because each stream is expensive for broker
+egress, only a few speed tests may run concurrently in addition to the per-IP
+rate limit; a busy broker answers `429` with `Retry-After`, and the app should
+retry the measurement later rather than treat it as a failure.
 
 ## Telemetry dashboard
 
@@ -113,7 +134,8 @@ The dashboard requires the configured token, creates an HttpOnly administrator
 session lasting 12 hours, and refreshes its operational overview every 30
 seconds. It supports one-hour, 24-hour, and seven-day windows. The JSONL file
 remains the durable telemetry store; the broker retains the most recent seven
-days in memory for dashboard queries.
+days in memory for dashboard queries, capped at a 64 MiB budget that discards
+the oldest records first if a burst of telemetry would exceed it.
 
 The authenticated dashboard reads its data from:
 

--- a/internal/broker/ratelimit.go
+++ b/internal/broker/ratelimit.go
@@ -1,0 +1,111 @@
+package broker
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Per-IP limits for the unauthenticated endpoints. They only need to stop a
+// single source from monopolizing broker resources; volumetric floods from
+// many sources are the edge proxy's (Cloudflare's) job. Buckets are generous
+// because carrier-grade NAT can put whole networks behind one client IP.
+const (
+	relayListRatePerSecond = 2.0
+	relayListBurst         = 30
+
+	telemetryRatePerSecond = 1.0
+	telemetryBurst         = 20
+
+	// A full speed test streams up to 25 MB, so sustained refills are slow and
+	// the real egress bound is the concurrency cap below.
+	speedTestRatePerSecond = 1.0 / 30
+	speedTestBurst         = 3
+	speedTestMaxConcurrent = 4
+
+	// rateLimiterMaxTrackedIPs bounds limiter memory (~100 B per tracked IP).
+	rateLimiterMaxTrackedIPs = 100_000
+)
+
+// ipRateLimiter is a token-bucket limiter keyed by client IP.
+type ipRateLimiter struct {
+	ratePerSecond float64
+	burst         float64
+	maxKeys       int
+	now           func() time.Time
+
+	mu      sync.Mutex
+	buckets map[string]*tokenBucket
+}
+
+type tokenBucket struct {
+	tokens   float64
+	lastSeen time.Time
+}
+
+func newIPRateLimiter(ratePerSecond, burst float64, maxKeys int) *ipRateLimiter {
+	return &ipRateLimiter{
+		ratePerSecond: ratePerSecond,
+		burst:         burst,
+		maxKeys:       maxKeys,
+		now:           time.Now,
+		buckets:       make(map[string]*tokenBucket),
+	}
+}
+
+func (l *ipRateLimiter) allow(key string) bool {
+	now := l.now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	bucket, ok := l.buckets[key]
+	if !ok {
+		if len(l.buckets) >= l.maxKeys {
+			l.sweepLocked(now)
+		}
+		if len(l.buckets) >= l.maxKeys {
+			// Fail open: an attacker rotating through more source IPs than the
+			// table holds would otherwise turn the limiter into a DoS against
+			// legitimate clients. Multi-source floods are handled at the edge.
+			return true
+		}
+		bucket = &tokenBucket{tokens: l.burst, lastSeen: now}
+		l.buckets[key] = bucket
+	}
+
+	if elapsed := now.Sub(bucket.lastSeen).Seconds(); elapsed > 0 {
+		bucket.tokens = min(l.burst, bucket.tokens+elapsed*l.ratePerSecond)
+		bucket.lastSeen = now
+	}
+	if bucket.tokens < 1 {
+		return false
+	}
+	bucket.tokens--
+	return true
+}
+
+// sweepLocked drops buckets that have been idle long enough to refill
+// completely; forgetting those loses nothing because a recreated bucket
+// starts full anyway.
+func (l *ipRateLimiter) sweepLocked(now time.Time) {
+	for key, bucket := range l.buckets {
+		if now.Sub(bucket.lastSeen).Seconds()*l.ratePerSecond >= l.burst-bucket.tokens {
+			delete(l.buckets, key)
+		}
+	}
+}
+
+// rateLimited rejects requests over the per-IP budget with 429 before they
+// reach next. The key comes from the trusted-proxy-aware resolver so limits
+// apply to real client IPs, not to Cloudflare's.
+func rateLimited(limiter *ipRateLimiter, clientIP *clientIPResolver, retryAfterSeconds int, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.allow(clientIP.clientIP(r)) {
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+			writeError(w, http.StatusTooManyRequests, "rate limit exceeded, retry later")
+			return
+		}
+		next(w, r)
+	}
+}

--- a/internal/broker/ratelimit_test.go
+++ b/internal/broker/ratelimit_test.go
@@ -1,0 +1,128 @@
+package broker
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestIPRateLimiterEnforcesBurstThenRefills(t *testing.T) {
+	current := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	limiter := newIPRateLimiter(1, 2, 10)
+	limiter.now = func() time.Time { return current }
+
+	if !limiter.allow("203.0.113.1") || !limiter.allow("203.0.113.1") {
+		t.Fatal("expected burst of 2 to be allowed")
+	}
+	if limiter.allow("203.0.113.1") {
+		t.Fatal("expected third immediate request to be denied")
+	}
+
+	current = current.Add(1500 * time.Millisecond)
+	if !limiter.allow("203.0.113.1") {
+		t.Fatal("expected refill to allow a request after 1.5s at 1/s")
+	}
+	if limiter.allow("203.0.113.1") {
+		t.Fatal("expected partial refill to deny a second request")
+	}
+}
+
+func TestIPRateLimiterIsolatesSources(t *testing.T) {
+	current := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	limiter := newIPRateLimiter(1, 1, 10)
+	limiter.now = func() time.Time { return current }
+
+	if !limiter.allow("203.0.113.1") {
+		t.Fatal("first source should be allowed")
+	}
+	if limiter.allow("203.0.113.1") {
+		t.Fatal("first source should be exhausted")
+	}
+	if !limiter.allow("203.0.113.2") {
+		t.Fatal("second source must have its own bucket")
+	}
+}
+
+func TestIPRateLimiterFailsOpenWhenTableFull(t *testing.T) {
+	current := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	limiter := newIPRateLimiter(1, 1, 2)
+	limiter.now = func() time.Time { return current }
+
+	limiter.allow("203.0.113.1")
+	limiter.allow("203.0.113.2")
+
+	if !limiter.allow("203.0.113.3") || !limiter.allow("203.0.113.3") {
+		t.Fatal("untracked sources must fail open when the table is full")
+	}
+	if limiter.allow("203.0.113.1") {
+		t.Fatal("tracked sources must stay limited while the table is full")
+	}
+}
+
+func TestIPRateLimiterSweepsIdleBuckets(t *testing.T) {
+	current := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	limiter := newIPRateLimiter(1, 1, 1)
+	limiter.now = func() time.Time { return current }
+
+	if !limiter.allow("203.0.113.1") {
+		t.Fatal("first source should be allowed")
+	}
+
+	// After the idle source has fully refilled it is safe to forget, freeing
+	// its slot for a new source, which then gets tracked (not fail-open).
+	current = current.Add(2 * time.Second)
+	if !limiter.allow("203.0.113.2") {
+		t.Fatal("new source should claim the swept slot")
+	}
+	if limiter.allow("203.0.113.2") {
+		t.Fatal("new source must be tracked and limited, not failed open")
+	}
+}
+
+func TestServerRateLimitsSpeedTest(t *testing.T) {
+	server := NewServer(NewStore(), Config{})
+
+	for index := 0; index < speedTestBurst; index++ {
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10", nil))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("request %d inside burst: expected 200, got %d", index+1, recorder.Code)
+		}
+	}
+
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10", nil))
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 past the burst, got %d", recorder.Code)
+	}
+	if recorder.Header().Get("Retry-After") == "" {
+		t.Fatal("expected Retry-After header on 429")
+	}
+
+	// A different source IP is not affected by the exhausted bucket.
+	otherSource := httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10", nil)
+	otherSource.RemoteAddr = "203.0.113.99:4444"
+	recorder = httptest.NewRecorder()
+	server.ServeHTTP(recorder, otherSource)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected other source to pass, got %d", recorder.Code)
+	}
+}
+
+func TestServerRateLimitsTelemetry(t *testing.T) {
+	server := NewServer(NewStore(), Config{TelemetrySink: &memoryTelemetrySink{}})
+
+	status := 0
+	for index := 0; index < telemetryBurst+1; index++ {
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/telemetry/events", nil))
+		status = recorder.Code
+		if index < telemetryBurst && status == http.StatusTooManyRequests {
+			t.Fatalf("request %d inside burst unexpectedly limited", index+1)
+		}
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 past the burst, got %d", status)
+	}
+}

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -13,6 +13,10 @@ import (
 	"openrung/internal/relay"
 )
 
+// maxRegisterBodyBytes caps volunteer registration payloads; descriptors are
+// small structs, so anything near the cap is malformed or hostile.
+const maxRegisterBodyBytes = 64 << 10
+
 type Config struct {
 	RegistrationToken string
 	VolunteerLeaseTTL time.Duration
@@ -33,6 +37,10 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 		cfg.VolunteerLeaseTTL = 3 * time.Minute
 	}
 	clientIP := newClientIPResolver(cfg.TrustedProxyCIDRs)
+	clientSeen := newClientSeenDeduper(clientSeenDedupWindow, clientSeenDedupMaxEntries)
+	relayListLimiter := newIPRateLimiter(relayListRatePerSecond, relayListBurst, rateLimiterMaxTrackedIPs)
+	telemetryLimiter := newIPRateLimiter(telemetryRatePerSecond, telemetryBurst, rateLimiterMaxTrackedIPs)
+	speedTestLimiter := newIPRateLimiter(speedTestRatePerSecond, speedTestBurst, rateLimiterMaxTrackedIPs)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -45,9 +53,9 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	})
 	mux.HandleFunc("POST /api/v1/volunteers/register", registerHandler(store, cfg))
 	mux.HandleFunc("POST /api/v1/volunteers/", heartbeatHandler(store, cfg))
-	mux.HandleFunc("GET /api/v1/relays", listRelaysHandler(store, cfg.TelemetrySink, clientIP))
-	mux.HandleFunc("POST /api/v1/telemetry/events", telemetryHandler(cfg.TelemetrySink, store, clientIP))
-	mux.HandleFunc("GET /api/v1/speed-test", speedTestHandler())
+	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen)))
+	mux.HandleFunc("POST /api/v1/telemetry/events", rateLimited(telemetryLimiter, clientIP, 10, telemetryHandler(cfg.TelemetrySink, store, clientIP)))
+	mux.HandleFunc("GET /api/v1/speed-test", rateLimited(speedTestLimiter, clientIP, 30, speedTestHandler(speedTestMaxConcurrent)))
 	if cfg.DashboardToken != "" && cfg.TelemetryReader != nil {
 		dashboard := newDashboardServer(cfg.DashboardToken, cfg.TelemetryReader)
 		dashboard.relayLabels = relayLabelResolver(store)
@@ -65,6 +73,7 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 		}
 
 		var req relay.RegisterRequest
+		r.Body = http.MaxBytesReader(w, r.Body, maxRegisterBodyBytes)
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON request")
 			return
@@ -160,9 +169,9 @@ func geoLookupHost(desc *relay.Descriptor) string {
 	return desc.PublicHost
 }
 
-func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *clientIPResolver) http.HandlerFunc {
+func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *clientIPResolver, clientSeen *clientSeenDeduper) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		recordClientSeen(r, telemetrySink, clientIP)
+		recordClientSeen(r, telemetrySink, clientIP, clientSeen)
 		limit := 5
 		if raw := r.URL.Query().Get("limit"); raw != "" {
 			parsed, err := strconv.Atoi(raw)

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -123,6 +123,17 @@ func TestRegisterRejectsUnsafeLabel(t *testing.T) {
 	}
 }
 
+func TestRegisterRejectsOversizedBody(t *testing.T) {
+	server := NewServer(NewStore(), Config{})
+
+	oversized := []byte(`{"public_host":"` + strings.Repeat("a", maxRegisterBodyBytes) + `"}`)
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(oversized)))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized register body, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestRegisterResolvesRelayLocation(t *testing.T) {
 	resolver := &stubGeoResolver{geo: relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP", Latitude: 35.6895, Longitude: 139.6917}}
 	server := NewServer(NewStore(), Config{GeoIP: resolver})

--- a/internal/broker/telemetry.go
+++ b/internal/broker/telemetry.go
@@ -24,15 +24,60 @@ const (
 	telemetryRetention     = 7 * 24 * time.Hour
 	telemetryFlushInterval = 5 * time.Second
 	telemetrySyncInterval  = 30 * time.Second
+
+	// maxTelemetryFutureSkew tolerates client clock drift. Events dated further
+	// into the future are rejected so forged timestamps cannot pollute
+	// time-windowed dashboards; retention itself keys off the server-assigned
+	// ReceivedAt and never trusts the client clock.
+	maxTelemetryFutureSkew = time.Hour
+
+	// Length caps for free-form event fields keep a single record small; the
+	// identity fields have their own caps in validateTelemetryEvent.
+	maxTelemetryKeyBytes   = 64
+	maxTelemetryValueBytes = 256
+
+	// maxTelemetryMemoryBytes bounds the decoded records held in memory for the
+	// dashboard, and maxTelemetryFileBytes bounds the JSONL file on disk (it is
+	// compacted down to the retained in-memory set when appends exceed the
+	// budget). Together they cap what an anonymous telemetry flood can consume.
+	maxTelemetryMemoryBytes = 64 << 20
+	maxTelemetryFileBytes   = 256 << 20
+
+	// clientSeenDedupWindow suppresses repeat client_seen records per client
+	// session so relay-list polling is not one disk write per request. It stays
+	// below the 5-minute operational-stats window so an active client is still
+	// recorded at least once per window.
+	clientSeenDedupWindow     = 4 * time.Minute
+	clientSeenDedupMaxEntries = 10_000
+
+	// speedTestWriteWindow is how long a single speed-test download may take
+	// before the connection is cut. The handler extends its own write deadline
+	// to this because slow links legitimately need minutes for 25 MB, far past
+	// the server-wide write timeout.
+	speedTestWriteWindow = 5 * time.Minute
 )
 
-func speedTestHandler() http.HandlerFunc {
+func speedTestHandler(maxConcurrent int) http.HandlerFunc {
+	slots := make(chan struct{}, maxConcurrent)
 	return func(w http.ResponseWriter, r *http.Request) {
 		requested, err := strconv.Atoi(r.URL.Query().Get("bytes"))
 		if err != nil || requested < 1 || requested > maxSpeedTestBytes {
 			writeError(w, http.StatusBadRequest, "bytes must be between 1 and 25000000")
 			return
 		}
+
+		// Each stream can push up to 25 MB, so the number running at once — not
+		// the per-IP request rate — is what bounds worst-case broker egress.
+		select {
+		case slots <- struct{}{}:
+			defer func() { <-slots }()
+		default:
+			w.Header().Set("Retry-After", "10")
+			writeError(w, http.StatusTooManyRequests, "speed test is busy, retry later")
+			return
+		}
+
+		_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(speedTestWriteWindow))
 
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -87,18 +132,30 @@ type TelemetryReader interface {
 	TelemetryRecords(time.Time) []TelemetryRecord
 }
 
+// storedTelemetryRecord pairs a record with its encoded JSONL size so the
+// memory and file budgets can be enforced without re-marshalling.
+type storedTelemetryRecord struct {
+	record TelemetryRecord
+	bytes  int64
+}
+
 type JSONLTelemetrySink struct {
-	mu        sync.RWMutex
-	file      *os.File
-	writer    *bufio.Writer
-	records   []TelemetryRecord
-	now       func() time.Time
-	stop      chan struct{}
-	done      chan struct{}
-	closeOnce sync.Once
-	closeErr  error
-	writeErr  error
-	closed    bool
+	mu          sync.RWMutex
+	path        string
+	file        *os.File
+	writer      *bufio.Writer
+	records     []storedTelemetryRecord
+	memoryBytes int64
+	fileBytes   int64
+	memoryLimit int64
+	fileLimit   int64
+	now         func() time.Time
+	stop        chan struct{}
+	done        chan struct{}
+	closeOnce   sync.Once
+	closeErr    error
+	writeErr    error
+	closed      bool
 }
 
 func NewJSONLTelemetrySink(path string) (*JSONLTelemetrySink, error) {
@@ -123,18 +180,29 @@ func newJSONLTelemetrySinkWithIntervals(path string, now func() time.Time, flush
 		return nil, fmt.Errorf("open telemetry file: %w", err)
 	}
 	sink := &JSONLTelemetrySink{
-		file: file, now: now, stop: make(chan struct{}), done: make(chan struct{}),
+		path: path, file: file, now: now, stop: make(chan struct{}), done: make(chan struct{}),
+		memoryLimit: maxTelemetryMemoryBytes, fileLimit: maxTelemetryFileBytes,
 	}
 	if err := sink.loadRecent(); err != nil {
 		_ = file.Close()
 		return nil, err
 	}
 	sink.writer = bufio.NewWriter(file)
+	if err := sink.maybeCompactLocked(); err != nil {
+		_ = sink.file.Close()
+		return nil, fmt.Errorf("compact telemetry file: %w", err)
+	}
 	go sink.persistenceLoop(flushInterval, syncInterval)
 	return sink, nil
 }
 
 func (s *JSONLTelemetrySink) loadRecent() error {
+	info, err := s.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat telemetry file: %w", err)
+	}
+	s.fileBytes = info.Size()
+
 	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
 		return fmt.Errorf("seek telemetry file: %w", err)
 	}
@@ -148,15 +216,32 @@ func (s *JSONLTelemetrySink) loadRecent() error {
 		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
 			return fmt.Errorf("decode telemetry record on line %d: %w", line, err)
 		}
-		if !record.Event.OccurredAt.Before(cutoff) {
-			s.records = append(s.records, record)
+		if retentionTime(record).Before(cutoff) {
+			continue
 		}
+		size := int64(len(scanner.Bytes()) + 1)
+		s.records = append(s.records, storedTelemetryRecord{record: record, bytes: size})
+		s.memoryBytes += size
+		// Enforce the budget while scanning so loading an oversized file cannot
+		// balloon memory before a post-load trim.
+		s.dropOldestOverBudgetLocked()
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("read telemetry file: %w", err)
 	}
-	_, err := s.file.Seek(0, io.SeekEnd)
+	_, err = s.file.Seek(0, io.SeekEnd)
 	return err
+}
+
+// retentionTime is the timestamp retention decisions key off: the
+// server-assigned receipt time, falling back to the event time for legacy
+// records persisted before ReceivedAt existed. OccurredAt alone is never
+// trusted — it is client-controlled.
+func retentionTime(record TelemetryRecord) time.Time {
+	if !record.ReceivedAt.IsZero() {
+		return record.ReceivedAt
+	}
+	return record.Event.OccurredAt
 }
 
 func (s *JSONLTelemetrySink) Close() error {
@@ -186,15 +271,40 @@ func (s *JSONLTelemetrySink) WriteTelemetry(_ context.Context, records []Telemet
 		return s.writeErr
 	}
 
-	encoder := json.NewEncoder(s.writer)
 	for _, record := range records {
-		if err := encoder.Encode(record); err != nil {
+		line, err := json.Marshal(record)
+		if err != nil {
 			return fmt.Errorf("encode telemetry record: %w", err)
 		}
+		line = append(line, '\n')
+		if _, err := s.writer.Write(line); err != nil {
+			s.writeErr = fmt.Errorf("write telemetry record: %w", err)
+			return s.writeErr
+		}
+		size := int64(len(line))
+		s.records = append(s.records, storedTelemetryRecord{record: record, bytes: size})
+		s.memoryBytes += size
+		s.fileBytes += size
 	}
-	s.records = append(s.records, records...)
 	s.pruneLocked(s.now().UTC().Add(-telemetryRetention))
+	s.dropOldestOverBudgetLocked()
+	if err := s.maybeCompactLocked(); err != nil {
+		s.writeErr = fmt.Errorf("compact telemetry file: %w", err)
+		return s.writeErr
+	}
 	return nil
+}
+
+// maybeCompactLocked compacts once the file is over budget, but only when the
+// retained set is small enough that rewriting meaningfully shrinks the file —
+// otherwise every append would trigger a futile full rewrite. With the default
+// limits (memory budget ≤ ¼ of the file budget) an over-budget file always
+// qualifies.
+func (s *JSONLTelemetrySink) maybeCompactLocked() error {
+	if s.fileBytes <= s.fileLimit || s.memoryBytes >= s.fileBytes/2 {
+		return nil
+	}
+	return s.compactLocked()
 }
 
 func (s *JSONLTelemetrySink) persistenceLoop(flushInterval, syncInterval time.Duration) {
@@ -244,9 +354,9 @@ func (s *JSONLTelemetrySink) TelemetryRecords(since time.Time) []TelemetryRecord
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	records := make([]TelemetryRecord, 0, len(s.records))
-	for _, record := range s.records {
-		if !record.Event.OccurredAt.Before(since) {
-			records = append(records, record)
+	for _, stored := range s.records {
+		if !stored.record.Event.OccurredAt.Before(since) {
+			records = append(records, stored.record)
 		}
 	}
 	return records
@@ -254,12 +364,88 @@ func (s *JSONLTelemetrySink) TelemetryRecords(since time.Time) []TelemetryRecord
 
 func (s *JSONLTelemetrySink) pruneLocked(cutoff time.Time) {
 	kept := s.records[:0]
-	for _, record := range s.records {
-		if !record.Event.OccurredAt.Before(cutoff) {
-			kept = append(kept, record)
+	for _, stored := range s.records {
+		if retentionTime(stored.record).Before(cutoff) {
+			s.memoryBytes -= stored.bytes
+			continue
 		}
+		kept = append(kept, stored)
 	}
 	s.records = kept
+}
+
+// dropOldestOverBudgetLocked enforces the in-memory byte budget by discarding
+// the oldest-received records first. This — not the retention window — is what
+// keeps an anonymous telemetry flood from growing broker memory without bound.
+func (s *JSONLTelemetrySink) dropOldestOverBudgetLocked() {
+	drop := 0
+	for drop < len(s.records) && s.memoryBytes > s.memoryLimit {
+		s.memoryBytes -= s.records[drop].bytes
+		drop++
+	}
+	if drop == 0 {
+		return
+	}
+	s.records = append(s.records[:0], s.records[drop:]...)
+}
+
+// compactLocked rewrites the JSONL file to contain only the records still
+// retained in memory and swaps the live handle to the rewritten file. Without
+// this the append-only file grows without bound.
+func (s *JSONLTelemetrySink) compactLocked() error {
+	if err := s.flushLocked(false); err != nil {
+		return err
+	}
+	dir, base := filepath.Split(s.path)
+	temp, err := os.CreateTemp(dir, base+".compact-*")
+	if err != nil {
+		return fmt.Errorf("create compaction file: %w", err)
+	}
+	tempPath := temp.Name()
+	discard := func() {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+	}
+
+	writer := bufio.NewWriter(temp)
+	var written int64
+	for _, stored := range s.records {
+		line, err := json.Marshal(stored.record)
+		if err == nil {
+			line = append(line, '\n')
+			_, err = writer.Write(line)
+		}
+		if err != nil {
+			discard()
+			return fmt.Errorf("write compacted telemetry: %w", err)
+		}
+		written += int64(len(line))
+	}
+	if err := writer.Flush(); err != nil {
+		discard()
+		return fmt.Errorf("flush compacted telemetry: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		discard()
+		return fmt.Errorf("sync compacted telemetry: %w", err)
+	}
+	if err := os.Rename(tempPath, s.path); err != nil {
+		discard()
+		return fmt.Errorf("swap compacted telemetry file: %w", err)
+	}
+
+	// The rename unlinked the old file; keep appending through the handle of
+	// the freshly written one.
+	if _, err := temp.Seek(0, io.SeekEnd); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("seek compacted telemetry file: %w", err)
+	}
+	old := s.file
+	s.file = temp
+	s.writer = bufio.NewWriter(temp)
+	s.fileBytes = written
+	_ = old.Close()
+	return nil
 }
 
 func telemetryHandler(sink TelemetrySink, relayMetrics RelayStore, clientIP *clientIPResolver) http.HandlerFunc {
@@ -286,7 +472,7 @@ func telemetryHandler(sink TelemetrySink, relayMetrics RelayStore, clientIP *cli
 		sourceIP := clientIP.clientIP(r)
 		records := make([]TelemetryRecord, 0, len(batch.Events))
 		for _, event := range batch.Events {
-			if err := validateTelemetryEvent(event); err != nil {
+			if err := validateTelemetryEvent(event, now); err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
@@ -308,7 +494,7 @@ func telemetryHandler(sink TelemetrySink, relayMetrics RelayStore, clientIP *cli
 	}
 }
 
-func validateTelemetryEvent(event TelemetryEvent) error {
+func validateTelemetryEvent(event TelemetryEvent, now time.Time) error {
 	switch {
 	case event.SchemaVersion != 1:
 		return errors.New("schema_version must be 1")
@@ -322,19 +508,77 @@ func validateTelemetryEvent(event TelemetryEvent) error {
 		return errors.New("session_id is required and must be at most 128 characters")
 	case event.OccurredAt.IsZero():
 		return errors.New("occurred_at is required")
+	case event.OccurredAt.After(now.Add(maxTelemetryFutureSkew)):
+		return errors.New("occurred_at must not be in the future")
+	case len(event.RelayID) > 128:
+		return errors.New("relay_id must be at most 128 characters")
+	case len(event.Application) > maxTelemetryValueBytes:
+		return errors.New("application_package must be at most 256 characters")
+	case len(event.DestinationIP) > maxTelemetryKeyBytes:
+		return errors.New("destination_ip must be at most 64 characters")
+	case len(event.Protocol) > maxTelemetryKeyBytes:
+		return errors.New("protocol must be at most 64 characters")
 	case len(event.Attributes) > 32 || len(event.Measurements) > 32:
 		return errors.New("telemetry maps may contain at most 32 entries")
+	}
+	for key, value := range event.Attributes {
+		if len(key) > maxTelemetryKeyBytes || len(value) > maxTelemetryValueBytes {
+			return errors.New("attribute keys are limited to 64 characters and values to 256")
+		}
+	}
+	for key := range event.Measurements {
+		if len(key) > maxTelemetryKeyBytes {
+			return errors.New("measurement keys are limited to 64 characters")
+		}
 	}
 	return nil
 }
 
-func recordClientSeen(r *http.Request, sink TelemetrySink, clientIP *clientIPResolver) {
+// clientSeenDeduper suppresses repeat client_seen records for the same client
+// session inside a short window.
+type clientSeenDeduper struct {
+	window     time.Duration
+	maxEntries int
+	mu         sync.Mutex
+	seen       map[string]time.Time
+}
+
+func newClientSeenDeduper(window time.Duration, maxEntries int) *clientSeenDeduper {
+	return &clientSeenDeduper{window: window, maxEntries: maxEntries, seen: make(map[string]time.Time)}
+}
+
+func (d *clientSeenDeduper) shouldRecord(clientID, sessionID string, now time.Time) bool {
+	key := clientID + "\x00" + sessionID
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if last, ok := d.seen[key]; ok && now.Sub(last) < d.window {
+		return false
+	}
+	if len(d.seen) >= d.maxEntries {
+		for seenKey, seenAt := range d.seen {
+			if now.Sub(seenAt) >= d.window {
+				delete(d.seen, seenKey)
+			}
+		}
+	}
+	// When the table is full of live entries the record is written rather than
+	// suppressed: over-recording under pressure beats hiding active clients.
+	if len(d.seen) < d.maxEntries {
+		d.seen[key] = now
+	}
+	return true
+}
+
+func recordClientSeen(r *http.Request, sink TelemetrySink, clientIP *clientIPResolver, dedup *clientSeenDeduper) {
 	clientID := strings.TrimSpace(r.Header.Get("X-OpenRung-Client-ID"))
 	sessionID := strings.TrimSpace(r.Header.Get("X-OpenRung-Session-ID"))
 	if sink == nil || clientID == "" || sessionID == "" || len(clientID) > 128 || len(sessionID) > 128 {
 		return
 	}
 	now := time.Now().UTC()
+	if dedup != nil && !dedup.shouldRecord(clientID, sessionID, now) {
+		return
+	}
 	event := TelemetryEvent{
 		SchemaVersion: 1,
 		EventID:       "client-seen-" + sessionID,

--- a/internal/broker/telemetry_test.go
+++ b/internal/broker/telemetry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -95,7 +96,7 @@ func TestTelemetryHandlerRejectsMissingIdentity(t *testing.T) {
 func TestSpeedTestHandlerStreamsRequestedBytes(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10000", nil)
 	recorder := httptest.NewRecorder()
-	speedTestHandler().ServeHTTP(recorder, req)
+	speedTestHandler(speedTestMaxConcurrent).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", recorder.Code, recorder.Body.String())
@@ -111,10 +112,68 @@ func TestSpeedTestHandlerStreamsRequestedBytes(t *testing.T) {
 func TestSpeedTestHandlerRejectsOversizedRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=25000001", nil)
 	recorder := httptest.NewRecorder()
-	speedTestHandler().ServeHTTP(recorder, req)
+	speedTestHandler(speedTestMaxConcurrent).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", recorder.Code)
+	}
+}
+
+// gatedWriter blocks the handler's first body write until released, keeping a
+// speed-test stream "in flight" so concurrency limits can be observed.
+type gatedWriter struct {
+	header  http.Header
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+	written int
+}
+
+func newGatedWriter() *gatedWriter {
+	return &gatedWriter{header: make(http.Header), started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (w *gatedWriter) Header() http.Header { return w.header }
+func (w *gatedWriter) WriteHeader(int)     {}
+func (w *gatedWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.started)
+		<-w.release
+	})
+	w.written += len(p)
+	return len(p), nil
+}
+
+func TestSpeedTestHandlerLimitsConcurrentStreams(t *testing.T) {
+	handler := speedTestHandler(1)
+
+	blocked := newGatedWriter()
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		handler.ServeHTTP(blocked, httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=100000", nil))
+	}()
+	<-blocked.started
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=100000", nil))
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 while a stream holds the only slot, got %d", recorder.Code)
+	}
+	if recorder.Header().Get("Retry-After") == "" {
+		t.Fatal("expected Retry-After header on busy response")
+	}
+
+	close(blocked.release)
+	<-firstDone
+	if blocked.written != 100000 {
+		t.Fatalf("expected first stream to finish with 100000 bytes, got %d", blocked.written)
+	}
+
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected freed slot to serve again, got %d", recorder.Code)
 	}
 }
 
@@ -253,6 +312,195 @@ func TestJSONLTelemetrySinkCloseFlushesAndSyncs(t *testing.T) {
 	}
 	if !strings.Contains(string(contents), `"event_id":"close"`) {
 		t.Fatalf("close did not persist buffered telemetry: %s", contents)
+	}
+}
+
+func TestTelemetryHandlerRejectsFutureEvent(t *testing.T) {
+	sink := &memoryTelemetrySink{}
+	payload, err := json.Marshal(telemetryBatch{Events: []TelemetryEvent{{
+		SchemaVersion: 1,
+		EventID:       "event-1",
+		Event:         "connection_attempted",
+		OccurredAt:    time.Now().UTC().Add(2 * time.Hour),
+		ClientID:      "client-1",
+		SessionID:     "session-1",
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/telemetry/events", bytes.NewReader(payload))
+	recorder := httptest.NewRecorder()
+	telemetryHandler(sink, nil, newClientIPResolver(nil)).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for future-dated event, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(sink.records) != 0 {
+		t.Fatalf("expected no stored records, got %d", len(sink.records))
+	}
+}
+
+func TestTelemetryHandlerRejectsOversizedAttributeValue(t *testing.T) {
+	sink := &memoryTelemetrySink{}
+	payload, err := json.Marshal(telemetryBatch{Events: []TelemetryEvent{{
+		SchemaVersion: 1,
+		EventID:       "event-1",
+		Event:         "connection_attempted",
+		OccurredAt:    time.Now().UTC(),
+		ClientID:      "client-1",
+		SessionID:     "session-1",
+		Attributes:    map[string]string{"note": strings.Repeat("x", maxTelemetryValueBytes+1)},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/telemetry/events", bytes.NewReader(payload))
+	recorder := httptest.NewRecorder()
+	telemetryHandler(sink, nil, newClientIPResolver(nil)).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized attribute, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestJSONLTelemetrySinkEnforcesMemoryBudget(t *testing.T) {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	sink, err := newJSONLTelemetrySink(filepath.Join(t.TempDir(), "telemetry.jsonl"), func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+
+	sample, err := json.Marshal(telemetryRecordAt(now, "event-0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordSize := int64(len(sample) + 1)
+	sink.memoryLimit = 2*recordSize + recordSize/2
+
+	for index := 0; index < 5; index++ {
+		record := telemetryRecordAt(now, fmt.Sprintf("event-%d", index))
+		if err := sink.WriteTelemetry(context.Background(), []TelemetryRecord{record}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	records := sink.TelemetryRecords(time.Time{})
+	if len(records) != 2 {
+		t.Fatalf("expected budget to retain 2 records, got %d", len(records))
+	}
+	if records[0].Event.EventID != "event-3" || records[1].Event.EventID != "event-4" {
+		t.Fatalf("expected oldest records dropped first, got %q and %q", records[0].Event.EventID, records[1].Event.EventID)
+	}
+	if sink.memoryBytes > sink.memoryLimit {
+		t.Fatalf("memory accounting exceeds budget: %d > %d", sink.memoryBytes, sink.memoryLimit)
+	}
+}
+
+func TestJSONLTelemetrySinkCompactsOversizedFile(t *testing.T) {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
+	sink, err := newJSONLTelemetrySinkWithIntervals(path, func() time.Time { return now }, time.Hour, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sample, err := json.Marshal(telemetryRecordAt(now, "event-0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordSize := int64(len(sample) + 1)
+	sink.memoryLimit = 2*recordSize + recordSize/2
+	sink.fileLimit = 3 * recordSize
+
+	for index := 0; index < 6; index++ {
+		record := telemetryRecordAt(now, fmt.Sprintf("event-%d", index))
+		if err := sink.WriteTelemetry(context.Background(), []TelemetryRecord{record}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if sink.fileBytes > sink.fileLimit {
+		t.Fatalf("file accounting exceeds budget after writes: %d > %d", sink.fileBytes, sink.fileLimit)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(contents)), "\n")
+	if len(lines) >= 6 {
+		t.Fatalf("expected compaction to shrink the file, still holds %d records", len(lines))
+	}
+	for _, line := range lines {
+		var record TelemetryRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("compacted file contains malformed record: %v", err)
+		}
+	}
+	if !strings.Contains(lines[len(lines)-1], `"event_id":"event-5"`) {
+		t.Fatalf("expected newest record to survive compaction, got %s", lines[len(lines)-1])
+	}
+}
+
+func TestJSONLTelemetrySinkRetentionIgnoresClientClock(t *testing.T) {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	sink, err := newJSONLTelemetrySink(filepath.Join(t.TempDir(), "telemetry.jsonl"), func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+
+	// Received 8 days ago but "occurred" a year from now: the client-controlled
+	// event time must not be able to extend retention.
+	forged := telemetryRecordAt(now.Add(365*24*time.Hour), "forged-future")
+	forged.ReceivedAt = now.Add(-8 * 24 * time.Hour)
+	current := telemetryRecordAt(now, "current")
+	if err := sink.WriteTelemetry(context.Background(), []TelemetryRecord{forged, current}); err != nil {
+		t.Fatal(err)
+	}
+
+	records := sink.TelemetryRecords(time.Time{})
+	if len(records) != 1 || records[0].Event.EventID != "current" {
+		t.Fatalf("expected only the honestly-timed record to survive, got %+v", records)
+	}
+}
+
+func TestClientSeenDeduperSuppressesRepeatsWithinWindow(t *testing.T) {
+	dedup := newClientSeenDeduper(4*time.Minute, 10)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+
+	if !dedup.shouldRecord("client-1", "session-1", now) {
+		t.Fatal("first sighting must record")
+	}
+	if dedup.shouldRecord("client-1", "session-1", now.Add(time.Minute)) {
+		t.Fatal("repeat inside the window must be suppressed")
+	}
+	if !dedup.shouldRecord("client-1", "session-2", now) {
+		t.Fatal("a different session must record")
+	}
+	if !dedup.shouldRecord("client-1", "session-1", now.Add(5*time.Minute)) {
+		t.Fatal("sighting after the window must record again")
+	}
+}
+
+func TestRelayListDedupsRepeatClientSeen(t *testing.T) {
+	sink := &memoryTelemetrySink{}
+	server := NewServer(NewStore(), Config{TelemetrySink: sink})
+	for range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil)
+		req.Header.Set("X-OpenRung-Client-ID", "client-1")
+		req.Header.Set("X-OpenRung-Session-ID", "session-1")
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", recorder.Code)
+		}
+	}
+	if len(sink.records) != 1 {
+		t.Fatalf("expected one client_seen record for repeat polling, got %d", len(sink.records))
 	}
 }
 


### PR DESCRIPTION
## Summary

The broker's unauthenticated endpoints let a single cheap source exhaust memory, disk, egress, and connections. This bounds all four (items 1–3 from the security review discussion):

**Telemetry ingest could grow broker memory and disk without bound**
- In-memory records now live under a 64 MiB byte budget; oldest-received records are dropped first once the budget is exceeded.
- The JSONL file is compacted (rewritten to the retained set via temp file + atomic rename) when it passes 256 MiB, on write and at startup. It was previously append-only forever.
- Retention keys off server-assigned `ReceivedAt` instead of the client-controlled `occurred_at`; events dated more than 1 h into the future are rejected and free-form fields are length-capped, so forged timestamps/payloads cannot extend retention or pollute dashboards.
- `client_seen` records from `GET /api/v1/relays` are deduped per client session in a 4-minute window (kept under the 5-minute operational-stats window), so anonymous polling is no longer one disk write per request.

**Speed test was a free 25 MB egress lever**
- Global cap of 4 concurrent streams — concurrency, not request rate, is what bounds worst-case egress — plus a per-IP budget (burst 3, ~2/min sustained). Over budget → `429` + `Retry-After`.
- The handler extends its own write deadline to 5 min via `ResponseController` so slow links can still finish a full download inside the new tighter server-wide timeouts.

**Broker `http.Server` had no timeouts (slowloris)**
- `ReadHeaderTimeout` 10 s, read/write/idle timeouts 2 min, 64 KiB header cap — matching what the relay hub already did.
- Also added the missing `MaxBytesReader` (64 KiB) on volunteer registration bodies.

All unauthenticated endpoints (`/relays`, `/telemetry/events`, `/speed-test`) now sit behind per-IP token buckets keyed by the Cloudflare-aware resolved client IP. The limiter is dependency-free, capped at 100k tracked IPs, and fails open when the table fills: rotating-IP floods are the edge proxy's job, and failing closed would DoS legitimate users. Buckets are generous because carrier-grade NAT puts many clients behind one IP; the `/relays` sustained rate (2/s per IP) is the constant to tune if legitimate 429s ever show up.

Token-gated volunteer endpoints and `/healthz` (LB probes) are deliberately not rate limited.

## Test plan

- New unit tests: limiter burst/refill/isolation/fail-open/sweep, memory budget enforcement, file compaction, forged-timestamp retention, future-event and oversized-field rejection, client_seen dedup, speed-test concurrency gate (blocked mid-stream writer), 429 wiring through `NewServer`, oversized register body.
- `go vet ./...`, `go test ./...`, and `go test -race ./internal/broker` all pass.
- Deploy note: code-only change, no new flags or env vars; the production broker on Lightsail just needs a binary redeploy. Clients should treat `429` + `Retry-After` as back-off, not failure (documented in docs/api.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)