### PR TITLE
Point Android download at the permanent GitHub latest-release URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1502,7 +1502,7 @@
           </div>
           <div class="download-card" data-reveal>
             <div class="dl-actions">
-              <a class="button" id="apk-link" href="https://downloads.openrung.org/android/android-0.2.1-release.apk">
+              <a class="button" id="apk-link" href="https://github.com/openrung/openrung-mobile-app/releases/latest/download/openrung-android.apk">
                 <svg aria-hidden="true"><use href="#dl-arrow"/></svg>
                 <span data-i18n="downloadAndroid">Download for Android (APK)</span>
               </a>
@@ -1684,8 +1684,11 @@
       // Reveal-on-scroll styles only engage when JS actually runs.
       document.documentElement.classList.add("js");
 
-      const APP_VERSION = "0.2.1";
-      const APK_URL = "https://downloads.openrung.org/android/android-" + APP_VERSION + "-release.apk";
+      const APP_VERSION = "0.2.3";
+      // Permanent "latest release" link — GitHub redirects it to the newest published APK, so it
+      // never needs a per-release edit. openrung-android.apk is the stable-named asset attached by
+      // the openrung-mobile-app release workflow.
+      const APK_URL = "https://github.com/openrung/openrung-mobile-app/releases/latest/download/openrung-android.apk";
 
       /* ============================================================
          Translations


### PR DESCRIPTION
## What
Repoints the Android download button (`#apk-link`) from the hardcoded, per-version `downloads.openrung.org/android/android-<APP_VERSION>-release.apk` to the **permanent GitHub latest-release URL**:

```
https://github.com/openrung/openrung-mobile-app/releases/latest/download/openrung-android.apk
```

GitHub redirects that to the newest published release's APK, so **the button tracks new releases automatically** — no site edit per release. `openrung-android.apk` is a stable-named asset the openrung-mobile-app release workflow now attaches to every release (and it's already backfilled onto the current v0.2.3 release, so the link is live today).

Changed both the runtime `APK_URL` (which the JS assigns to `apk-link.href`) and the static `href` fallback so they agree.

## Note on the version *text*
The download link no longer depends on `APP_VERSION`, but the displayed version number still does (`[data-version]` spans). I bumped `APP_VERSION` `0.2.1 → 0.2.3` to match the current release, but that's still a **manual** value. If you want the version text to auto-update too, a follow-up can fetch the latest release tag from the GitHub API client-side (with graceful fallback) — happy to add that separately.

## Verify
Load the page and check the "Download for Android (APK)" button resolves to the GitHub URL and downloads a ~170 MB `openrung-android.apk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)