### PR TITLE
Send relay list with Cache-Control: no-store

### DIFF
--- a/internal/broker/ratelimit.go
+++ b/internal/broker/ratelimit.go
@@ -102,6 +102,9 @@ func (l *ipRateLimiter) sweepLocked(now time.Time) {
 func rateLimited(limiter *ipRateLimiter, clientIP *clientIPResolver, retryAfterSeconds int, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !limiter.allow(clientIP.clientIP(r)) {
+			// A 429 is per-client state: a shared cache (Cloudflare's edge)
+			// storing one would replay it to every client behind the edge.
+			w.Header().Set("Cache-Control", "no-store")
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
 			writeError(w, http.StatusTooManyRequests, "rate limit exceeded, retry later")
 			return

--- a/internal/broker/ratelimit_test.go
+++ b/internal/broker/ratelimit_test.go
@@ -99,6 +99,9 @@ func TestServerRateLimitsSpeedTest(t *testing.T) {
 	if recorder.Header().Get("Retry-After") == "" {
 		t.Fatal("expected Retry-After header on 429")
 	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("expected no-store cache control on 429, got %q", got)
+	}
 
 	// A different source IP is not affected by the exhausted bucket.
 	otherSource := httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10", nil)

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -162,6 +162,10 @@ func geoLookupHost(desc *relay.Descriptor) string {
 
 func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *clientIPResolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Relay availability is real-time: shared caches (Cloudflare's edge in
+		// production) must never store a copy, and clients cannot bust an edge
+		// cache from their side. Set on every path so errors aren't cached either.
+		w.Header().Set("Cache-Control", "no-store")
 		recordClientSeen(r, telemetrySink, clientIP)
 		limit := 5
 		if raw := r.URL.Query().Get("limit"); raw != "" {

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -246,6 +246,25 @@ func TestListRelaysReportsStoreFailure(t *testing.T) {
 	}
 }
 
+func TestListRelaysIsNeverCacheable(t *testing.T) {
+	server := NewServer(NewStore(), Config{})
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("expected no-store cache control on relay list, got %q", got)
+	}
+
+	failingServer := NewServer(failingStore{Store: NewStore(), listErr: errors.New("database down")}, Config{})
+	failRecorder := httptest.NewRecorder()
+	failingServer.ServeHTTP(failRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	if got := failRecorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("expected no-store cache control on relay list error, got %q", got)
+	}
+}
+
 func TestHeartbeatMissingRelayStillReturnsNotFound(t *testing.T) {
 	server := NewServer(NewStore(), Config{})
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
## What

- `GET /api/v1/relays` now responds with `Cache-Control: no-store`, set first thing in the handler so every response path carries it — the 200 list as well as the 400 (bad `limit`) and 503 (store failure) errors. Adds `TestListRelaysIsNeverCacheable` covering the 200 and 503 paths.
- The `rateLimited` wrapper (from #5) also sets `Cache-Control: no-store` on its 429 responses. Cloudflare skips 429s by default, but a per-client rejection must never be replayable from a shared cache, so the origin doesn't depend on that default.
- Merges main (#5 broker abuse hardening); the only conflict was in `listRelaysHandler`, resolved by keeping the new header alongside main's four-argument `recordClientSeen`.

## Why

`cf-cache-status` headers on the production broker showed Cloudflare's edge caching the relay list and serving it up to ~4 hours stale to any client, including already-shipped app builds. Relay availability is real-time data, and client-side request headers cannot bust Cloudflare's cache — only the origin response headers (or zone config) control it.

The speed-test and dashboard handlers already set `no-store`; the relay list was the only GET endpoint missing it, so this follows the existing idiom.

## Reviewer notes

Two deploy-side follow-ups this PR cannot cover:

1. **Purge the edge cache at rollout** — entries already cached keep serving until their TTL expires even after the origin starts sending `no-store`.
2. **Check the Cloudflare cache rule** — Cloudflare doesn't cache extensionless JSON by default, so the observed `HIT` implies a Cache Everything / cache rule on the zone. If that rule's Edge TTL is set to *override* origin, `no-store` is ignored; it must respect origin headers or exclude `/api/*`.

Post-deploy verification: `curl -sI` the prod endpoint — `cf-cache-status` should read `BYPASS`/`DYNAMIC`, never `HIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)