### PR TITLE
Harden data plane and client trust boundaries (urgent security fixes)

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -37,6 +37,14 @@ func run() error {
 	if err != nil {
 		return err
 	}
+
+	// Fail closed: with no registration token, anyone can register a relay and
+	// poison the directory that clients route their VPN traffic through. Require
+	// a token unless the operator explicitly opts into an open broker.
+	registrationToken := os.Getenv("OPENRUNG_VOLUNTEER_TOKEN")
+	if registrationToken == "" && !envTrue("OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION") {
+		return errors.New("OPENRUNG_VOLUNTEER_TOKEN is empty: refusing to start an open broker where anyone can register relays. Set OPENRUNG_VOLUNTEER_TOKEN, or set OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true to run open intentionally")
+	}
 	geoResolver := newGeoIPResolver(*geoIPEndpoint)
 	store, err := newRelayStore(*relayStore, *relayDatabaseURL, rankingMode)
 	if err != nil {
@@ -50,7 +58,7 @@ func run() error {
 		return err
 	}
 	handler := broker.NewServer(store, broker.Config{
-		RegistrationToken: os.Getenv("OPENRUNG_VOLUNTEER_TOKEN"),
+		RegistrationToken: registrationToken,
 		VolunteerLeaseTTL: *leaseTTL,
 		TelemetrySink:     telemetrySink,
 		TelemetryReader:   telemetrySink,
@@ -134,6 +142,16 @@ func envDefault(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+// envTrue reports whether an env var is set to a truthy value.
+func envTrue(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // splitAndTrim parses a comma-separated env value into a trimmed, non-empty slice.

--- a/cmd/client/telemetry.go
+++ b/cmd/client/telemetry.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -79,12 +78,9 @@ func probeInternet(ctx context.Context, brokerURL string) (int64, bool) {
 }
 
 func healthURL(brokerURL string) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(brokerURL))
+	parsed, err := client.EnforceSecureBrokerURL(brokerURL)
 	if err != nil {
 		return "", err
-	}
-	if parsed.Scheme == "" || parsed.Host == "" {
-		return "", fmt.Errorf("broker URL must include scheme and host")
 	}
 	basePath := strings.Trim(parsed.Path, "/")
 	parts := []string{"healthz"}

--- a/cmd/relayhub/main.go
+++ b/cmd/relayhub/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -30,6 +31,13 @@ func run() error {
 	cfg, err := parseConfig()
 	if err != nil {
 		return err
+	}
+
+	// Fail closed: an empty token disables volunteer authentication, so any node
+	// could register as a relay through this hub. Require a token unless the
+	// operator explicitly opts into an open hub.
+	if cfg.Token == "" && !envTrue("OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS") {
+		return errors.New("OPENRUNG_VOLUNTEER_TOKEN is empty: refusing to start an open hub where any node can register as a relay. Set OPENRUNG_VOLUNTEER_TOKEN, or set OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true to run open intentionally")
 	}
 
 	alloc, err := tunnel.NewPortAllocator(cfg.PortRangeStart, cfg.PortRangeEnd)
@@ -219,4 +227,14 @@ func envDurationDefault(key string, fallback time.Duration) time.Duration {
 		}
 	}
 	return fallback
+}
+
+// envTrue reports whether an env var is set to a truthy value.
+func envTrue(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }

--- a/deploy/relayhub/.env.example
+++ b/deploy/relayhub/.env.example
@@ -23,10 +23,12 @@ OPENRUNG_BROKER_URL=https://broker.example.com
 #OPENRUNG_HUB_PUBLIC_BIND_HOST=
 
 # ---------------------------------------------------------------------------
-# Auth (optional, strongly recommended)
+# Auth (required outside local development)
 # ---------------------------------------------------------------------------
 # Shared bearer token: volunteers must present it to open a tunnel, and the hub
 # uses it for its broker registration calls. Must match the broker's token.
+# The hub refuses to start without it; to run an open hub intentionally (local
+# dev only) set OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true instead.
 #OPENRUNG_VOLUNTEER_TOKEN=
 
 # ---------------------------------------------------------------------------

--- a/deploy/relayhub/README.md
+++ b/deploy/relayhub/README.md
@@ -126,7 +126,7 @@ flags — run `relayhub -h`). See `.env.example` for the full list. The essentia
 | `OPENRUNG_BROKER_URL`         | yes      | —              | Broker the hub registers relays with               |
 | `OPENRUNG_HUB_CONTROL_ADDR`   | no       | `:9443`        | Address volunteers dial                            |
 | `OPENRUNG_HUB_PORT_RANGE`     | no       | `20000-20100`  | Public ports allocated to tunnels (one each)       |
-| `OPENRUNG_VOLUNTEER_TOKEN`    | no       | —              | Shared auth token (must match the broker)          |
+| `OPENRUNG_VOLUNTEER_TOKEN`    | yes\*    | —              | Shared auth token (must match the broker). Required: the hub refuses to start without it unless `OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true` |
 | `OPENRUNG_HUB_TLS_CERT/KEY`   | no       | —              | TLS for the control channel                        |
 | `OPENRUNG_HUB_HEARTBEAT_INTERVAL` | no   | `30s`          | How often live relays are re-heartbeated           |
 | `OPENRUNG_HUB_HTTP_ADDR`      | no       | —              | HTTP API address (e.g. `:9444`) — serves the reachability prober and, with reflectors, the punch coordinator; empty disables both |

--- a/deploy/volunteer/.env.example
+++ b/deploy/volunteer/.env.example
@@ -42,9 +42,10 @@ OPENRUNG_PUBLIC_HOST=2001:db8::1234
 #OPENRUNG_LISTEN_PORT=443
 
 # ---------------------------------------------------------------------------
-# Broker auth (optional)
+# Broker auth (required against a production broker)
 # ---------------------------------------------------------------------------
-# Registration token, if the broker requires one.
+# Registration token the broker requires. Production brokers require one by
+# default (they refuse to start open), so set this to match the broker's token.
 #OPENRUNG_VOLUNTEER_TOKEN=
 
 # ---------------------------------------------------------------------------

--- a/desktop/config/config.go
+++ b/desktop/config/config.go
@@ -11,15 +11,17 @@ import (
 
 const (
 	// DefaultBrokerURL is the HTTPS, Cloudflare-fronted discovery endpoint.
-	// Discovery runs BEFORE the tunnel is up, so TLS + CDN edge IPs make it
-	// costly to block; the raw-IP fallback in DefaultBrokerURLs covers a
-	// blocked edge.
+	// Discovery runs BEFORE the tunnel is up, so it must be TLS: the relay list
+	// seeds the entire VPN config and the request carries the client identity, so
+	// a cleartext endpoint would hand both to an on-path censor.
 	DefaultBrokerURL = "https://broker.openrung.org/"
 
-	// TelemetryBrokerURL is the raw origin IP. Heartbeats fire ~once/minute
-	// per connected user and ride the established tunnel, so they skip the CDN
-	// front to avoid burning the Workers free-tier quota.
-	TelemetryBrokerURL = "http://54.238.185.205:8080/"
+	// TelemetryBrokerURL is the endpoint for client telemetry. It must be HTTPS:
+	// the first events (BeginSession / connection_attempted) fire BEFORE the
+	// tunnel is up, so a cleartext endpoint would expose the persistent client
+	// identity to a network observer. Reuses the HTTPS discovery endpoint; a
+	// pinned bare-IP fallback can be layered on later if CDN quota is a concern.
+	TelemetryBrokerURL = DefaultBrokerURL
 
 	// RelayLimit is the connect-path page size; DirectoryRelayLimit is the
 	// broker's maximum page size (larger is rejected with HTTP 400), used to
@@ -39,12 +41,13 @@ const (
 	MinDirectoryRefreshInterval = 30 * time.Second
 )
 
-// DefaultBrokerURLs are the ordered discovery candidates: Cloudflare-fronted
-// endpoint first, raw IP as a fallback so a blocked edge never takes discovery
-// offline.
+// DefaultBrokerURLs are the ordered discovery candidates. HTTPS only: discovery
+// runs BEFORE the tunnel, so a cleartext bare-IP fallback would let an on-path
+// censor read or rewrite the relay list — and observe the client identity
+// headers — exactly the adversary this tool exists to defeat. A pinned bare-IP
+// HTTPS fallback for a blocked edge can be added later.
 var DefaultBrokerURLs = []string{
 	"https://broker.openrung.org/",
-	"http://54.238.185.205:8080/",
 }
 
 // BrokerCandidates returns the ordered, de-duplicated discovery candidates for

--- a/desktop/config/config_test.go
+++ b/desktop/config/config_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestBrokerCandidates(t *testing.T) {
 	https := "https://broker.openrung.org/"
-	ip := "http://54.238.185.205:8080/"
 
 	tests := []struct {
 		name    string
@@ -15,24 +14,24 @@ func TestBrokerCandidates(t *testing.T) {
 		want    []string
 	}{
 		{
-			name:    "empty primary yields defaults in order",
+			name:    "empty primary yields the HTTPS default",
 			primary: "",
-			want:    []string{https, ip},
+			want:    []string{https},
 		},
 		{
 			name:    "blank primary is ignored",
 			primary: "   ",
-			want:    []string{https, ip},
+			want:    []string{https},
 		},
 		{
 			name:    "genuine override is tried first",
 			primary: "https://mirror.example/",
-			want:    []string{"https://mirror.example/", https, ip},
+			want:    []string{"https://mirror.example/", https},
 		},
 		{
-			name:    "primary echoing a default does not reorder defaults",
-			primary: ip,
-			want:    []string{https, ip},
+			name:    "primary echoing a default does not duplicate it",
+			primary: https,
+			want:    []string{https},
 		},
 	}
 

--- a/internal/broker/auth_hardening_test.go
+++ b/internal/broker/auth_hardening_test.go
@@ -1,0 +1,50 @@
+package broker
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthorizedRejectsInvalidTokens(t *testing.T) {
+	withAuth := func(v string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil)
+		if v != "" {
+			r.Header.Set("Authorization", v)
+		}
+		return r
+	}
+
+	// Empty configured token: open mode (gated at startup), authorize anything.
+	if !authorized(withAuth(""), "") {
+		t.Fatal("empty configured token should authorize any request")
+	}
+	// Correct bearer token authorizes.
+	if !authorized(withAuth("Bearer s3cret"), "s3cret") {
+		t.Fatal("correct bearer token should authorize")
+	}
+	// Everything else is rejected, including length-adjacent and case variants.
+	for _, bad := range []string{"", "Bearer wrong", "s3cret", "Bearer s3cre", "Bearer s3crett", "bearer s3cret", "Bearer  s3cret"} {
+		if authorized(withAuth(bad), "s3cret") {
+			t.Errorf("authorized accepted invalid Authorization header %q", bad)
+		}
+	}
+}
+
+// TestServerRateLimitsRegister confirms the volunteer registration endpoint is
+// behind the per-IP limiter (the pre-fix endpoint was unthrottled).
+func TestServerRateLimitsRegister(t *testing.T) {
+	server := NewServer(NewStore(), Config{})
+	status := 0
+	for i := 0; i < volunteerBurst+1; i++ {
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil))
+		status = recorder.Code
+		if i < volunteerBurst && status == http.StatusTooManyRequests {
+			t.Fatalf("request %d inside burst unexpectedly limited", i+1)
+		}
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 past the burst, got %d", status)
+	}
+}

--- a/internal/broker/ratelimit.go
+++ b/internal/broker/ratelimit.go
@@ -18,6 +18,13 @@ const (
 	telemetryRatePerSecond = 1.0
 	telemetryBurst         = 20
 
+	// Volunteer registration/heartbeat are token-gated in production; this limiter
+	// is a backstop against a flood if the token leaks or the broker is
+	// deliberately run open. Generous: one relay hub re-registers and heartbeats
+	// every relay it fronts (a whole port range) from a single origin IP.
+	volunteerRatePerSecond = 20.0
+	volunteerBurst         = 256
+
 	// A full speed test streams up to 25 MB, so sustained refills are slow and
 	// the real egress bound is the concurrency cap below.
 	speedTestRatePerSecond = 1.0 / 30

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -41,6 +42,7 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	relayListLimiter := newIPRateLimiter(relayListRatePerSecond, relayListBurst, rateLimiterMaxTrackedIPs)
 	telemetryLimiter := newIPRateLimiter(telemetryRatePerSecond, telemetryBurst, rateLimiterMaxTrackedIPs)
 	speedTestLimiter := newIPRateLimiter(speedTestRatePerSecond, speedTestBurst, rateLimiterMaxTrackedIPs)
+	volunteerLimiter := newIPRateLimiter(volunteerRatePerSecond, volunteerBurst, rateLimiterMaxTrackedIPs)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -51,8 +53,8 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 		}
 		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 	})
-	mux.HandleFunc("POST /api/v1/volunteers/register", registerHandler(store, cfg))
-	mux.HandleFunc("POST /api/v1/volunteers/", heartbeatHandler(store, cfg))
+	mux.HandleFunc("POST /api/v1/volunteers/register", rateLimited(volunteerLimiter, clientIP, 10, registerHandler(store, cfg)))
+	mux.HandleFunc("POST /api/v1/volunteers/", rateLimited(volunteerLimiter, clientIP, 10, heartbeatHandler(store, cfg)))
 	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen)))
 	mux.HandleFunc("POST /api/v1/telemetry/events", rateLimited(telemetryLimiter, clientIP, 10, telemetryHandler(cfg.TelemetrySink, store, clientIP)))
 	mux.HandleFunc("GET /api/v1/speed-test", rateLimited(speedTestLimiter, clientIP, 30, speedTestHandler(speedTestMaxConcurrent)))
