### PR TITLE
Containerize the broker (deploy/broker: Dockerfile + compose)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: test fmt broker volunteer relayhub client docker-build docker-keygen docker-run relayhub-docker-build
+.PHONY: test fmt broker volunteer relayhub client docker-build docker-keygen docker-run relayhub-docker-build broker-docker-build
 
 VOLUNTEER_IMAGE ?= openrung-volunteer:latest
 RELAYHUB_IMAGE ?= openrung-relayhub:latest
+BROKER_IMAGE ?= openrung-broker:latest
 
 fmt:
 	gofmt -w cmd internal
@@ -40,6 +41,10 @@ docker-build:
 # Build the relay hub image (run from the repo root).
 relayhub-docker-build:
 	docker build -f deploy/relayhub/Dockerfile -t $(RELAYHUB_IMAGE) .
+
+# Build the broker (control plane) image (run from the repo root).
+broker-docker-build:
+	docker build -f deploy/broker/Dockerfile -t $(BROKER_IMAGE) .
 
 # Print a fresh Reality key pair for a stable relay identity.
 docker-keygen:

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -23,9 +23,9 @@ func main() {
 }
 
 func run() error {
-	addr := flag.String("addr", ":8080", "HTTP listen address")
+	addr := flag.String("addr", envDefault("OPENRUNG_ADDR", ":8080"), "HTTP listen address")
 	leaseTTL := flag.Duration("lease-ttl", 3*time.Minute, "volunteer relay lease TTL")
-	telemetryFile := flag.String("telemetry-file", "openrung-telemetry.jsonl", "append-only client telemetry JSONL file")
+	telemetryFile := flag.String("telemetry-file", envDefault("OPENRUNG_TELEMETRY_FILE", "openrung-telemetry.jsonl"), "append-only client telemetry JSONL file (its directory must be writable)")
 	statusInterval := flag.Duration("status-interval", time.Minute, "interval for broker network status logs; 0 disables")
 	relayStore := flag.String("relay-store", envDefault("OPENRUNG_RELAY_STORE", "memory"), "relay state backend: memory or postgres")
 	relayDatabaseURL := flag.String("relay-database-url", os.Getenv("OPENRUNG_RELAY_DATABASE_URL"), "PostgreSQL database URL for relay state")

--- a/deploy/broker/.env.example
+++ b/deploy/broker/.env.example
@@ -1,0 +1,65 @@
+# OpenRung broker configuration. Copy to .env and edit, then:
+#   docker compose up -d --build
+#
+# The broker is configured entirely through OPENRUNG_* environment variables.
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+# Shared bearer token volunteers/hubs must present to register a relay. It gates
+# the relay directory that clients route their VPN traffic through.
+#
+# The broker refuses to start without a token, so this template opts into an
+# open, unauthenticated broker (anyone can register a relay). To require auth
+# instead, set OPENRUNG_VOLUNTEER_TOKEN below — a token supersedes the anonymous
+# flag, which then becomes a no-op — and remove or comment out the anonymous line.
+OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true
+#OPENRUNG_VOLUNTEER_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Telemetry dashboard (optional)
+# ---------------------------------------------------------------------------
+# Set a long random token to enable the protected /admin/telemetry dashboard.
+# When unset, the dashboard and its data API return 404. Serve the broker over
+# HTTPS (e.g. behind Cloudflare) so the admin session cookie is protected.
+#OPENRUNG_DASHBOARD_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Listen address (optional)
+# ---------------------------------------------------------------------------
+# With host networking (the compose default) this binds directly on the host.
+#OPENRUNG_ADDR=:8080
+
+# ---------------------------------------------------------------------------
+# Trusted proxies (optional)
+# ---------------------------------------------------------------------------
+# Cloudflare's published ranges are trusted by default for CF-Connecting-IP /
+# X-Forwarded-For. Add extra CIDRs (e.g. an upstream load balancer) here,
+# comma-separated. Do NOT add broad ranges — a too-wide entry lets clients spoof
+# their source IP past rate limiting.
+#OPENRUNG_TRUSTED_PROXY_CIDRS=
+
+# ---------------------------------------------------------------------------
+# Relay state store (optional; defaults to in-memory)
+# ---------------------------------------------------------------------------
+# memory (default) keeps relay state in the process; postgres shares it across
+# restarts / multiple brokers behind a load balancer.
+#OPENRUNG_RELAY_STORE=postgres
+#OPENRUNG_RELAY_DATABASE_URL=postgres://openrung:change-me@db:5432/openrung?sslmode=disable
+
+# Relay ranking: global (default, live-metric scoring) or legacy (IPv6-first).
+#OPENRUNG_RELAY_RANKING=global
+
+# ---------------------------------------------------------------------------
+# Relay geolocation (optional)
+# ---------------------------------------------------------------------------
+# HTTP endpoint used to resolve a relay's public IP to city/country for the map.
+# Set to "off" to disable outbound geo lookups entirely.
+#OPENRUNG_GEOIP_ENDPOINT=off
+
+# ---------------------------------------------------------------------------
+# Telemetry file (optional)
+# ---------------------------------------------------------------------------
+# The image points this at the persistent named volume; override only if you
+# change the volume mount in docker-compose.yml.
+#OPENRUNG_TELEMETRY_FILE=/var/lib/openrung/telemetry.jsonl

--- a/deploy/broker/Dockerfile
+++ b/deploy/broker/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+#
+# OpenRung broker — the control-plane HTTP API: it matches clients with healthy
+# relays and records operational telemetry. It never carries user traffic and
+# bundles no Xray. Build from the repository ROOT so the Go sources are in the
+# build context:
+#
+#   docker build -f deploy/broker/Dockerfile -t openrung-broker .
+#
+# Multi-arch (amd64 + arm64) via buildx:
+#
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     -f deploy/broker/Dockerfile -t <registry>/openrung-broker .
+
+# --- Stage 1: build the broker binary (cross-compiled, no cgo) ---
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETARCH
+ARG TARGETOS=linux
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w" -o /out/broker ./cmd/broker
+
+# --- Stage 2: minimal runtime ---
+FROM alpine:3.21
+# Image bundles GPL-2.0-only (busybox/apk-tools/baselayout from Alpine),
+# MPL-2.0 (ca-certificates, pgx compiled into the binary), and MIT/BSD
+# components. See /usr/local/share/openrung/THIRD_PARTY_NOTICES.md.
+LABEL org.opencontainers.image.source="https://github.com/openrung/openrung" \
+      org.opencontainers.image.licenses="GPL-3.0-or-later AND MPL-2.0 AND GPL-2.0-only AND MIT AND BSD-3-Clause" \
+      org.opencontainers.image.title="openrung-broker"
+RUN apk add --no-cache ca-certificates tzdata \
+    && addgroup -S openrung \
+    && adduser -S -G openrung openrung \
+    # State dir for the append-only telemetry JSONL. Owned by the runtime user so
+    # a fresh named volume mounted here inherits writable ownership (Docker copies
+    # the image dir's ownership onto an empty named volume). Bind mounts do NOT —
+    # chown the host path to the container user for those.
+    && mkdir -p /var/lib/openrung \
+    && chown openrung:openrung /var/lib/openrung
+COPY --from=build /out/broker /usr/local/bin/broker
+# Third-party attribution + GPL/MPL source offers travel with the distributed image.
+COPY THIRD_PARTY_NOTICES.md /usr/local/share/openrung/THIRD_PARTY_NOTICES.md
+USER openrung
+# The broker is configured entirely through OPENRUNG_* environment variables, so
+# the binary is the entrypoint directly (no shell wrapper). It receives SIGTERM
+# as PID 1 for a clean shutdown (it drains in-flight requests and flushes
+# telemetry).
+ENV OPENRUNG_TELEMETRY_FILE=/var/lib/openrung/telemetry.jsonl
+ENTRYPOINT ["/usr/local/bin/broker"]

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -1,0 +1,110 @@
+# OpenRung Broker
+
+The broker is the **control plane**: it matches clients with healthy relays and
+records operational telemetry. It never carries user traffic and never holds any
+Reality key — it only serves the relay directory (`GET /api/v1/relays`), accepts
+volunteer registrations/heartbeats, ingests client telemetry, and (optionally)
+serves a protected telemetry dashboard.
+
+Because its traffic is tiny (control-plane only), the broker can run anywhere —
+unlike relay hubs, egress cost is not a concern. In production it is typically
+fronted by Cloudflare with a direct-IP origin fallback on `:8080`.
+
+## Quick start
+
+```sh
+cp .env.example .env          # edit: token/anonymous, dashboard, store
+docker compose up -d --build
+docker compose logs -f
+```
+
+The broker listens on `:8080` (host networking). Point hubs and volunteers at it
+with `OPENRUNG_BROKER_URL`, and check it:
+
+```sh
+curl http://localhost:8080/healthz
+curl http://localhost:8080/api/v1/relays
+```
+
+## ⚠️ Auth: the broker fails closed
+
+The broker **refuses to start without a registration token** so that not just
+anyone can register a relay into the directory clients route their VPN traffic
+through. You must either:
+
+- set `OPENRUNG_VOLUNTEER_TOKEN` to a long random string (shared with your hubs
+  and volunteers), **or**
+- explicitly opt into an open, unauthenticated broker with
+  `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true` (the `.env.example` default).
+
+A token, when set, takes precedence and enforces auth; the anonymous flag then
+becomes a no-op. Generate a token with `openssl rand -hex 32`. Send it only over
+TLS — see Cloudflare below.
+
+## Telemetry persistence
+
+The broker appends client telemetry to a JSONL file and periodically compacts it
+in place (7-day retention). The image points `OPENRUNG_TELEMETRY_FILE` at
+`/var/lib/openrung/telemetry.jsonl` on a persistent named volume, so dashboard
+history survives restarts. The root filesystem is otherwise read-only.
+
+- **Named volume (default):** works out of the box — Docker gives the fresh
+  volume the image dir's `openrung` ownership.
+- **Bind mount instead?** `chown` the host directory to the container's
+  `openrung` uid first, or the broker will fail to open the telemetry file.
+- **Don't need history?** Point `OPENRUNG_TELEMETRY_FILE` at `/tmp/…` (tmpfs) and
+  drop the volume.
+
+## Telemetry dashboard
+
+Set `OPENRUNG_DASHBOARD_TOKEN` to a long random string to enable the protected
+dashboard at `/admin/telemetry`. When unset, the dashboard and its data API
+return 404. Always serve it over HTTPS so the admin session cookie is protected.
+
+## Shared PostgreSQL state (optional)
+
+For safer restarts or multiple brokers behind a load balancer, use Postgres
+instead of the default in-memory store:
+
+```sh
+OPENRUNG_RELAY_STORE=postgres
+OPENRUNG_RELAY_DATABASE_URL=postgres://openrung:change-me@db:5432/openrung?sslmode=disable
+```
+
+## Fronting with Cloudflare
+
+Put the broker behind Cloudflare (or another proxy) for TLS and DDoS absorption.
+The broker trusts Cloudflare's published ranges for `CF-Connecting-IP` /
+`X-Forwarded-For` automatically; add any additional proxy CIDRs with
+`OPENRUNG_TRUSTED_PROXY_CIDRS`. The container uses **host networking** so the
+broker sees the real Cloudflare edge IP as the peer — do not switch it to bridge
+networking without reading the note in `docker-compose.yml`, or per-IP rate
+limiting and telemetry source IPs will all collapse onto the docker gateway.
+
+Firewall the raw origin `:8080` to Cloudflare's ranges so clients cannot bypass
+the edge and spoof forwarded headers.
+
+## Configuration
+
+| Variable                             | Required | Default                             | Purpose                                                        |
+| ------------------------------------ | -------- | ----------------------------------- | -------------------------------------------------------------- |
+| `OPENRUNG_VOLUNTEER_TOKEN`           | yes\*    | —                                   | Shared registration token (must match hubs/volunteers)         |
+| `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION` | yes\* | —                                   | Set `true` to run open when no token is set (\*one of these)   |
+| `OPENRUNG_DASHBOARD_TOKEN`           | no       | —                                   | Enables the protected `/admin/telemetry` dashboard             |
+| `OPENRUNG_ADDR`                      | no       | `:8080`                             | HTTP listen address                                            |
+| `OPENRUNG_TRUSTED_PROXY_CIDRS`       | no       | Cloudflare ranges                   | Extra trusted proxy CIDRs for forwarded client IPs             |
+| `OPENRUNG_RELAY_STORE`               | no       | `memory`                            | Relay state backend: `memory` or `postgres`                    |
+| `OPENRUNG_RELAY_DATABASE_URL`        | if pg    | —                                   | PostgreSQL URL when `OPENRUNG_RELAY_STORE=postgres`            |
+| `OPENRUNG_RELAY_RANKING`             | no       | `global`                            | Relay ranking mode: `global` or `legacy`                       |
+| `OPENRUNG_GEOIP_ENDPOINT`            | no       | ipwho.is                            | IP-geolocation endpoint for relay city/country; `off` disables |
+| `OPENRUNG_TELEMETRY_FILE`            | no       | `/var/lib/openrung/telemetry.jsonl` | Append-only telemetry JSONL path (its dir must be writable)    |
+
+\* The broker refuses to start unless either `OPENRUNG_VOLUNTEER_TOKEN` or
+`OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true` is set.
+
+## Build the image directly
+
+```sh
+# from the repo root
+docker build -f deploy/broker/Dockerfile -t openrung-broker .
+```

--- a/deploy/broker/docker-compose.yml
+++ b/deploy/broker/docker-compose.yml
@@ -1,0 +1,48 @@
+# OpenRung broker (control plane).
+#
+#   cp .env.example .env      # then edit .env (token/anonymous, dashboard, store)
+#   docker compose up -d --build
+#   docker compose logs -f
+#
+services:
+  broker:
+    build:
+      context: ../..
+      dockerfile: deploy/broker/Dockerfile
+    image: openrung-broker:latest
+    container_name: openrung-broker
+    restart: unless-stopped
+    env_file: [.env]
+
+    # Host networking so the broker sees the REAL peer IP. Its client-IP resolver
+    # only honours CF-Connecting-IP / X-Forwarded-For when the direct peer is a
+    # Cloudflare (or OPENRUNG_TRUSTED_PROXY_CIDRS) address; behind Docker bridge
+    # NAT every peer becomes the docker gateway, which would collapse per-IP rate
+    # limiting and telemetry source IPs onto a single address. The broker binds
+    # OPENRUNG_ADDR (:8080 by default) directly on the host.
+    #
+    # Prefer bridge networking? Uncomment the ports block, DROP network_mode, add
+    # the docker bridge subnet to OPENRUNG_TRUSTED_PROXY_CIDRS, and firewall the
+    # published port to Cloudflare's ranges only (otherwise a direct hit can spoof
+    # the forwarded client IP):
+    #   ports:
+    #     - "8080:8080"
+    network_mode: host
+
+    # Least privilege: the broker needs no capabilities (it binds a port >= 1024
+    # and never changes users or mounts).
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+
+    # Read-only root filesystem. The only writable path the broker needs is the
+    # telemetry state dir (append-only JSONL + in-place compaction temp files),
+    # which is a persistent named volume so dashboard history survives restarts.
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - openrung-broker-state:/var/lib/openrung
+
+volumes:
+  openrung-broker-state:


### PR DESCRIPTION
The broker was the only core component without a container image — production ran it non-containerized, outside the repo. This adds a hardened image matching the existing relayhub/volunteer pattern so the broker is reproducible and captured in-repo.

## What's added
- **`deploy/broker/Dockerfile`** — multi-arch, cgo-free static build on `golang:1.25-alpine`, minimal `alpine:3.21` runtime, non-root `USER`, `ca-certificates`/`tzdata`. Creates `/var/lib/openrung` owned by the runtime user so a fresh **named volume inherits writable ownership** for the telemetry JSONL.
- **`deploy/broker/docker-compose.yml`** — `read_only` rootfs, `cap_drop: ALL`, `no-new-privileges`, `tmpfs /tmp`, persistent named volume for telemetry, and **host networking**.
- **`deploy/broker/.env.example` + `README.md`** — full env surface, the fail-closed token requirement (template defaults to `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`, no token), dashboard, Postgres, Cloudflare fronting, and volume/ownership notes.
- **`cmd/broker/main.go`** — `-addr` and `-telemetry-file` now fall back to `OPENRUNG_ADDR` / `OPENRUNG_TELEMETRY_FILE` (mirroring the existing `envDefault` flags), so the container is configured purely through env like the relayhub image.
- **`Makefile`** — `broker-docker-build` target.

## Why host networking
The broker's client-IP resolver only trusts `CF-Connecting-IP` / `X-Forwarded-For` when the **direct peer** is a Cloudflare (or `OPENRUNG_TRUSTED_PROXY_CIDRS`) address. Behind Docker bridge NAT every peer becomes the docker gateway, which would collapse per-IP rate limiting and telemetry source IPs onto a single address. Host networking preserves the real peer IP. A bridge alternative (with the required trusted-CIDR + firewall caveats) is documented inline in the compose file.

## Verification
Docker daemon wasn't available in my environment, so I couldn't run a live `docker build`/`run` — but the Dockerfile is a near-exact copy of the proven relayhub image, and I verified the runtime contract the container depends on at the binary level:
- With env config, the broker binds `OPENRUNG_ADDR`, runs `MkdirAll` on the telemetry dir (`0750`) + file (`0600`) from `OPENRUNG_TELEMETRY_FILE`, and serves `/healthz` (`{"ok":true}`) + `/api/v1/relays`.
- `docker compose config` parses cleanly; `go build ./...` + `go test ./cmd/broker/... ./internal/broker/...` green; gofmt clean.

**Please do a `docker build -f deploy/broker/Dockerfile .` + `docker compose up` in an environment with a daemon before merging** — that's the one check I couldn't run here.

Independent of #10 (touches different Makefile lines; both auto-merge). Depends only on the already-merged fail-closed change from #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)