### PR TITLE
Provision new instances with the standard id_ed25519_openrung key

### DIFF
--- a/deploy/broker/lightsail-up.sh
+++ b/deploy/broker/lightsail-up.sh
@@ -105,8 +105,24 @@ docker run -d --name openrung-broker --restart unless-stopped \\
   ${IMAGE}
 EOF
 
+# SSH access: import the standard key pair (id_ed25519_openrung) into this region
+# and launch the instance with it, so it is reachable with the fleet's standard
+# key. Idempotent. Falls back to the Lightsail default key pair when no local key
+# is found (override the key with OPENRUNG_SSH_PUBKEY / OPENRUNG_SSH_KEY_NAME).
+SSH_KEY_NAME="${OPENRUNG_SSH_KEY_NAME:-openrung}"
+SSH_PUBKEY="${OPENRUNG_SSH_PUBKEY:-}"
+if [ -z "$SSH_PUBKEY" ] && [ -f "$HOME/.ssh/id_ed25519_openrung" ]; then
+  SSH_PUBKEY="$(ssh-keygen -y -f "$HOME/.ssh/id_ed25519_openrung" 2>/dev/null || true)"
+fi
+KEYPAIR_ARG=""
+if [ -n "$SSH_PUBKEY" ]; then
+  aws lightsail import-key-pair --key-pair-name "$SSH_KEY_NAME" --public-key-base64 "$SSH_PUBKEY" --region "$REGION" >/dev/null 2>&1 || true
+  KEYPAIR_ARG="--key-pair-name $SSH_KEY_NAME"
+fi
+
 aws lightsail create-instances \
   --instance-names "$NAME" \
+  $KEYPAIR_ARG \
   --availability-zone "$AZ" \
   --blueprint-id "$BLUEPRINT" \
   --bundle-id "$BUNDLE" \

--- a/deploy/relayhub/ec2-up.sh
+++ b/deploy/relayhub/ec2-up.sh
@@ -35,8 +35,10 @@ CONTROL_PORT="${OPENRUNG_HUB_CONTROL_PORT:-9443}"
 HTTP_PORT="${OPENRUNG_HUB_HTTP_PORT:-9444}"
 PORT_RANGE="${OPENRUNG_HUB_PORT_RANGE:-20000-20100}"
 REFLECTOR_PORT="${OPENRUNG_HUB_REFLECTOR_PORT:-19302}"
-KEY_NAME="${OPENRUNG_KEY_NAME:-openrung-relayhub}"
-KEY_FILE="${OPENRUNG_KEY_FILE:-$HOME/.ssh/${KEY_NAME}.pem}"
+KEY_NAME="${OPENRUNG_KEY_NAME:-openrung}"
+# Local private key used to SSH into the instance and (below) imported as the EC2
+# key pair when it does not exist yet, so hosts share the fleet-standard key.
+KEY_FILE="${OPENRUNG_KEY_FILE:-$HOME/.ssh/id_ed25519_openrung}"
 SG_NAME="${OPENRUNG_SG_NAME:-openrung-relayhub}"
 TOKEN="${OPENRUNG_VOLUNTEER_TOKEN:-}"
 
@@ -75,11 +77,23 @@ fi
 echo "Security group: ${SG_ID}"
 
 # --- key pair (idempotent) ---
+# Prefer importing the fleet-standard public key (derived from $KEY_FILE) so every
+# host is reachable with the same key. Only generate a fresh key pair as a last
+# resort, and never overwrite an existing local private key.
 if ! aws ec2 describe-key-pairs --region "$REGION" --key-names "$KEY_NAME" >/dev/null 2>&1; then
-  mkdir -p "$(dirname "$KEY_FILE")"
-  aws ec2 create-key-pair --region "$REGION" --key-name "$KEY_NAME" --query KeyMaterial --output text > "$KEY_FILE"
-  chmod 600 "$KEY_FILE"
-  echo "Created key pair, private key at ${KEY_FILE}"
+  if [ -f "$KEY_FILE" ] && PUBKEY="$(ssh-keygen -y -f "$KEY_FILE" 2>/dev/null)" && [ -n "$PUBKEY" ]; then
+    aws ec2 import-key-pair --region "$REGION" --key-name "$KEY_NAME" \
+      --public-key-material "$(printf '%s' "$PUBKEY" | base64)" >/dev/null
+    echo "Imported key pair '${KEY_NAME}' from ${KEY_FILE}"
+  elif [ -e "$KEY_FILE" ]; then
+    echo "ERROR: ${KEY_FILE} exists but is not a usable SSH private key; set OPENRUNG_KEY_FILE" >&2
+    exit 1
+  else
+    mkdir -p "$(dirname "$KEY_FILE")"
+    aws ec2 create-key-pair --region "$REGION" --key-name "$KEY_NAME" --query KeyMaterial --output text > "$KEY_FILE"
+    chmod 600 "$KEY_FILE"
+    echo "Created key pair, private key at ${KEY_FILE}"
+  fi
 fi
 
 # --- two Elastic IPs ---

--- a/deploy/relayhub/lightsail-up.sh
+++ b/deploy/relayhub/lightsail-up.sh
@@ -116,8 +116,24 @@ docker run -d --name openrung-relayhub --restart unless-stopped \\
   ${IMAGE}
 EOF
 
