### PR TITLE
CI: publish desktop binaries to a GitHub Release on v* tags

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -89,3 +89,29 @@ jobs:
             desktop/build/bin/OpenRung-*.zip
             desktop/build/bin/OpenRung-*.tar.gz
           if-no-files-found: error
+
+  # Publish a GitHub Release with all three binaries attached. Runs only for
+  # `v*` tag pushes (not manual dispatch, which stays artifact-only for testing).
+  # Requires all three build jobs to succeed — we don't ship a partial release.
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the tag's GitHub Release + upload assets
+    steps:
+      # Pulls every artifact from this run into artifacts/<artifact-name>/<file>.
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: OpenRung Desktop ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            artifacts/**/OpenRung-*.zip
+            artifacts/**/OpenRung-*.tar.gz


### PR DESCRIPTION
## What

Adds a `release` job to `desktop-release.yml` that publishes the macOS, Linux, and Windows desktop binaries to a GitHub Release whenever a `v*` tag is pushed.

## Why

The workflow already builds all three platforms on native runners (verified green: [run 28845120724](https://github.com/openrung/openrung/actions/runs/28845120724)), but it only uploaded them as **run artifacts** — which expire after 90 days and are only downloadable by users with repo access. There was no permanent, public download link for the desktop app.

## How

- New `release` job `needs: build`, downloads all three artifacts, and publishes them with `softprops/action-gh-release@v2`.
- Mirrors the mobile repo's convention: `generate_release_notes: true`, `fail_on_unmatched_files: true`, `permissions: contents: write`.
- `if: startsWith(github.ref, 'refs/tags/v')` — manual `workflow_dispatch` runs stay artifact-only (for testing); only real tag pushes cut a release.
- `needs: build` (with the existing `fail-fast: false`) means a partial release is never published — all three platforms must build.

## Testing it

After merge, push a version tag to trigger a real release:

```
git tag v0.1.0 && git push origin v0.1.0
```

Manual dispatch runs are unaffected — they still just produce artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)