### PR TITLE
Broker telemetry: fix O(n²) startup load that hung the broker on large files

### DIFF
--- a/internal/broker/telemetry.go
+++ b/internal/broker/telemetry.go
@@ -149,13 +149,18 @@ type JSONLTelemetrySink struct {
 	fileBytes   int64
 	memoryLimit int64
 	fileLimit   int64
-	now         func() time.Time
-	stop        chan struct{}
-	done        chan struct{}
-	closeOnce   sync.Once
-	closeErr    error
-	writeErr    error
-	closed      bool
+	// compactionShifts counts records slid to the front of the slice by
+	// dropOldestOverBudgetLocked. Over-budget loads must keep this O(number of
+	// records) — the per-line trim it replaced made it O(records²) and hung
+	// startup on a large file. Tests assert the linear bound.
+	compactionShifts int64
+	now              func() time.Time
+	stop             chan struct{}
+	done             chan struct{}
+	closeOnce        sync.Once
+	closeErr         error
+	writeErr         error
+	closed           bool
 }
 
 func NewJSONLTelemetrySink(path string) (*JSONLTelemetrySink, error) {
@@ -167,6 +172,13 @@ func newJSONLTelemetrySink(path string, now func() time.Time) (*JSONLTelemetrySi
 }
 
 func newJSONLTelemetrySinkWithIntervals(path string, now func() time.Time, flushInterval, syncInterval time.Duration) (*JSONLTelemetrySink, error) {
+	return newJSONLTelemetrySinkWithLimits(path, now, flushInterval, syncInterval, maxTelemetryMemoryBytes, maxTelemetryFileBytes)
+}
+
+// newJSONLTelemetrySinkWithLimits is the full constructor; the byte budgets are
+// parameters so tests can exercise the load- and write-time trimming paths
+// without materialising a multi-megabyte file.
+func newJSONLTelemetrySinkWithLimits(path string, now func() time.Time, flushInterval, syncInterval time.Duration, memoryLimit, fileLimit int64) (*JSONLTelemetrySink, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("telemetry file path is required")
 	}
@@ -181,7 +193,7 @@ func newJSONLTelemetrySinkWithIntervals(path string, now func() time.Time, flush
 	}
 	sink := &JSONLTelemetrySink{
 		path: path, file: file, now: now, stop: make(chan struct{}), done: make(chan struct{}),
-		memoryLimit: maxTelemetryMemoryBytes, fileLimit: maxTelemetryFileBytes,
+		memoryLimit: memoryLimit, fileLimit: fileLimit,
 	}
 	if err := sink.loadRecent(); err != nil {
 		_ = file.Close()
@@ -222,13 +234,28 @@ func (s *JSONLTelemetrySink) loadRecent() error {
 		size := int64(len(scanner.Bytes()) + 1)
 		s.records = append(s.records, storedTelemetryRecord{record: record, bytes: size})
 		s.memoryBytes += size
-		// Enforce the budget while scanning so loading an oversized file cannot
-		// balloon memory before a post-load trim.
-		s.dropOldestOverBudgetLocked()
+		// Keep memory bounded during the scan, but trim only after overshooting the
+		// budget by 2×, not on every line. dropOldestOverBudgetLocked re-copies the
+		// surviving slice, so calling it per line made loading an oversized file
+		// O(n²) — a 169 MB file hung broker startup for minutes. Amortising the trim
+		// over a 2× overshoot keeps the whole load O(n) (each record is copied O(1)
+		// times) while memory still peaks at ~2× the budget instead of the whole
+		// file. The final trim below restores the steady-state ≤ budget invariant.
+		// Keep memory bounded during the scan, but trim only after overshooting the
+		// budget by 2×, not on every line. dropOldestOverBudgetLocked re-copies the
+		// surviving slice, so calling it per line made loading an oversized file
+		// O(n²) — a 169 MB file hung broker startup for minutes. Amortising the trim
+		// over a 2× overshoot keeps the whole load O(n) (each record is copied O(1)
+		// times) while memory still peaks at ~2× the budget instead of the whole
+		// file. The final trim below restores the steady-state ≤ budget invariant.
+		if s.memoryBytes > 2*s.memoryLimit {
+			s.dropOldestOverBudgetLocked()
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("read telemetry file: %w", err)
 	}
+	s.dropOldestOverBudgetLocked()
 	_, err = s.file.Seek(0, io.SeekEnd)
 	return err
 }
@@ -386,6 +413,7 @@ func (s *JSONLTelemetrySink) dropOldestOverBudgetLocked() {
 	if drop == 0 {
 		return
 	}
+	s.compactionShifts += int64(len(s.records) - drop)
 	s.records = append(s.records[:0], s.records[drop:]...)
 }
 

--- a/internal/broker/telemetry_test.go
+++ b/internal/broker/telemetry_test.go
@@ -397,6 +397,102 @@ func TestJSONLTelemetrySinkEnforcesMemoryBudget(t *testing.T) {
 	}
 }
 
+func TestJSONLTelemetrySinkLoadTrimsToNewestWithinBudget(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
+
+	// A pre-existing file with far more records than the budget can hold, oldest
+	// first (append-only order).
+	const total = 50
+	var buf bytes.Buffer
+	var recordSize int64
+	for index := 0; index < total; index++ {
+		line, err := json.Marshal(telemetryRecordAt(now, fmt.Sprintf("event-%03d", index)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+		recordSize = int64(len(line) + 1)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Budget holds 10 records; loading must keep the 10 newest and honour the
+	// budget invariant despite the mid-scan 2× overshoot.
+	const want = 10
+	sink, err := newJSONLTelemetrySinkWithLimits(path, func() time.Time { return now }, time.Hour, time.Hour, want*recordSize, maxTelemetryFileBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+
+	if sink.memoryBytes > sink.memoryLimit {
+		t.Fatalf("loaded set exceeds budget: %d > %d", sink.memoryBytes, sink.memoryLimit)
+	}
+	records := sink.TelemetryRecords(time.Time{})
+	if len(records) != want {
+		t.Fatalf("expected %d newest records retained, got %d", want, len(records))
+	}
+	for i, record := range records {
+		wantID := fmt.Sprintf("event-%03d", total-want+i)
+		if record.Event.EventID != wantID {
+			t.Fatalf("retained record %d = %q, want %q (oldest should be dropped)", i, record.Event.EventID, wantID)
+		}
+	}
+}
+
+func TestJSONLTelemetrySinkLoadCompactionStaysLinear(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
+
+	// Many more records than the budget retains, so loading must trim repeatedly.
+	const total = 20_000
+	sample, err := json.Marshal(telemetryRecordAt(now, "event-000000"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordSize := int64(len(sample) + 1)
+
+	var buf bytes.Buffer
+	buf.Grow(int(recordSize) * total)
+	for index := 0; index < total; index++ {
+		line, err := json.Marshal(telemetryRecordAt(now, fmt.Sprintf("event-%06d", index)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The old per-line trim shifted the whole retained slice on every over-budget
+	// line, so total shifts were ~O(total²) (here ~1000× this bound) and startup
+	// hung on a large file. The amortised trim moves each record a constant number
+	// of times, keeping shifts O(total). This is a deterministic, hardware-
+	// independent guard against reintroducing the quadratic load.
+	const retain = 2000
+	sink, err := newJSONLTelemetrySinkWithLimits(path, func() time.Time { return now }, time.Hour, time.Hour, retain*recordSize, maxTelemetryFileBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+
+	if sink.memoryBytes > sink.memoryLimit {
+		t.Fatalf("loaded set exceeds budget: %d > %d", sink.memoryBytes, sink.memoryLimit)
+	}
+	records := sink.TelemetryRecords(time.Time{})
+	if len(records) == 0 || records[len(records)-1].Event.EventID != "event-019999" {
+		t.Fatalf("expected newest record retained last, got %d records", len(records))
+	}
+	if sink.compactionShifts > 4*int64(total) {
+		t.Fatalf("load shifted %d records for %d total; expected O(total) — possible O(n²) regression", sink.compactionShifts, total)
+	}
+}
+
 func TestJSONLTelemetrySinkCompactsOversizedFile(t *testing.T) {
 	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
 	path := filepath.Join(t.TempDir(), "telemetry.jsonl")


### PR DESCRIPTION
## What

`JSONLTelemetrySink.loadRecent` enforced the in-memory byte budget by calling `dropOldestOverBudgetLocked` **on every scanned line**, and each trim re-copies the surviving slice (`append(s.records[:0], s.records[drop:]...)`). Once the telemetry JSONL exceeds the 64 MB budget, that's **O(n²)** in the record count.

This fix amortises the trim: allow the retained set to overshoot to **2× the budget** during the scan, trim in one pass when it does, and do a single final trim after the scan to restore the `≤ budget` invariant. Each record is now shifted a constant number of times → **O(n)** load, with peak memory still bounded (~2× budget, not the whole file).

## Why (this caused a production outage)

On 2026-07-08 a routine broker redeploy on `typhoon-broker` forced a restart. Its `telemetry.jsonl` had grown to **169 MB** over ~31 h of uptime, so startup pegged a CPU core for minutes in the O(n²) load — and because the sink is constructed *before* the HTTP listener starts, the broker never began serving. Every restart (old or new image, postgres or memory store) hung identically. The only reason it hadn't surfaced earlier is that the long-lived container never restarted while the file grew.

Immediate mitigation was to trim the on-disk file back under the budget. This PR is the durable fix so restarts stay fast as the file regrows.

## How it stays O(n)

`dropOldestOverBudgetLocked` trims down to the budget. Triggering it only when the set overshoots to 2× means it runs ~`n / (budget-in-records)` times over the whole load, each copying ~one budget's worth of survivors → total copies O(n). Between trims memory rises from budget to 2× budget, so peak memory is bounded by 2× the budget regardless of file size.

## Tests

- **`TestJSONLTelemetrySinkLoadCompactionStaysLinear`** — deterministic, hardware-independent regression guard. A new internal `compactionShifts` counter records how many elements the trim slides; the test asserts it stays `O(total)`. Verified it trips on the old code: the per-line trim shifted **36,000,000** records for 20,000 inputs (~1000× the linear bound); the fix shifts ~18,000.
- **`TestJSONLTelemetrySinkLoadTrimsToNewestWithinBudget`** — correctness: an over-budget file loads to exactly the newest records within budget, oldest dropped, invariant held despite the mid-scan 2× overshoot.
- Adds `newJSONLTelemetrySinkWithLimits` so the budget paths are testable without materialising a multi-MB file.

`gofmt`, `go vet`, and `go test ./internal/broker/` all pass.

## Follow-up worth considering (not in this PR)

Cap on-disk file growth so it can't dwarf the in-memory budget between compactions (e.g. size-based compaction independent of the append path). The 7-day retention alone let the file reach 169 MB well before any record expired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)