### PR TITLE
Add CI workflow to build/push the broker image to GHCR

### DIFF
--- a/.github/workflows/broker-image.yml
+++ b/.github/workflows/broker-image.yml
@@ -1,0 +1,57 @@
+name: broker-image
+
+# Build and publish the broker (control plane) image to GHCR.
+# Multi-arch (amd64 + arm64) so it runs on x86 and Graviton/ARM VPSes.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'cmd/broker/**'
+      - 'internal/broker/**'
+      - 'internal/relay/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'deploy/broker/**'
+      - '.github/workflows/broker-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/openrung-broker
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/broker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
**The broker image is not currently built by CI.** #11 containerized the broker and #12 added a Lightsail provisioner that pulls `ghcr.io/openrung/openrung-broker:main` — but there was no workflow to build or push that image, so the pull would fail. This adds it.

`broker-image.yml` is an exact parallel of the existing `relayhub-image.yml`:
- Multi-arch **amd64 + arm64** build of `deploy/broker/Dockerfile`, pushed to `ghcr.io/<owner>/openrung-broker`.
- Triggers on push to `main` / `v*` tags, scoped to the broker's own paths (`cmd/broker`, `internal/broker`, `internal/relay`, `go.mod/sum`, `deploy/broker`, and the workflow itself) — deliberately **not** `internal/tunnel`/`internal/punch`, which the broker doesn't import.
- Also `workflow_dispatch` for manual runs.
- Same GHCR login, `docker/metadata-action` tagging (`branch`, `tag`, `sha`), and gha build cache as the other image workflows.

## ⚠️ After merge — two things
1. **Merging this triggers the first build** (the push touches `.github/workflows/broker-image.yml`, which matches its own path filter).
2. **The first GHCR publish defaults to PRIVATE.** Flip it once: GitHub → org **Packages** → `openrung-broker` → *Package settings* → *Change visibility* → *Public*. Until then, the Lightsail instance can't pull it anonymously.

Validated: YAML parses; structural diff vs `relayhub-image.yml` shows only the name, comment, image, Dockerfile, and the intended narrower path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)