### PR TITLE
Default deploy/dev config to anonymous broker + hub (no token)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	go test ./...
 
 broker:
-	go run ./cmd/broker -addr :8080
+	OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true go run ./cmd/broker -addr :8080
 
 volunteer:
 	go run ./cmd/volunteer \
@@ -24,7 +24,7 @@ volunteer:
 		-skip-xray-run
 
 relayhub:
-	go run ./cmd/relayhub \
+	OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true go run ./cmd/relayhub \
 		-broker http://localhost:8080 \
 		-public-host 127.0.0.1 \
 		-port-range 20000-20010 \

--- a/README.md
+++ b/README.md
@@ -78,14 +78,21 @@ You need Go 1.25+, and volunteers also need an
 
 ### Start the broker
 
+The broker fails closed: it refuses to start unless you either set a shared
+registration token (`OPENRUNG_VOLUNTEER_TOKEN`, matched by hubs/volunteers) or
+explicitly opt into an open, unauthenticated broker. Running open lets anyone
+register a relay into the directory, so only do it on a trusted/private network:
+
 ```sh
-go run ./cmd/broker -addr :8080
+OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true \
+  go run ./cmd/broker -addr :8080
 ```
 
 For safer restarts or multiple brokers behind a load balancer, run the broker
-with shared PostgreSQL relay state:
+with shared PostgreSQL relay state (keep the token / anonymous flag):
 
 ```sh
+OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true \
 OPENRUNG_RELAY_STORE=postgres \
 OPENRUNG_RELAY_DATABASE_URL='postgres://openrung:change-me@localhost:5432/openrung?sslmode=disable' \
   go run ./cmd/broker -addr :8080
@@ -98,6 +105,7 @@ To enable the protected telemetry dashboard, set a separate administrator token
 before starting the broker, then open `/admin/telemetry`:
 
 ```sh
+OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true \
 OPENRUNG_DASHBOARD_TOKEN='replace-with-a-long-random-token' \
   go run ./cmd/broker -addr :8080
 ```

--- a/deploy/relayhub/.env.example
+++ b/deploy/relayhub/.env.example
@@ -23,12 +23,16 @@ OPENRUNG_BROKER_URL=https://broker.example.com
 #OPENRUNG_HUB_PUBLIC_BIND_HOST=
 
 # ---------------------------------------------------------------------------
-# Auth (required outside local development)
+# Auth
 # ---------------------------------------------------------------------------
 # Shared bearer token: volunteers must present it to open a tunnel, and the hub
 # uses it for its broker registration calls. Must match the broker's token.
-# The hub refuses to start without it; to run an open hub intentionally (local
-# dev only) set OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true instead.
+#
+# The hub refuses to start without a token, so this template opts into an open,
+# unauthenticated hub (no token configured). To require auth instead, set
+# OPENRUNG_VOLUNTEER_TOKEN below — a token supersedes the anonymous flag, which
+# then becomes a no-op — and remove or comment out the anonymous line.
+OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true
 #OPENRUNG_VOLUNTEER_TOKEN=
 
 # ---------------------------------------------------------------------------

--- a/deploy/relayhub/ec2-up.sh
+++ b/deploy/relayhub/ec2-up.sh
@@ -157,6 +157,7 @@ OPENRUNG_HUB_TLS_KEY=/etc/openrung/certs/hub.key
 OPENRUNG_HUB_REFLECTOR_ADDRS=$PRIMARY:__REFLECTOR_PORT__,$SECONDARY:__REFLECTOR_PORT__
 OPENRUNG_HUB_REFLECTOR_ADVERTISE=__EIP1__:__REFLECTOR_PORT__,__EIP2__:__REFLECTOR_PORT__
 __TOKEN_ENV__
+__ANON_ENV__
 ENV
 
 docker pull __IMAGE__
@@ -168,8 +169,16 @@ docker run -d --name openrung-relayhub --restart unless-stopped \
   __IMAGE__
 TMPL
 
+# Without a token the hub fails closed, so when none is provided we explicitly
+# opt into anonymous volunteers (open, unauthenticated hub) instead — set
+# OPENRUNG_VOLUNTEER_TOKEN to require auth.
 TOKEN_ENV=""
-if [ -n "$TOKEN" ]; then TOKEN_ENV="OPENRUNG_VOLUNTEER_TOKEN=${TOKEN}"; fi
+ANON_ENV=""
+if [ -n "$TOKEN" ]; then
+  TOKEN_ENV="OPENRUNG_VOLUNTEER_TOKEN=${TOKEN}"
+else
+  ANON_ENV="OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true"
+fi
 sed -i \
   -e "s#__IMAGE__#${IMAGE}#g" \
   -e "s#__BROKER_URL__#${BROKER_URL}#g" \
@@ -177,6 +186,7 @@ sed -i \
   -e "s/__CONTROL_PORT__/${CONTROL_PORT}/g" -e "s/__HTTP_PORT__/${HTTP_PORT}/g" \
   -e "s/__PORT_RANGE__/${PORT_RANGE}/g" -e "s/__REFLECTOR_PORT__/${REFLECTOR_PORT}/g" \
   -e "s#__TOKEN_ENV__#${TOKEN_ENV}#g" \
+  -e "s#__ANON_ENV__#${ANON_ENV}#g" \
   "$UD"
 
 # --- launch (primary private IP + one secondary; auto public IP for boot egress) ---

--- a/deploy/relayhub/lightsail-up.sh
+++ b/deploy/relayhub/lightsail-up.sh
@@ -54,9 +54,16 @@ aws lightsail allocate-static-ip --static-ip-name "$IPNAME" --region "$REGION" >
 STATIC_IP="$(aws lightsail get-static-ip --static-ip-name "$IPNAME" --region "$REGION" --query 'staticIp.ipAddress' --output text)"
 
 # Optional bearer token (must match the broker). Included in the env file only
-# when set so a blank line is harmless.
+# when set so a blank line is harmless. Without a token the hub fails closed, so
+# when none is provided we explicitly opt into anonymous volunteers (open,
+# unauthenticated hub) instead — set OPENRUNG_VOLUNTEER_TOKEN to require auth.
 TOKEN_ENV=""
-if [ -n "$TOKEN" ]; then TOKEN_ENV="OPENRUNG_VOLUNTEER_TOKEN=${TOKEN}"; fi
+ANON_ENV=""
+if [ -n "$TOKEN" ]; then
+  TOKEN_ENV="OPENRUNG_VOLUNTEER_TOKEN=${TOKEN}"
+else
+  ANON_ENV="OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true"
+fi
 
 # HTTP API (reachability prober) env line, only when a port is configured.
 HTTP_ENV=""
@@ -97,6 +104,7 @@ OPENRUNG_HUB_TLS_CERT=/etc/openrung/certs/hub.crt
 OPENRUNG_HUB_TLS_KEY=/etc/openrung/certs/hub.key
 ${HTTP_ENV}
 ${TOKEN_ENV}
+${ANON_ENV}
 ENVEOF
 
 docker pull ${IMAGE}


### PR DESCRIPTION
Follow-up to #9. The fail-closed startup guard added there makes the broker and hub refuse to start without `OPENRUNG_VOLUNTEER_TOKEN`. This deployment runs **without a token**, so this PR explicitly opts into the open behavior everywhere the binaries are launched — keeping a token-less deploy running exactly as it did before the fail-closed change.

## Changes
- **Broker** — README "Start the broker" examples and the `make broker` target set `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`.
- **Hub** — the relayhub `lightsail-up.sh` / `ec2-up.sh` provisioning scripts write `OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true` into the env file **when no token is provided** (a token, when set, still takes precedence and enforces auth); the compose `.env.example` enables it; and `make relayhub` sets it.

## Behavior
- No token → hub/broker start open (current deployment).
- Set `OPENRUNG_VOLUNTEER_TOKEN` later → it supersedes the anonymous flag (which becomes a no-op) and auth is enforced, no other changes needed.

## Verified
Built the binaries and confirmed end-to-end:
- Without the flag: broker and hub both **fail closed** with the expected error naming the exact env var.
- With the flag: both pass the token gate (proven by each then failing on a deliberately-bad arg — bad `-relay-store` / unbindable control port — rather than the token error).
- Shell scripts pass `bash -n`; env-var names match the code exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)