+# SSH access: import the standard key pair (id_ed25519_openrung) into this region
+# and launch the instance with it, so it is reachable with the fleet's standard
+# key. Idempotent. Falls back to the Lightsail default key pair when no local key
+# is found (override the key with OPENRUNG_SSH_PUBKEY / OPENRUNG_SSH_KEY_NAME).
+SSH_KEY_NAME="${OPENRUNG_SSH_KEY_NAME:-openrung}"
+SSH_PUBKEY="${OPENRUNG_SSH_PUBKEY:-}"
+if [ -z "$SSH_PUBKEY" ] && [ -f "$HOME/.ssh/id_ed25519_openrung" ]; then
+  SSH_PUBKEY="$(ssh-keygen -y -f "$HOME/.ssh/id_ed25519_openrung" 2>/dev/null || true)"
+fi
+KEYPAIR_ARG=""
+if [ -n "$SSH_PUBKEY" ]; then
+  aws lightsail import-key-pair --key-pair-name "$SSH_KEY_NAME" --public-key-base64 "$SSH_PUBKEY" --region "$REGION" >/dev/null 2>&1 || true
+  KEYPAIR_ARG="--key-pair-name $SSH_KEY_NAME"
+fi
+
 aws lightsail create-instances \
   --instance-names "$NAME" \
+  $KEYPAIR_ARG \
   --availability-zone "$AZ" \
   --blueprint-id "$BLUEPRINT" \
   --bundle-id "$BUNDLE" \

--- a/deploy/volunteer/lightsail-up.sh
+++ b/deploy/volunteer/lightsail-up.sh
@@ -55,8 +55,24 @@ docker run -d --name openrung-volunteer --restart unless-stopped \\
   ${IMAGE}
 EOF
 
+# SSH access: import the standard key pair (id_ed25519_openrung) into this region
+# and launch the instance with it, so it is reachable with the fleet's standard
+# key. Idempotent. Falls back to the Lightsail default key pair when no local key
+# is found (override the key with OPENRUNG_SSH_PUBKEY / OPENRUNG_SSH_KEY_NAME).
+SSH_KEY_NAME="${OPENRUNG_SSH_KEY_NAME:-openrung}"
+SSH_PUBKEY="${OPENRUNG_SSH_PUBKEY:-}"
+if [ -z "$SSH_PUBKEY" ] && [ -f "$HOME/.ssh/id_ed25519_openrung" ]; then
+  SSH_PUBKEY="$(ssh-keygen -y -f "$HOME/.ssh/id_ed25519_openrung" 2>/dev/null || true)"
+fi
+KEYPAIR_ARG=""
+if [ -n "$SSH_PUBKEY" ]; then
+  aws lightsail import-key-pair --key-pair-name "$SSH_KEY_NAME" --public-key-base64 "$SSH_PUBKEY" --region "$REGION" >/dev/null 2>&1 || true
+  KEYPAIR_ARG="--key-pair-name $SSH_KEY_NAME"
+fi
+
 aws lightsail create-instances \
   --instance-names "$NAME" \
+  $KEYPAIR_ARG \
   --availability-zone "$AZ" \
   --blueprint-id "$BLUEPRINT" \
   --bundle-id "$BUNDLE" \


### PR DESCRIPTION
Makes freshly-provisioned instances reachable with the fleet-standard SSH key (`id_ed25519_openrung`) rather than the per-region Lightsail default or a throwaway EC2 key pair.

## Changes
- **Lightsail scripts** (`broker`, `relayhub`, `volunteer` `lightsail-up.sh`): derive the pubkey from `~/.ssh/id_ed25519_openrung`, `import-key-pair` it as `openrung` in the target region (idempotent), and launch with `--key-pair-name openrung`. Configurable via `OPENRUNG_SSH_KEY_NAME` / `OPENRUNG_SSH_PUBKEY`; **graceful fallback** to the Lightsail default key pair if no local key is found (so the scripts still work for others).
- **`relayhub/ec2-up.sh`**: default key pair → `openrung`; **imports** the standard pubkey (from `OPENRUNG_KEY_FILE`, default `~/.ssh/id_ed25519_openrung`) when the EC2 key pair doesn't exist yet, instead of generating a fresh one — and refuses to overwrite an existing local private key.

## Context (infra done out-of-band, not in this PR)
- The `openrung` key pair is imported into all fleet Lightsail regions (ap-northeast-1/-2, ap-southeast-1, ap-east-1) + EC2 (ap-northeast-2).
- All 7 running hosts (broker, 5 volunteers, hub) now authenticate with `id_ed25519_openrung`; the old custom/personal keys were pruned. Per your call, the per-region **Lightsail default keys were kept as break-glass**; the broker and EC2 hub are openrung-only (they had no default).

Note: new Lightsail boxes launched with `--key-pair-name openrung` will **not** get the Lightsail default break-glass key (specifying a key pair replaces it). That's consistent with the EC2 model. Shout if you'd rather new boxes also keep a break-glass key — that'd be a user-data-injection variant instead.

All 4 scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)