@@ -248,7 +250,11 @@ func authorized(r *http.Request, token string) bool {
 	if token == "" {
 		return true
 	}
-	return r.Header.Get("Authorization") == "Bearer "+token
+	// Constant-time compare so a network attacker cannot recover the token one
+	// byte at a time from response-timing differences.
+	expected := "Bearer " + token
+	presented := r.Header.Get("Authorization")
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(expected)) == 1
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/client/broker.go
+++ b/internal/client/broker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -61,19 +62,13 @@ func (c BrokerClient) ListRelays(ctx context.Context, limit int, clientID, sessi
 }
 
 func RelayListURL(baseURL string, limit int) (string, error) {
-	if strings.TrimSpace(baseURL) == "" {
-		return "", fmt.Errorf("broker URL is required")
-	}
 	if limit < 1 {
 		limit = defaultRelayLimit
 	}
 
-	parsed, err := url.Parse(baseURL)
+	parsed, err := EnforceSecureBrokerURL(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("parse broker URL: %w", err)
-	}
-	if parsed.Scheme == "" || parsed.Host == "" {
-		return "", fmt.Errorf("broker URL must include scheme and host")
+		return "", err
 	}
 
 	basePath := strings.Trim(parsed.Path, "/")
@@ -88,6 +83,52 @@ func RelayListURL(baseURL string, limit int) (string, error) {
 	parsed.RawQuery = query.Encode()
 
 	return parsed.String(), nil
+}
+
+// EnforceSecureBrokerURL parses baseURL and rejects cleartext broker endpoints.
+// https is allowed to any host; plain http is allowed ONLY to a loopback host
+// (local development). Plaintext http to any other host is refused so an on-path
+// network observer cannot read or tamper with the pre-tunnel broker traffic —
+// the relay directory seeds the entire VPN config and both the directory and
+// telemetry requests carry the persistent client identity headers. It returns
+// the parsed URL so callers can build endpoint paths on it.
+//
+// (A pinned bare-IP HTTPS fallback for a blocked edge can be layered on later;
+// until then there is no cleartext path off the device.)
+func EnforceSecureBrokerURL(baseURL string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(baseURL)
+	if trimmed == "" {
+		return nil, fmt.Errorf("broker URL is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("parse broker URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("broker URL must include scheme and host")
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		return parsed, nil
+	case "http":
+		if hostIsLoopback(parsed.Hostname()) {
+			return parsed, nil
+		}
+		return nil, fmt.Errorf("refusing cleartext broker URL %q: use https (plain http is allowed only to localhost)", trimmed)
+	default:
+		return nil, fmt.Errorf("broker URL scheme must be https, got %q", parsed.Scheme)
+	}
+}
+
+// hostIsLoopback reports whether host is localhost or a loopback IP literal.
+func hostIsLoopback(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func brokerStatusError(resp *http.Response) error {

--- a/internal/client/secureurl_test.go
+++ b/internal/client/secureurl_test.go
@@ -1,0 +1,43 @@
+package client
+
+import "testing"
+
+func TestEnforceSecureBrokerURL(t *testing.T) {
+	allowed := []string{
+		"https://broker.openrung.org/",
+		"https://1.2.3.4:8443",
+		"http://localhost:8080",
+		"http://127.0.0.1:8080/",
+		"http://[::1]:8080",
+	}
+	for _, u := range allowed {
+		if _, err := EnforceSecureBrokerURL(u); err != nil {
+			t.Errorf("EnforceSecureBrokerURL(%q) rejected a safe URL: %v", u, err)
+		}
+	}
+
+	rejected := []string{
+		"http://broker.openrung.org/", // cleartext to a real host
+		"http://54.238.185.205:8080/", // cleartext bare IP (the removed fallback)
+		"http://192.168.1.1/",         // cleartext to a LAN host
+		"ftp://broker.openrung.org/",  // wrong scheme
+		"broker.openrung.org",         // no scheme
+		"",                            // empty
+	}
+	for _, u := range rejected {
+		if _, err := EnforceSecureBrokerURL(u); err == nil {
+			t.Errorf("EnforceSecureBrokerURL(%q) accepted a cleartext/invalid URL", u)
+		}
+	}
+}
+
+// TestRelayListURLRejectsCleartext confirms the enforcement flows through the
+// public builder that both the CLI and desktop discovery actually call.
+func TestRelayListURLRejectsCleartext(t *testing.T) {
+	if _, err := RelayListURL("http://54.238.185.205:8080/", 5); err == nil {
+		t.Fatal("RelayListURL accepted a cleartext bare-IP broker URL")
+	}
+	if _, err := RelayListURL("http://localhost:8080", 5); err != nil {
+		t.Fatalf("RelayListURL rejected a loopback dev URL: %v", err)
+	}
+}

--- a/internal/clienttelemetry/client.go
+++ b/internal/clienttelemetry/client.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
+
+	"openrung/internal/client"
 )
 
 // HTTPClient posts telemetry batches to the broker. It is the CLI analog of the
@@ -63,18 +64,13 @@ func (c HTTPClient) Send(ctx context.Context, events []Event) error {
 }
 
 // TelemetryURL builds the telemetry endpoint URL from a broker base URL,
-// mirroring RelayListURL in internal/client/broker.go.
+// mirroring RelayListURL in internal/client/broker.go. Like the relay-list path
+// it refuses cleartext endpoints so pre-tunnel telemetry (which carries the
+// persistent client identity) never leaves the device in the clear.
 func TelemetryURL(baseURL string) (string, error) {
-	if strings.TrimSpace(baseURL) == "" {
-		return "", fmt.Errorf("broker URL is required")
-	}
-
-	parsed, err := url.Parse(baseURL)
+	parsed, err := client.EnforceSecureBrokerURL(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("parse broker URL: %w", err)
-	}
-	if parsed.Scheme == "" || parsed.Host == "" {
-		return "", fmt.Errorf("broker URL must include scheme and host")
+		return "", err
 	}
 
 	basePath := strings.Trim(parsed.Path, "/")

--- a/internal/clienttelemetry/secureurl_test.go
+++ b/internal/clienttelemetry/secureurl_test.go
@@ -1,0 +1,20 @@
+package clienttelemetry
+
+import "testing"
+
+// TestTelemetryURLRejectsCleartext confirms pre-tunnel telemetry (which carries
+// the persistent client identity) cannot be sent to a cleartext endpoint.
+func TestTelemetryURLRejectsCleartext(t *testing.T) {
+	if _, err := TelemetryURL("http://54.238.185.205:8080/"); err == nil {
+		t.Fatal("TelemetryURL accepted a cleartext bare-IP broker URL")
+	}
+	if _, err := TelemetryURL("http://example.com/"); err == nil {
+		t.Fatal("TelemetryURL accepted cleartext http to a real host")
+	}
+	if _, err := TelemetryURL("http://127.0.0.1:8080"); err != nil {
+		t.Fatalf("TelemetryURL rejected a loopback dev URL: %v", err)
+	}
+	if _, err := TelemetryURL("https://broker.openrung.org/"); err != nil {
+		t.Fatalf("TelemetryURL rejected a valid HTTPS URL: %v", err)
+	}
+}

--- a/internal/punch/protocol.go
+++ b/internal/punch/protocol.go
@@ -132,6 +132,66 @@ func dedupeEndpoints(in []Endpoint) []Endpoint {
 	return out
 }
 
+// maxPunchPeers caps how many candidate endpoints of each kind (host, srflx) a
+// single peer may advertise. A legitimate peer offers a handful — one reflexive
+// per reflector vantage point plus a few LAN addresses — so a longer list is a
+// bid to turn Attempt's probe spray into a reflected flood at third parties.
+const maxPunchPeers = 8
+
+// isGloballyRoutable reports whether ip is an ordinary public unicast address,
+// i.e. NOT loopback, private (RFC1918/ULA), link-local, carrier-grade-NAT shared
+// space (RFC6598 100.64.0.0/10), unspecified, or multicast.
+func isGloballyRoutable(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() || ip.IsLoopback() ||
+		ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+		return false // 100.64.0.0/10 carrier-grade NAT shared space
+	}
+	return true
+}
+
+// SanitizePeers filters and clamps peer-advertised punch candidates so the probe
+// spray in Attempt can never be aimed at an arbitrary third party:
+//
+//   - A "host" (LAN) candidate must NOT be globally routable. A public IP tagged
+//     as a same-subnet address is an attempt to make the volunteer flood a
+//     victim, never a real LAN peer, so it is dropped.
+//   - Multicast/unspecified addresses and invalid ports are always dropped.
+//   - Each kind (host, srflx) is independently capped at maxPunchPeers.
+//
+// Reflexive ("srflx") provenance is enforced upstream by the punch coordinator,
+// which forwards only reflector-observed reflexive endpoints; a public srflx
+// reaching here has therefore already been proven to belong to a real peer.
+func SanitizePeers(in []Endpoint) []Endpoint {
+	out := make([]Endpoint, 0, len(in))
+	var hostN, srflxN int
+	for _, e := range dedupeEndpoints(in) {
+		ip := net.ParseIP(e.IP)
+		if ip == nil || e.Port < 1 || e.Port > 65535 || ip.IsMulticast() || ip.IsUnspecified() {
+			continue
+		}
+		switch e.Kind {
+		case KindHost:
+			if isGloballyRoutable(ip) || hostN >= maxPunchPeers {
+				continue
+			}
+			hostN++
+		case KindSrflx:
+			if srflxN >= maxPunchPeers {
+				continue
+			}
+			srflxN++
+		default:
+			continue // unknown kind: never spray at it
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
 // PunchRequest is the client -> hub HTTP body (POST /api/v1/punch/request).
 type PunchRequest struct {
 	RelayID         string     `json:"relay_id"`

--- a/internal/punch/punch.go
+++ b/internal/punch/punch.go
@@ -78,8 +78,12 @@ func matchProbe(data []byte, magic, sessionID string, token []byte) bool {
 // quic-go uses). Attempt runs entirely in the caller's goroutine and starts no
 // background reader, so there is no race with quic-go's read loop afterwards.
 func Attempt(ctx context.Context, sock *net.UDPConn, peers []Endpoint, sessionID string, token []byte, deadline time.Time) (*net.UDPAddr, error) {
+	// SanitizePeers clamps the candidate count and drops globally-routable "host"
+	// addresses, so a malicious peer cannot make this socket spray probes at an
+	// arbitrary victim (open UDP reflector) or exhaust the sender with a huge
+	// candidate list.
 	peerAddrs := make([]*net.UDPAddr, 0, len(peers))
-	for _, p := range dedupeEndpoints(peers) {
+	for _, p := range SanitizePeers(peers) {
 		if addr, err := p.UDPAddr(); err == nil {
 			peerAddrs = append(peerAddrs, addr)
 		}

--- a/internal/punch/sanitize_test.go
+++ b/internal/punch/sanitize_test.go
@@ -1,0 +1,66 @@
+package punch
+
+import "testing"
+
+// TestSanitizePeersDropsRoutableHostsAndCaps is the regression test for the open
+// UDP reflector: a peer must not be able to make Attempt spray probes at an
+// arbitrary public victim, nor flood the sender with an unbounded candidate list.
+func TestSanitizePeersDropsRoutableHosts(t *testing.T) {
+	in := []Endpoint{
+		{IP: "8.8.8.8", Port: 53, Kind: KindHost},        // public victim tagged as LAN → drop
+		{IP: "192.168.1.5", Port: 1234, Kind: KindHost},  // real RFC1918 LAN → keep
+		{IP: "127.0.0.1", Port: 4000, Kind: KindHost},    // loopback → keep
+		{IP: "100.64.0.9", Port: 5000, Kind: KindHost},   // CGNAT client LAN, not globally routable → keep
+		{IP: "203.0.113.7", Port: 6000, Kind: KindSrflx}, // public reflexive → keep (provenance upstream)
+		{IP: "224.0.0.1", Port: 7000, Kind: KindSrflx},   // multicast → drop
+		{IP: "0.0.0.0", Port: 8000, Kind: KindSrflx},     // unspecified → drop
+		{IP: "10.0.0.1", Port: 0, Kind: KindHost},        // invalid port → drop
+		{IP: "10.0.0.2", Port: 9000, Kind: "bogus"},      // unknown kind → drop
+	}
+	got := SanitizePeers(in)
+	want := map[string]bool{
+		"192.168.1.5:1234": true,
+		"127.0.0.1:4000":   true,
+		"100.64.0.9:5000":  true,
+		"203.0.113.7:6000": true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("SanitizePeers kept %d endpoints, want %d: %+v", len(got), len(want), got)
+	}
+	for _, e := range got {
+		if !want[e.String()] {
+			t.Errorf("unexpectedly kept %s (%s)", e.String(), e.Kind)
+		}
+	}
+}
+
+func TestSanitizePeersCapsEachKind(t *testing.T) {
+	var in []Endpoint
+	for i := 0; i < maxPunchPeers*3; i++ {
+		in = append(in,
+			Endpoint{IP: "10.1.1." + itoa(i), Port: 2000, Kind: KindHost},
+			Endpoint{IP: "203.0.113." + itoa(i), Port: 3000, Kind: KindSrflx},
+		)
+	}
+	got := SanitizePeers(in)
+	var host, srflx int
+	for _, e := range got {
+		switch e.Kind {
+		case KindHost:
+			host++
+		case KindSrflx:
+			srflx++
+		}
+	}
+	if host != maxPunchPeers || srflx != maxPunchPeers {
+		t.Fatalf("cap not enforced: host=%d srflx=%d, want %d each", host, srflx, maxPunchPeers)
+	}
+}
+
+// itoa avoids importing strconv for the tiny loop above; i stays < 24.
+func itoa(i int) string {
+	if i < 10 {
+		return string(rune('0' + i))
+	}
+	return string(rune('0'+i/10)) + string(rune('0'+i%10))
+}

--- a/internal/tunnel/hardening_test.go
+++ b/internal/tunnel/hardening_test.go
@@ -1,0 +1,94 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+func TestMaxConcurrentConns(t *testing.T) {
+	cases := []struct {
+		maxSessions int
+		want        int
+	}{
+		{1, perTunnelConnFloor},   // 256 < floor → floor
+		{4, 4 * connsPerSession},  // within range
+		{1000, perTunnelConnCeil}, // far above ceil → ceil
+	}
+	for _, c := range cases {
+		tn := &tunnel{registerReq: relay.RegisterRequest{MaxSessions: c.maxSessions}}
+		if got := tn.maxConcurrentConns(); got != c.want {
+			t.Errorf("maxConcurrentConns(MaxSessions=%d) = %d, want %d", c.maxSessions, got, c.want)
+		}
+	}
+}
+
+// TestHubReapsSilentClientConnection is the regression test for the unbounded
+// client-connection DoS: a connection that opens the public port and never sends
+// the handshake must be reaped, not held forever pinning a goroutine + stream.
+func TestHubReapsSilentClientConnection(t *testing.T) {
+	orig := clientHandshakeTimeout
+	clientHandshakeTimeout = 200 * time.Millisecond
+	defer func() { clientHandshakeTimeout = orig }()
+
+	echoHost, echoPort := startEchoServer(t)
+	registrar := &fakeRegistrar{relayID: "relay_reap"}
+	_, controlAddr, _ := startTestHub(t, registrar, "secret")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ackCh := make(chan HelloAckFrame, 1)
+	client := &Client{
+		HubAddr: controlAddr,
+		Hello: HelloFrame{
+			Token: "secret", RealityPublicKey: "pk", ShortID: "sid", ServerName: "www.example.com",
+			ClientID: "cid", Flow: relay.FlowVision, ExitMode: relay.ExitModeDirect,
+			MaxSessions: 4, MaxMbps: 10, VolunteerVersion: "test",
+		},
+		TargetHost:   echoHost,
+		TargetPort:   echoPort,
+		ReconnectMin: 10 * time.Millisecond,
+		Logger:       discardLogger(),
+		OnRegistered: func(a HelloAckFrame) {
+			select {
+			case ackCh <- a:
+			default:
+			}
+		},
+	}
+	go func() { _ = client.Run(ctx) }()
+
+	var ack HelloAckFrame
+	select {
+	case ack = <-ackCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for tunnel")
+	}
+
+	// Open the public port and stay silent. The hub must close us after the
+	// handshake window; a clean EOF (not our own read-deadline firing)
+	// distinguishes "hub reaped us" from "reaping is broken".
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(ack.PublicPort)), time.Second)
+	if err != nil {
+		t.Fatalf("dial public port: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	start := time.Now()
+	if _, err := conn.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF from hub reaping the silent connection, got %v after %s", err, time.Since(start))
+	}
+
+	// A connection that DOES send the handshake is still spliced and echoes fine
+	// even with the short handshake window.
+	if err := dialEchoThroughTunnel(ack.PublicPort); err != nil {
+		t.Fatalf("active connection should still echo: %v", err)
+	}
+}

--- a/internal/tunnel/punch.go
+++ b/internal/tunnel/punch.go
@@ -190,14 +190,19 @@ func (c *PunchCoordinator) handleRequest(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Classify the client from the hub's OWN reflector observations (keyed by the
-	// client nonce), never trusting the client's self-declared class. Fall back to
-	// the client-reported candidates only if the reflector saw nothing.
-	clientReflexive := req.ClientReflexive
+	// client nonce), never trusting the client's self-declared class or reflexive
+	// address. A client-declared reflexive could name any victim IP, which the
+	// volunteer would then spray with punch probes — an open UDP reflector. So we
+	// forward ONLY reflector-observed reflexive endpoints; when the reflector saw
+	// nothing for this nonce we send none (the client falls back to the hub
+	// relay). Host candidates are clamped and filtered to non-routable addresses
+	// (see SanitizePeers) so they can only reach the volunteer's own LAN.
+	var clientReflexive []punch.Endpoint
 	clientClass := punch.ClassUnknown
 	if key, err := punch.NonceKey(req.ClientNonce); err == nil {
 		if class, reflexive, ok := c.Reflector.Classify(key); ok {
 			clientClass = class
-			clientReflexive = reflexive
+			clientReflexive = punch.SanitizePeers(reflexive)
 		}
 	}
 
@@ -213,7 +218,7 @@ func (c *PunchCoordinator) handleRequest(w http.ResponseWriter, r *http.Request)
 		SessionID:       sessionID,
 		RelayID:         req.RelayID,
 		ClientReflexive: clientReflexive,
-		ClientLocal:     req.ClientLocal,
+		ClientLocal:     punch.SanitizePeers(req.ClientLocal),
 		ClientClass:     clientClass,
 		PunchToken:      tokenHex,
 		ReflectorAddrs:  c.Hub.ReflectorAddrs,

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -316,15 +316,29 @@ func (t *tunnel) run(parent context.Context) {
 		_ = t.session.Close()
 	}()
 
-	t.logger.Info("tunnel ready")
+	// Bound concurrent public-port connections: each costs a goroutine, a yamux
+	// stream, and a volunteer-side dial, so an unbounded accept loop lets anyone
+	// exhaust hub/volunteer file descriptors and the yamux stream window just by
+	// opening TCP connections. Excess connections are dropped, not queued.
+	sem := make(chan struct{}, t.maxConcurrentConns())
+	t.logger.Info("tunnel ready", "max_conns", cap(sem))
 	for {
 		clientConn, err := t.publicListener.Accept()
 		if err != nil {
 			break
 		}
+		select {
+		case sem <- struct{}{}:
+		default:
+			// At the per-tunnel cap: shed the excess connection rather than pin
+			// another goroutine + stream. Genuine load stays well under the cap.
+			_ = clientConn.Close()
+			continue
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() { <-sem }()
 			t.handleClient(clientConn)
 		}()
 	}
@@ -353,7 +367,50 @@ func (t *tunnel) handleClient(clientConn net.Conn) {
 			return
 		}
 	}
+	// A real client (VLESS speaks first) sends its handshake immediately. Reap a
+	// connection that opens the public port and then goes silent — otherwise idle
+	// connections pin goroutines and yamux streams up to the per-tunnel cap. The
+	// deadline covers only the first read; once the client speaks we clear it and
+	// splice unbounded (yamux keepalive detects dead peers), so an established
+	// tunnel of any lifetime is unaffected.
+	_ = clientConn.SetReadDeadline(time.Now().Add(clientHandshakeTimeout))
+	first := make([]byte, 4096)
+	n, err := clientConn.Read(first)
+	if err != nil {
+		return
+	}
+	_ = clientConn.SetReadDeadline(time.Time{})
+	if _, err := stream.Write(first[:n]); err != nil {
+		return
+	}
 	pipe(clientConn, stream)
+}
+
+// clientHandshakeTimeout bounds how long a freshly accepted public connection
+// may stay silent before the hub reaps it (see handleClient). A var so tests can
+// shorten it; not meant to be reconfigured at runtime.
+var clientHandshakeTimeout = 30 * time.Second
+
+// Per-tunnel bound on concurrent public-port connections. The cap scales with
+// the volunteer's advertised session capacity (one session fans out into many
+// short-lived connections) but is clamped so it can be neither unbounded nor
+// trivially small. Overflow from a hostile MaxSessions falls through to the
+// floor, never a panic.
+const (
+	connsPerSession    = 256
+	perTunnelConnFloor = 512
+	perTunnelConnCeil  = 8192
+)
+
+func (t *tunnel) maxConcurrentConns() int {
+	n := t.registerReq.MaxSessions * connsPerSession
+	if n < perTunnelConnFloor {
+		return perTunnelConnFloor
+	}
+	if n > perTunnelConnCeil {
+		return perTunnelConnCeil
+	}
+	return n
 }
 
 func (t *tunnel) heartbeatLoop(ctx context.Context) {


### PR DESCRIPTION
Fixes four urgent issues from the security review. Each fix ships with regression tests; the full suite passes on both the root and `desktop` modules, `go vet` clean, data-plane packages race-clean.

## What & why

### 1. Open UDP reflector / DDoS amplifier (punch coordinator) — `internal/punch`, `internal/tunnel/punch.go`
The coordinator forwarded client-declared candidate endpoints verbatim to the volunteer, which then sprayed UDP probes at every candidate with **no count cap and no address filter**. An unauthenticated attacker (relay IDs are public in the directory) could aim a volunteer's probe spray at any victim IP — tens of thousands of packets per request.
- New `SanitizePeers`: caps candidates at 8/kind and drops globally-routable `host` candidates (keeps loopback/private/CGNAT, which can't reach an internet victim). Applied in `Attempt`, the actual spray primitive.
- Coordinator now forwards **only reflector-observed reflexive** endpoints, never client-declared — so a victim IP can't be injected as a "reflexive" target.

### 2. Unbounded per-tunnel client connections — `internal/tunnel/server.go`
The hub accept loop spawned a goroutine + yamux stream + volunteer dial per inbound connection, with no cap and no deadline; anyone opening silent TCP connections could exhaust FDs/goroutines/stream window.
- Per-tunnel concurrency cap (scaled from `MaxSessions`, clamped `512..8192`); excess connections are dropped, not queued.
- 30s handshake deadline reaps connections that open the public port and stay silent. Wire-identical to before for real traffic (VLESS speaks first); established tunnels are unaffected.

### 3. Registration fail-open + timing side-channel + no throttle — `internal/broker`, `cmd/broker`, `cmd/relayhub`
- Broker token check was non-constant-time `==` → now `subtle.ConstantTimeCompare`.
- `register` + `heartbeat` are now rate-limited per IP (generous limits sized for a hub fronting a full port range from one origin IP).
- Broker and relayhub **fail closed**: refuse to start without a token unless `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION` / `OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS` is set. Matches the architecture doc's "require authentication for volunteers outside local development." Deploy docs/`.env.example`s updated.

### 4. Cleartext client↔broker traffic — `internal/client`, `internal/clienttelemetry`, `cmd/client`, `desktop/config`
Discovery and pre-tunnel telemetry could fall back to a hardcoded plaintext bare-IP endpoint, exposing the relay list **and the persistent client identity** to exactly the on-path censor this tool exists to defeat.
- Dropped the bare-IP fallback; defaults are HTTPS-only.
- New `EnforceSecureBrokerURL`, routed through every broker-URL builder (relay list, telemetry, health probe): `https` to any host; `http` only to loopback for local dev; plaintext to a real host is refused before any packet is sent.

## Reviewer notes / deployment
- **⚠️ Fix #3 is the one deploy-affecting change.** A broker/hub currently running **without** a token set will refuse to start after this. If your production broker has `OPENRUNG_VOLUNTEER_TOKEN` set, deploy is safe; if not, either set a matching token on broker + volunteers together, or set the `ALLOW_ANONYMOUS_*` opt-in to preserve current open behavior. Only bites on restart — a running broker keeps running.
- Fixes #1/#2 are backward-compatible (hub-side only, same wire bytes) and #1 mostly hardens a not-yet-deployed path (punch is dormant).
- The loopback exception in #4 keeps `http://localhost` dev workflows and the CLI default working.

## Explicitly out of scope (separate follow-ups)
- Volunteer/hub → broker registration still defaults to plaintext `http://` (would need the origin on HTTPS first — same rollout hazard as #3).
- The punch-endpoint fallback (`http://<relay>:9444`) is still cleartext and pairs with the desktop `InsecureSkipVerify` finding; needs scheme + fingerprint-pinning together.
- In-memory relay store still doesn't dedupe on `host:port` (Postgres path does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)