### PR TITLE
Broker: move dashboard telemetry reads to SQL under the Postgres store (PR B)

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -59,16 +59,23 @@ func run() error {
 		slog.Error("could not initialize telemetry storage", "error", err)
 		return err
 	}
-	handler := broker.NewServer(store, broker.Config{
+	cfg := broker.Config{
 		RegistrationToken: registrationToken,
 		VolunteerLeaseTTL: *leaseTTL,
 		TelemetrySink:     telemetrySink,
-		TelemetryReader:   telemetrySink,
 		DashboardToken:    os.Getenv("OPENRUNG_DASHBOARD_TOKEN"),
 		// Cloudflare's published ranges are trusted by default; add more (e.g. an upstream LB) here.
 		TrustedProxyCIDRs: splitAndTrim(os.Getenv("OPENRUNG_TRUSTED_PROXY_CIDRS")),
 		GeoIP:             geoResolver,
-	})
+	}
+	// The Postgres store aggregates dashboard queries in SQL; the JSONL sink's
+	// dashboard is aggregated in Go from its in-memory record set.
+	if querier, ok := telemetrySink.(broker.TelemetryQuerier); ok {
+		cfg.TelemetryQuerier = querier
+	} else {
+		cfg.TelemetryReader = telemetrySink
+	}
+	handler := broker.NewServer(store, cfg)
 	maintenanceInterval := *statusInterval
 	if maintenanceInterval <= 0 {
 		maintenanceInterval = time.Minute

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -90,8 +90,9 @@ automatically) instead of the JSONL file. It uses
 `OPENRUNG_TELEMETRY_DATABASE_URL`, falling back to
 `OPENRUNG_RELAY_DATABASE_URL` so a broker already on the Postgres relay store
 needs no extra configuration; the broker refuses to start if neither is set.
-The dashboard still aggregates in memory from the most recent events, so it
-works the same under either backend.
+In postgres mode the admin dashboard aggregates in SQL, bounded by the
+selected time window, so dashboard cost and broker memory stay flat as event
+history grows.
 
 ## Telemetry dashboard
 

--- a/internal/broker/dashboard.go
+++ b/internal/broker/dashboard.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strconv"
@@ -31,17 +32,17 @@ var dashboardHTML []byte
 
 type dashboardServer struct {
 	tokenHash   [32]byte
-	reader      TelemetryReader
+	querier     TelemetryQuerier
 	relayLabels func() map[string]string
 	now         func() time.Time
 	mu          sync.Mutex
 	sessions    map[string]time.Time
 }
 
-func newDashboardServer(token string, reader TelemetryReader) *dashboardServer {
+func newDashboardServer(token string, querier TelemetryQuerier) *dashboardServer {
 	return &dashboardServer{
 		tokenHash: sha256.Sum256([]byte(token)),
-		reader:    reader,
+		querier:   querier,
 		now:       time.Now,
 		sessions:  make(map[string]time.Time),
 	}
@@ -175,7 +176,12 @@ func (d *dashboardServer) overview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := d.now().UTC()
-	ov := buildTelemetryOverview(d.reader.TelemetryRecords(now.Add(-window)), now, window)
+	ov, err := d.querier.TelemetryOverview(now, window)
+	if err != nil {
+		slog.Error("could not build telemetry overview", "error", err)
+		writeError(w, http.StatusInternalServerError, "could not build telemetry overview")
+		return
+	}
 	if len(ov.Recent) > overviewRecentSessions {
 		ov.Recent = ov.Recent[:overviewRecentSessions]
 	}
@@ -213,13 +219,15 @@ func (d *dashboardServer) listSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := d.now().UTC()
-	ov := buildTelemetryOverview(d.reader.TelemetryRecords(now.Add(-window)), now, window)
-	total := len(ov.Recent)
+	page, total, err := d.querier.TelemetrySessions(now, window, offset, limit)
+	if err != nil {
+		slog.Error("could not list telemetry sessions", "error", err)
+		writeError(w, http.StatusInternalServerError, "could not list telemetry sessions")
+		return
+	}
 	if offset > total {
 		offset = total
 	}
-	end := min(offset+limit, total)
-	page := append([]sessionSummary{}, ov.Recent[offset:end]...)
 	if d.relayLabels != nil {
 		applySessionRelayLabels(page, d.relayLabels())
 	}
@@ -346,6 +354,36 @@ type sessionAccumulator struct {
 	attempted          bool
 	succeeded          bool
 	failed             bool
+}
+
+// finalize derives the presentation fields from the accumulated raw ones. It
+// is shared by the in-memory aggregator and the Postgres querier so both
+// backends resolve source-IP/ISP precedence, device labels, status, and
+// activity identically.
+func (a *sessionAccumulator) finalize(now time.Time) sessionSummary {
+	summary := a.summary
+	summary.SourceIP = firstNonEmpty(a.observedClientIP, a.reportedClientIP, a.fallbackSourceIP)
+	summary.ISP = firstNonEmpty(a.isp, summary.Organization, summary.ASN)
+	summary.DeviceInfo = deviceInfoLabel(a.deviceManufacturer, a.deviceModel, summary.OperatingSystem)
+	// connection_ended carries the final duration; until then, surface the
+	// running duration from heartbeats so active sessions aren't blank.
+	if summary.DurationMS == 0 {
+		summary.DurationMS = a.runningDurationMS
+	}
+	switch {
+	case a.failed:
+		summary.Status = "failed"
+	case a.succeeded:
+		summary.Status = "succeeded"
+	case a.attempted:
+		summary.Status = "attempting"
+	}
+	if !a.lastHeartbeatAt.IsZero() {
+		lastHeartbeatAt := a.lastHeartbeatAt
+		summary.LastHeartbeatAt = &lastHeartbeatAt
+	}
+	summary.Active = !a.terminal && a.lastHeartbeatAt.After(now.Add(-activeSessionTimeout))
+	return summary
 }
 
 func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window time.Duration) telemetryOverview {
@@ -507,22 +545,7 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 	activeISPs := make(map[string]int)
 	activeOS := make(map[string]int)
 	for _, session := range sessions {
-		session.summary.SourceIP = firstNonEmpty(session.observedClientIP, session.reportedClientIP, session.fallbackSourceIP)
-		session.summary.ISP = firstNonEmpty(session.isp, session.summary.Organization, session.summary.ASN)
-		session.summary.DeviceInfo = deviceInfoLabel(session.deviceManufacturer, session.deviceModel, session.summary.OperatingSystem)
-		// connection_ended carries the final duration; until then, surface the
-		// running duration from heartbeats so active sessions aren't blank.
-		if session.summary.DurationMS == 0 {
-			session.summary.DurationMS = session.runningDurationMS
-		}
-		switch {
-		case session.failed:
-			session.summary.Status = "failed"
-		case session.succeeded:
-			session.summary.Status = "succeeded"
-		case session.attempted:
-			session.summary.Status = "attempting"
-		}
+		summary := session.finalize(now)
 		if session.attempted {
 			overview.Totals.Attempts++
 		}
@@ -532,24 +555,19 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 		if session.failed {
 			overview.Totals.Failures++
 		}
-		incrementNonEmpty(countryCounts, session.summary.Country)
-		incrementNonEmpty(cityCounts, session.summary.City)
-		incrementNonEmpty(ispCounts, session.summary.ISP)
-		if !session.lastHeartbeatAt.IsZero() {
-			lastHeartbeatAt := session.lastHeartbeatAt
-			session.summary.LastHeartbeatAt = &lastHeartbeatAt
-		}
-		session.summary.Active = !session.terminal && session.lastHeartbeatAt.After(now.Add(-activeSessionTimeout))
-		if session.summary.Active {
+		incrementNonEmpty(countryCounts, summary.Country)
+		incrementNonEmpty(cityCounts, summary.City)
+		incrementNonEmpty(ispCounts, summary.ISP)
+		if summary.Active {
 			overview.Totals.ActiveSessions++
-			activeClients[session.summary.ClientID] = struct{}{}
-			incrementNonEmpty(activeRelays, session.summary.RelayID)
-			incrementNonEmpty(activeCountries, session.summary.Country)
-			incrementNonEmpty(activeCities, session.summary.City)
-			incrementNonEmpty(activeISPs, session.summary.ISP)
-			incrementNonEmpty(activeOS, session.summary.OperatingSystem)
+			activeClients[summary.ClientID] = struct{}{}
+			incrementNonEmpty(activeRelays, summary.RelayID)
+			incrementNonEmpty(activeCountries, summary.Country)
+			incrementNonEmpty(activeCities, summary.City)
+			incrementNonEmpty(activeISPs, summary.ISP)
+			incrementNonEmpty(activeOS, summary.OperatingSystem)
 		}
-		overview.Recent = append(overview.Recent, session.summary)
+		overview.Recent = append(overview.Recent, summary)
 	}
 	overview.Totals.ActiveClients = len(activeClients)
 	if overview.Totals.Attempts > 0 {
@@ -571,9 +589,7 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 	for _, relay := range relays {
 		overview.TopRelays = append(overview.TopRelays, *relay)
 	}
-	sort.Slice(overview.TopRelays, func(i, j int) bool {
-		return overview.TopRelays[i].Successes+overview.TopRelays[i].Failures > overview.TopRelays[j].Successes+overview.TopRelays[j].Failures
-	})
+	sortTopRelays(overview.TopRelays)
 	if len(overview.TopRelays) > 10 {
 		overview.TopRelays = overview.TopRelays[:10]
 	}
@@ -590,8 +606,20 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 	for relayID, speed := range speeds {
 		overview.SpeedTests = append(overview.SpeedTests, speedTestSummary{RelayID: relayID, Tests: speed.tests, AverageMbps: float64(speed.mbps) / float64(speed.tests) / 1000, AverageTTFBMS: float64(speed.ttfb) / float64(speed.tests)})
 	}
-	sort.Slice(overview.SpeedTests, func(i, j int) bool { return overview.SpeedTests[i].AverageMbps > overview.SpeedTests[j].AverageMbps })
+	sortSpeedTests(overview.SpeedTests)
 	return overview
+}
+
+// sortTopRelays and sortSpeedTests are shared by the in-memory aggregator and
+// the Postgres querier so both rank identically.
+func sortTopRelays(relays []relaySummary) {
+	sort.Slice(relays, func(i, j int) bool {
+		return relays[i].Successes+relays[i].Failures > relays[j].Successes+relays[j].Failures
+	})
+}
+
+func sortSpeedTests(speedTests []speedTestSummary) {
+	sort.Slice(speedTests, func(i, j int) bool { return speedTests[i].AverageMbps > speedTests[j].AverageMbps })
 }
 
 func applyRelayLabels(ov *telemetryOverview, labels map[string]string) {

--- a/internal/broker/dashboard_test.go
+++ b/internal/broker/dashboard_test.go
@@ -111,7 +111,7 @@ func TestDashboardLoginOverviewAndLogout(t *testing.T) {
 
 func TestDashboardRejectsExpiredSessionAndInvalidWindow(t *testing.T) {
 	store := &dashboardTelemetryStore{}
-	dashboard := newDashboardServer("secret", store)
+	dashboard := newDashboardServer("secret", newTelemetryReaderQuerier(store))
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	dashboard.now = func() time.Time { return now }
 	dashboard.sessions["expired"] = now.Add(-time.Second)
@@ -326,7 +326,7 @@ func TestDashboardSessionsPagination(t *testing.T) {
 			t.Fatalf("write telemetry: %v", err)
 		}
 	}
-	dashboard := newDashboardServer("secret", store)
+	dashboard := newDashboardServer("secret", newTelemetryReaderQuerier(store))
 	dashboard.now = func() time.Time { return now }
 	dashboard.relayLabels = func() map[string]string { return map[string]string{"relay-1": "proud-falcon"} }
 	dashboard.sessions["valid"] = now.Add(time.Hour)

--- a/internal/broker/postgres_telemetry.go
+++ b/internal/broker/postgres_telemetry.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -29,6 +30,7 @@ const (
 	maxTelemetryPendingBytes = 16 << 20
 
 	postgresTelemetryFlushTimeout = 15 * time.Second
+	postgresTelemetryQueryTimeout = 30 * time.Second
 )
 
 // The envelope every query filters or sorts on lives in real columns; the
@@ -76,15 +78,15 @@ type telemetryEventPayload struct {
 
 // PostgresTelemetrySink persists telemetry events to a partitioned Postgres
 // table. Writes are buffered and inserted in batches (flushed every
-// telemetryFlushInterval, or immediately at a full HTTP batch); the dashboard
-// still reads from the same bounded in-memory retained set the JSONL sink
-// keeps, backfilled from the newest rows at startup.
+// telemetryFlushInterval, or immediately at a full HTTP batch). Reads happen
+// in Postgres too — TelemetryQuerier aggregation for the dashboard and a
+// short-window SELECT for the operational status log — so broker memory never
+// scales with telemetry volume and startup reads no old events.
 type PostgresTelemetrySink struct {
 	pool *pgxpool.Pool
 	now  func() time.Time
 
-	mu sync.RWMutex
-	telemetryRetained
+	mu           sync.RWMutex
 	pending      []storedTelemetryRecord
 	pendingBytes int64
 	pendingLimit int64
@@ -103,14 +105,12 @@ type PostgresTelemetrySink struct {
 }
 
 func NewPostgresTelemetrySink(ctx context.Context, databaseURL string) (*PostgresTelemetrySink, error) {
-	return newPostgresTelemetrySink(ctx, databaseURL, time.Now, telemetryFlushInterval, maxTelemetryMemoryBytes)
+	return newPostgresTelemetrySink(ctx, databaseURL, time.Now, telemetryFlushInterval)
 }
 
-// newPostgresTelemetrySink is the full constructor; the flush interval and
-// memory budget are parameters so tests can exercise flushing and the
-// backfill trim without waiting on production intervals or materialising
-// tens of megabytes.
-func newPostgresTelemetrySink(ctx context.Context, databaseURL string, now func() time.Time, flushInterval time.Duration, memoryLimit int64) (*PostgresTelemetrySink, error) {
+// newPostgresTelemetrySink is the full constructor; the flush interval is a
+// parameter so tests can keep the ticker out of the way and flush explicitly.
+func newPostgresTelemetrySink(ctx context.Context, databaseURL string, now func() time.Time, flushInterval time.Duration) (*PostgresTelemetrySink, error) {
 	if strings.TrimSpace(databaseURL) == "" {
 		return nil, errors.New("telemetry database URL is required")
 	}
@@ -119,13 +119,12 @@ func newPostgresTelemetrySink(ctx context.Context, databaseURL string, now func(
 		return nil, fmt.Errorf("open telemetry database: %w", err)
 	}
 	sink := &PostgresTelemetrySink{
-		pool:              pool,
-		now:               now,
-		telemetryRetained: telemetryRetained{memoryLimit: memoryLimit},
-		pendingLimit:      maxTelemetryPendingBytes,
-		partitions:        make(map[string]struct{}),
-		stop:              make(chan struct{}),
-		done:              make(chan struct{}),
+		pool:         pool,
+		now:          now,
+		pendingLimit: maxTelemetryPendingBytes,
+		partitions:   make(map[string]struct{}),
+		stop:         make(chan struct{}),
+		done:         make(chan struct{}),
 	}
 	if err := pool.Ping(ctx); err != nil {
 		pool.Close()
@@ -145,93 +144,12 @@ func newPostgresTelemetrySink(ctx context.Context, databaseURL string, now func(
 			return nil, err
 		}
 	}
-	if err := sink.loadRecent(ctx); err != nil {
-		pool.Close()
-		return nil, err
-	}
 	go sink.flushLoop(flushInterval)
 	return sink, nil
 }
 
-// loadRecent backfills the in-memory retained set from the newest rows inside
-// the retention window. Reading newest-first and cancelling the query once the
-// memory budget is reached keeps startup O(rows-loaded) no matter how much
-// history the table holds.
-func (s *PostgresTelemetrySink) loadRecent(ctx context.Context) error {
-	loadCtx, cancelLoad := context.WithCancel(ctx)
-	defer cancelLoad()
-
-	cutoff := s.now().UTC().Add(-telemetryRetention)
-	rows, err := s.pool.Query(loadCtx, `
-		SELECT received_at, COALESCE(host(source_ip), ''), event_id, event, occurred_at, client_id, session_id, COALESCE(relay_id, ''), payload
-		FROM telemetry_events
-		WHERE received_at > $1
-		ORDER BY received_at DESC
-	`, cutoff)
-	if err != nil {
-		return fmt.Errorf("load telemetry events: %w", err)
-	}
-	defer rows.Close()
-
-	var loaded []storedTelemetryRecord
-	var loadedBytes int64
-	truncated := false
-	for rows.Next() {
-		var record TelemetryRecord
-		var payload []byte
-		if err := rows.Scan(
-			&record.ReceivedAt,
-			&record.SourceIP,
-			&record.Event.EventID,
-			&record.Event.Event,
-			&record.Event.OccurredAt,
-			&record.Event.ClientID,
-			&record.Event.SessionID,
-			&record.Event.RelayID,
-			&payload,
-		); err != nil {
-			return fmt.Errorf("scan telemetry event: %w", err)
-		}
-		var remainder telemetryEventPayload
-		if err := json.Unmarshal(payload, &remainder); err != nil {
-			return fmt.Errorf("decode telemetry payload: %w", err)
-		}
-		record.Event.SchemaVersion = remainder.SchemaVersion
-		record.Event.Application = remainder.Application
-		record.Event.ApplicationID = remainder.ApplicationID
-		record.Event.DestinationIP = remainder.DestinationIP
-		record.Event.DestinationPort = remainder.DestinationPort
-		record.Event.Protocol = remainder.Protocol
-		record.Event.Attributes = remainder.Attributes
-		record.Event.Measurements = remainder.Measurements
-
-		size := telemetryRecordSize(record)
-		if loadedBytes+size > s.memoryLimit {
-			truncated = true
-			cancelLoad()
-			break
-		}
-		loaded = append(loaded, storedTelemetryRecord{record: record, bytes: size})
-		loadedBytes += size
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil && !(truncated && errors.Is(err, context.Canceled)) {
-		return fmt.Errorf("read telemetry events: %w", err)
-	}
-
-	// Rows arrived newest-first; the retained set is kept oldest-first like
-	// the JSONL sink's, so appends and budget drops stay append/trim-front.
-	for left, right := 0, len(loaded)-1; left < right; left, right = left+1, right-1 {
-		loaded[left], loaded[right] = loaded[right], loaded[left]
-	}
-	s.records = loaded
-	s.memoryBytes = loadedBytes
-	return nil
-}
-
-// telemetryRecordSize is the record's encoded JSON size — the same accounting
-// unit the JSONL sink uses, so the memory budget means the same thing under
-// both backends.
+// telemetryRecordSize is the record's encoded JSON size, used to bound the
+// unflushed write buffer.
 func telemetryRecordSize(record TelemetryRecord) int64 {
 	line, err := json.Marshal(record)
 	if err != nil {
@@ -248,12 +166,9 @@ func (s *PostgresTelemetrySink) WriteTelemetry(ctx context.Context, records []Te
 	}
 	for _, record := range records {
 		size := telemetryRecordSize(record)
-		s.append(record, size)
 		s.pending = append(s.pending, storedTelemetryRecord{record: record, bytes: size})
 		s.pendingBytes += size
 	}
-	s.prune(s.now().UTC().Add(-telemetryRetention))
-	s.dropOldestOverBudget()
 	shouldFlush := len(s.pending) >= postgresTelemetryFlushThreshold
 	s.mu.Unlock()
 
@@ -268,10 +183,80 @@ func (s *PostgresTelemetrySink) WriteTelemetry(ctx context.Context, records []Te
 	return nil
 }
 
+// TelemetryRecords satisfies TelemetryReader for the periodic operational
+// status log, which reads a short (minutes-wide) activity window; result size
+// scales with that window, not with stored history. The dashboard does NOT go
+// through this — it uses the aggregated TelemetryQuerier methods. Reads are
+// best-effort like the JSONL sink's: on query failure it logs and reports no
+// activity rather than failing the caller.
 func (s *PostgresTelemetrySink) TelemetryRecords(since time.Time) []TelemetryRecord {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.recordsSince(since)
+	if err := s.flush(); err != nil {
+		slog.Error("could not flush telemetry before read", "error", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryQueryTimeout)
+	defer cancel()
+
+	// received_at prunes partitions; the extra hour mirrors
+	// maxTelemetryFutureSkew so no event the occurred_at filter keeps is lost.
+	rows, err := s.pool.Query(ctx, `
+		SELECT received_at, COALESCE(host(source_ip), ''), event_id, event, occurred_at, client_id, session_id, COALESCE(relay_id, ''), payload
+		FROM telemetry_events
+		WHERE received_at > $1 AND occurred_at >= $2
+		ORDER BY received_at
+	`, since.Add(-maxTelemetryFutureSkew), since)
+	if err != nil {
+		slog.Error("could not read telemetry records", "error", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var records []TelemetryRecord
+	for rows.Next() {
+		record, err := scanTelemetryRecord(rows)
+		if err != nil {
+			slog.Error("could not scan telemetry record", "error", err)
+			return nil
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("could not read telemetry records", "error", err)
+		return nil
+	}
+	return records
+}
+
+func scanTelemetryRecord(row pgx.Row) (TelemetryRecord, error) {
+	var record TelemetryRecord
+	var payload []byte
+	if err := row.Scan(
+		&record.ReceivedAt,
+		&record.SourceIP,
+		&record.Event.EventID,
+		&record.Event.Event,
+		&record.Event.OccurredAt,
+		&record.Event.ClientID,
+		&record.Event.SessionID,
+		&record.Event.RelayID,
+		&payload,
+	); err != nil {
+		return TelemetryRecord{}, fmt.Errorf("scan telemetry event: %w", err)
+	}
+	var remainder telemetryEventPayload
+	if err := json.Unmarshal(payload, &remainder); err != nil {
+		return TelemetryRecord{}, fmt.Errorf("decode telemetry payload: %w", err)
+	}
+	record.ReceivedAt = record.ReceivedAt.UTC()
+	record.Event.OccurredAt = record.Event.OccurredAt.UTC()
+	record.Event.SchemaVersion = remainder.SchemaVersion
+	record.Event.Application = remainder.Application
+	record.Event.ApplicationID = remainder.ApplicationID
+	record.Event.DestinationIP = remainder.DestinationIP
+	record.Event.DestinationPort = remainder.DestinationPort
+	record.Event.Protocol = remainder.Protocol
+	record.Event.Attributes = remainder.Attributes
+	record.Event.Measurements = remainder.Measurements
+	return record, nil
 }
 
 func (s *PostgresTelemetrySink) flushLoop(flushInterval time.Duration) {

--- a/internal/broker/postgres_telemetry_query.go
+++ b/internal/broker/postgres_telemetry_query.go
@@ -1,0 +1,456 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// The dashboard queries below reproduce buildTelemetryOverview in SQL, bounded
+// by the dashboard window so their cost tracks the window, not stored history.
+// They share two CTEs: `events` extracts the payload fields the aggregator
+// reads, and `sessions` groups them per session with the same semantics as
+// sessionAccumulator. All queries take the same leading parameters:
+//
+//	$1 pruned-after  — received_at lower bound; occurred_at is what the
+//	                   aggregation filters on, but received_at prunes daily
+//	                   partitions. The caller widens it by
+//	                   maxTelemetryFutureSkew so no event the occurred_at
+//	                   filter would keep is lost to pruning.
+//	$2 window start  — occurred_at lower bound (inclusive)
+//	$3 now           — occurred_at upper bound (inclusive)
+//	$4 active-after  — heartbeat threshold (now - activeSessionTimeout);
+//	                   only session-level queries reference it.
+//
+// NULLIF mirrors the accumulator's plain `!= ""` checks; the btrim CASEs
+// mirror firstNonEmpty, which trims for the emptiness test but keeps the
+// original value.
+const telemetryEventsCTE = `
+events AS (
+	SELECT
+		received_at,
+		occurred_at,
+		event,
+		client_id,
+		session_id,
+		COALESCE(relay_id, '') AS relay_id,
+		host(source_ip) AS source_ip,
+		NULLIF(payload->>'application_package', '') AS application,
+		payload->'attributes'->>'failure_stage' AS failure_stage,
+		COALESCE(
+			NULLIF(payload->'attributes'->>'operating_system', ''),
+			'iOS ' || NULLIF(payload->'attributes'->>'ios_version', ''),
+			'Android (API ' || NULLIF(payload->'attributes'->>'android_api', '') || ')'
+		) AS os_label,
+		NULLIF(payload->'attributes'->>'device_manufacturer', '') AS device_manufacturer,
+		NULLIF(payload->'attributes'->>'device_model', '') AS device_model,
+		NULLIF(payload->'attributes'->>'app_version', '') AS app_version,
+		CASE
+			WHEN btrim(COALESCE(payload->'attributes'->>'country', '')) <> '' THEN payload->'attributes'->>'country'
+			WHEN btrim(COALESCE(payload->'attributes'->>'country_code', '')) <> '' THEN payload->'attributes'->>'country_code'
+		END AS country,
+		NULLIF(payload->'attributes'->>'city', '') AS city,
+		NULLIF(payload->'attributes'->>'organization', '') AS organization,
+		NULLIF(payload->'attributes'->>'asn', '') AS asn,
+		NULLIF(payload->'attributes'->>'isp', '') AS isp,
+		NULLIF(payload->'attributes'->>'client_ip', '') AS reported_client_ip,
+		(payload->'measurements'->>'session_duration_ms')::bigint AS session_duration_ms,
+		(payload->'measurements'->>'bytes_sent')::bigint AS bytes_sent,
+		(payload->'measurements'->>'bytes_received')::bigint AS bytes_received,
+		(payload->'measurements'->>'download_mbps_milli')::bigint AS download_mbps_milli,
+		(payload->'measurements'->>'time_to_first_byte_ms')::bigint AS ttfb_ms
+	FROM telemetry_events
+	WHERE received_at > $1 AND occurred_at >= $2 AND occurred_at <= $3
+)`
+
+// The `latest non-empty wins` aggregations order by (received_at, occurred_at)
+// as the canonical event order. The in-memory accumulator iterates records in
+// arrival order; rows from one uploaded batch share a received_at, so
+// occurred_at breaks those ties. bytes_sent/bytes_received are cumulative per
+// session, hence MAX; the GREATEST(..., 0) mirrors the accumulator never
+// letting a negative report beat its zero initial value.
+const telemetrySessionsCTE = `
+sessions AS (
+	SELECT
+		session_id,
+		(array_agg(client_id ORDER BY received_at, occurred_at))[1] AS client_id,
+		MIN(occurred_at) AS started_at,
+		MAX(received_at) AS last_seen_at,
+		COALESCE((array_agg(relay_id ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE relay_id <> ''))[1], '') AS relay_id,
+		COALESCE((array_agg(os_label ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE os_label IS NOT NULL))[1], '') AS operating_system,
+		COALESCE((array_agg(device_manufacturer ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE device_manufacturer IS NOT NULL))[1], '') AS device_manufacturer,
+		COALESCE((array_agg(device_model ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE device_model IS NOT NULL))[1], '') AS device_model,
+		COALESCE((array_agg(app_version ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE app_version IS NOT NULL))[1], '') AS app_version,
+		COALESCE((array_agg(country ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE country IS NOT NULL))[1], '') AS country,
+		COALESCE((array_agg(city ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE city IS NOT NULL))[1], '') AS city,
+		COALESCE((array_agg(organization ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE organization IS NOT NULL))[1], '') AS organization,
+		COALESCE((array_agg(asn ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE asn IS NOT NULL))[1], '') AS asn,
+		COALESCE((array_agg(isp ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE isp IS NOT NULL))[1], '') AS isp,
+		COALESCE((array_agg(source_ip ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE event = 'client_seen' AND source_ip IS NOT NULL))[1], '') AS observed_client_ip,
+		COALESCE((array_agg(reported_client_ip ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE reported_client_ip IS NOT NULL))[1], '') AS reported_client_ip,
+		COALESCE((array_agg(source_ip ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE source_ip IS NOT NULL))[1], '') AS fallback_source_ip,
+		MAX(received_at) FILTER (WHERE event = 'session_heartbeat') AS last_heartbeat_at,
+		GREATEST(COALESCE(MAX(session_duration_ms) FILTER (WHERE event = 'session_heartbeat'), 0), 0) AS running_duration_ms,
+		COALESCE((array_agg(COALESCE(session_duration_ms, 0) ORDER BY received_at DESC, occurred_at DESC) FILTER (WHERE event = 'connection_ended'))[1], 0) AS ended_duration_ms,
+		GREATEST(COALESCE(MAX(bytes_sent), 0), 0) AS bytes_sent,
+		GREATEST(COALESCE(MAX(bytes_received), 0), 0) AS bytes_received,
+		bool_or(event = 'connection_attempted') AS attempted,
+		bool_or(event = 'connection_succeeded') AS succeeded,
+		bool_or(event = 'connection_failed') AS failed,
+		bool_or(event IN ('connection_failed', 'connection_ended', 'tunnel_stopped')) AS terminal,
+		MAX(received_at) FILTER (WHERE event = 'session_heartbeat') > $4 AND NOT bool_or(event IN ('connection_failed', 'connection_ended', 'tunnel_stopped')) AS active
+	FROM events
+	GROUP BY session_id
+)`
+
+// isp precedence mirrors firstNonEmpty(isp, organization, asn).
+const telemetrySessionISPLabel = `
+	CASE
+		WHEN btrim(isp) <> '' THEN isp
+		WHEN btrim(organization) <> '' THEN organization
+		WHEN btrim(asn) <> '' THEN asn
+		ELSE ''
+	END`
+
+const telemetryTotalsQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
+SELECT
+	(SELECT COUNT(DISTINCT client_id) FROM events) AS clients,
+	COUNT(*) AS sessions,
+	COUNT(*) FILTER (WHERE attempted) AS attempts,
+	COUNT(*) FILTER (WHERE succeeded) AS successes,
+	COUNT(*) FILTER (WHERE failed) AS failures,
+	COUNT(DISTINCT client_id) FILTER (WHERE active) AS active_clients,
+	COUNT(*) FILTER (WHERE active) AS active_sessions
+FROM sessions`
+
+const telemetryTrendQuery = `WITH ` + telemetryEventsCTE + `
+SELECT
+	date_trunc('hour', occurred_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS hour,
+	COUNT(*) FILTER (WHERE event = 'connection_attempted') AS attempts,
+	COUNT(*) FILTER (WHERE event = 'connection_succeeded') AS successes,
+	COUNT(*) FILTER (WHERE event = 'connection_failed') AS failures
+FROM events
+WHERE event IN ('connection_attempted', 'connection_succeeded', 'connection_failed')
+GROUP BY 1`
+
+// Event-level count groups, discriminated by kind; the caller feeds each kind
+// through sortedCounts (or the relay merge) so top-N selection and tiebreaks
+// stay identical to the in-memory path.
+const telemetryEventCountsQuery = `WITH ` + telemetryEventsCTE + `
+SELECT 'top_applications' AS kind, application AS name, COUNT(*) AS count
+FROM events WHERE application IS NOT NULL GROUP BY application
+UNION ALL
+SELECT 'failure_stages',
+	CASE WHEN btrim(COALESCE(failure_stage, '')) <> '' THEN failure_stage ELSE 'unknown' END,
+	COUNT(*)
+FROM events WHERE event = 'connection_failed' GROUP BY 2
+UNION ALL
+SELECT 'relay_successes', relay_id, COUNT(*)
+FROM events WHERE event = 'connection_succeeded' AND relay_id <> '' GROUP BY relay_id
+UNION ALL
+SELECT 'relay_failures', relay_id, COUNT(*)
+FROM events WHERE event = 'relay_attempt_failed' AND relay_id <> '' GROUP BY relay_id`
+
+const telemetrySessionCountsQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
+SELECT 'top_countries' AS kind, country AS name, COUNT(*) AS count
+FROM sessions WHERE btrim(country) <> '' GROUP BY country
+UNION ALL
+SELECT 'top_cities', city, COUNT(*) FROM sessions WHERE btrim(city) <> '' GROUP BY city
+UNION ALL
+SELECT 'top_isps', ` + telemetrySessionISPLabel + `, COUNT(*)
+FROM sessions WHERE btrim(` + telemetrySessionISPLabel + `) <> '' GROUP BY 2
+UNION ALL
+SELECT 'active_by_relay', relay_id, COUNT(*) FROM sessions WHERE active AND btrim(relay_id) <> '' GROUP BY relay_id
+UNION ALL
+SELECT 'active_by_country', country, COUNT(*) FROM sessions WHERE active AND btrim(country) <> '' GROUP BY country
+UNION ALL
+SELECT 'active_by_city', city, COUNT(*) FROM sessions WHERE active AND btrim(city) <> '' GROUP BY city
+UNION ALL
+SELECT 'active_by_isp', ` + telemetrySessionISPLabel + `, COUNT(*)
+FROM sessions WHERE active AND btrim(` + telemetrySessionISPLabel + `) <> '' GROUP BY 2
+UNION ALL
+SELECT 'active_by_os', operating_system, COUNT(*) FROM sessions WHERE active AND btrim(operating_system) <> '' GROUP BY operating_system`
+
+const telemetrySpeedTestsQuery = `WITH ` + telemetryEventsCTE + `
+SELECT
+	relay_id,
+	COUNT(*) AS tests,
+	SUM(COALESCE(download_mbps_milli, 0)) AS mbps_milli,
+	SUM(COALESCE(ttfb_ms, 0)) AS ttfb_ms
+FROM events
+WHERE event = 'speed_test_completed' AND relay_id <> ''
+GROUP BY relay_id`
+
+// The (last_seen_at DESC, session_id) order matches the in-memory sort so
+// pages stay stable across requests when batched uploads share a received_at.
+const telemetrySessionPageQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
+SELECT
+	session_id, client_id, started_at, last_seen_at, relay_id, operating_system,
+	device_manufacturer, device_model, app_version, country, city, organization, asn, isp,
+	observed_client_ip, reported_client_ip, fallback_source_ip,
+	last_heartbeat_at, running_duration_ms, ended_duration_ms, bytes_sent, bytes_received,
+	attempted, succeeded, failed, terminal
+FROM sessions
+ORDER BY last_seen_at DESC, session_id
+LIMIT $5 OFFSET $6`
+
+const telemetrySessionCountQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
+SELECT COUNT(*) FROM sessions`
+
+// telemetryWindowArgs is the shared parameter list documented on the CTEs.
+// Queries that only touch the events CTE must take eventArgs — Postgres
+// rejects bound parameters a statement never references.
+func telemetryWindowArgs(now time.Time, window time.Duration) (eventArgs, sessionArgs []any) {
+	start := now.Add(-window)
+	sessionArgs = []any{start.Add(-maxTelemetryFutureSkew), start, now, now.Add(-activeSessionTimeout)}
+	return sessionArgs[:3], sessionArgs
+}
+
+// TelemetryOverview implements TelemetryQuerier by aggregating the window in
+// Postgres. Only per-group counts and the newest sessions travel back to Go,
+// so response size tracks the diversity of the window, not its event count.
+func (s *PostgresTelemetrySink) TelemetryOverview(now time.Time, window time.Duration) (telemetryOverview, error) {
+	if err := s.flush(); err != nil {
+		slog.Error("could not flush telemetry before read", "error", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryQueryTimeout)
+	defer cancel()
+	eventArgs, sessionArgs := telemetryWindowArgs(now, window)
+
+	overview := telemetryOverview{GeneratedAt: now, Window: window.String()}
+	if err := s.pool.QueryRow(ctx, telemetryTotalsQuery, sessionArgs...).Scan(
+		&overview.Totals.Clients,
+		&overview.Totals.Sessions,
+		&overview.Totals.Attempts,
+		&overview.Totals.Successes,
+		&overview.Totals.Failures,
+		&overview.Totals.ActiveClients,
+		&overview.Totals.ActiveSessions,
+	); err != nil {
+		return telemetryOverview{}, fmt.Errorf("query telemetry totals: %w", err)
+	}
+	if overview.Totals.Attempts > 0 {
+		overview.Totals.SuccessRate = float64(overview.Totals.Successes) / float64(overview.Totals.Attempts)
+	}
+
+	trend, err := s.queryTelemetryTrend(ctx, eventArgs, now, window)
+	if err != nil {
+		return telemetryOverview{}, err
+	}
+	overview.Trend = trend
+
+	eventCounts, err := s.queryTelemetryCounts(ctx, telemetryEventCountsQuery, eventArgs)
+	if err != nil {
+		return telemetryOverview{}, fmt.Errorf("query telemetry event counts: %w", err)
+	}
+	overview.TopApps = sortedCounts(eventCounts["top_applications"], 10)
+	overview.FailureStages = sortedCounts(eventCounts["failure_stages"], 10)
+	overview.TopRelays = topRelaySummaries(eventCounts["relay_successes"], eventCounts["relay_failures"])
+
+	sessionCounts, err := s.queryTelemetryCounts(ctx, telemetrySessionCountsQuery, sessionArgs)
+	if err != nil {
+		return telemetryOverview{}, fmt.Errorf("query telemetry session counts: %w", err)
+	}
+	overview.TopCountries = sortedCounts(sessionCounts["top_countries"], 10)
+	overview.TopCities = sortedCounts(sessionCounts["top_cities"], 10)
+	overview.TopISPs = sortedCounts(sessionCounts["top_isps"], 10)
+	overview.ActiveRelays = sortedCounts(sessionCounts["active_by_relay"], 10)
+	overview.ActiveCountries = sortedCounts(sessionCounts["active_by_country"], 10)
+	overview.ActiveCities = sortedCounts(sessionCounts["active_by_city"], 10)
+	overview.ActiveISPs = sortedCounts(sessionCounts["active_by_isp"], 10)
+	overview.ActiveOS = sortedCounts(sessionCounts["active_by_os"], 10)
+
+	speedTests, err := s.queryTelemetrySpeedTests(ctx, eventArgs)
+	if err != nil {
+		return telemetryOverview{}, err
+	}
+	overview.SpeedTests = speedTests
+
+	recent, err := s.queryTelemetrySessionPage(ctx, sessionArgs, now, overviewRecentSessions, 0)
+	if err != nil {
+		return telemetryOverview{}, err
+	}
+	// Match the in-memory path: no sessions marshals as null, not [].
+	if len(recent) > 0 {
+		overview.Recent = recent
+	}
+	return overview, nil
+}
+
+// TelemetrySessions implements TelemetryQuerier with LIMIT/OFFSET pagination.
+func (s *PostgresTelemetrySink) TelemetrySessions(now time.Time, window time.Duration, offset, limit int) ([]sessionSummary, int, error) {
+	if err := s.flush(); err != nil {
+		slog.Error("could not flush telemetry before read", "error", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryQueryTimeout)
+	defer cancel()
+	_, sessionArgs := telemetryWindowArgs(now, window)
+
+	var total int
+	if err := s.pool.QueryRow(ctx, telemetrySessionCountQuery, sessionArgs...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count telemetry sessions: %w", err)
+	}
+	page, err := s.queryTelemetrySessionPage(ctx, sessionArgs, now, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	if page == nil {
+		page = []sessionSummary{}
+	}
+	return page, total, nil
+}
+
+func (s *PostgresTelemetrySink) queryTelemetryTrend(ctx context.Context, args []any, now time.Time, window time.Duration) ([]trendPoint, error) {
+	first := now.Add(-window).Truncate(time.Hour)
+	var trend []trendPoint
+	for bucket := first; !bucket.After(now); bucket = bucket.Add(time.Hour) {
+		trend = append(trend, trendPoint{Time: bucket})
+	}
+
+	rows, err := s.pool.Query(ctx, telemetryTrendQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query telemetry trend: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var hour time.Time
+		var attempts, successes, failures int
+		if err := rows.Scan(&hour, &attempts, &successes, &failures); err != nil {
+			return nil, fmt.Errorf("scan telemetry trend: %w", err)
+		}
+		index := int(hour.UTC().Sub(first) / time.Hour)
+		if index < 0 || index >= len(trend) {
+			continue
+		}
+		trend[index].Attempts = attempts
+		trend[index].Successes = successes
+		trend[index].Failures = failures
+	}
+	return trend, rows.Err()
+}
+
+func (s *PostgresTelemetrySink) queryTelemetryCounts(ctx context.Context, query string, args []any) (map[string]map[string]int, error) {
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	counts := make(map[string]map[string]int)
+	for rows.Next() {
+		var kind, name string
+		var count int
+		if err := rows.Scan(&kind, &name, &count); err != nil {
+			return nil, err
+		}
+		if counts[kind] == nil {
+			counts[kind] = make(map[string]int)
+		}
+		counts[kind][name] = count
+	}
+	return counts, rows.Err()
+}
+
+// topRelaySummaries mirrors the in-memory relay ranking: entries exist for any
+// relay with a success or failure, ordered by total volume, top ten kept.
+func topRelaySummaries(successes, failures map[string]int) []relaySummary {
+	relays := make(map[string]*relaySummary)
+	for relayID, count := range successes {
+		relayFor(relays, relayID).Successes = count
+	}
+	for relayID, count := range failures {
+		relayFor(relays, relayID).Failures = count
+	}
+	var top []relaySummary
+	for _, relay := range relays {
+		top = append(top, *relay)
+	}
+	sortTopRelays(top)
+	if len(top) > 10 {
+		top = top[:10]
+	}
+	return top
+}
+
+func (s *PostgresTelemetrySink) queryTelemetrySpeedTests(ctx context.Context, args []any) ([]speedTestSummary, error) {
+	rows, err := s.pool.Query(ctx, telemetrySpeedTestsQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query telemetry speed tests: %w", err)
+	}
+	defer rows.Close()
+	var speedTests []speedTestSummary
+	for rows.Next() {
+		var relayID string
+		var tests int
+		var mbpsMilli, ttfbMS int64
+		if err := rows.Scan(&relayID, &tests, &mbpsMilli, &ttfbMS); err != nil {
+			return nil, fmt.Errorf("scan telemetry speed tests: %w", err)
+		}
+		speedTests = append(speedTests, speedTestSummary{
+			RelayID:       relayID,
+			Tests:         tests,
+			AverageMbps:   float64(mbpsMilli) / float64(tests) / 1000,
+			AverageTTFBMS: float64(ttfbMS) / float64(tests),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sortSpeedTests(speedTests)
+	return speedTests, nil
+}
+
+func (s *PostgresTelemetrySink) queryTelemetrySessionPage(ctx context.Context, args []any, now time.Time, limit, offset int) ([]sessionSummary, error) {
+	rows, err := s.pool.Query(ctx, telemetrySessionPageQuery, append(append([]any{}, args...), limit, offset)...)
+	if err != nil {
+		return nil, fmt.Errorf("query telemetry sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []sessionSummary
+	for rows.Next() {
+		var acc sessionAccumulator
+		var startedAt, lastSeenAt time.Time
+		var lastHeartbeatAt *time.Time
+		var endedDurationMS int64
+		if err := rows.Scan(
+			&acc.summary.SessionID,
+			&acc.summary.ClientID,
+			&startedAt,
+			&lastSeenAt,
+			&acc.summary.RelayID,
+			&acc.summary.OperatingSystem,
+			&acc.deviceManufacturer,
+			&acc.deviceModel,
+			&acc.summary.AppVersion,
+			&acc.summary.Country,
+			&acc.summary.City,
+			&acc.summary.Organization,
+			&acc.summary.ASN,
+			&acc.isp,
+			&acc.observedClientIP,
+			&acc.reportedClientIP,
+			&acc.fallbackSourceIP,
+			&lastHeartbeatAt,
+			&acc.runningDurationMS,
+			&endedDurationMS,
+			&acc.summary.BytesSent,
+			&acc.summary.BytesReceived,
+			&acc.attempted,
+			&acc.succeeded,
+			&acc.failed,
+			&acc.terminal,
+		); err != nil {
+			return nil, fmt.Errorf("scan telemetry session: %w", err)
+		}
+		acc.summary.Status = "seen"
+		acc.summary.StartedAt = startedAt.UTC()
+		acc.summary.LastSeenAt = lastSeenAt.UTC()
+		acc.summary.DurationMS = endedDurationMS
+		if lastHeartbeatAt != nil {
+			acc.lastHeartbeatAt = lastHeartbeatAt.UTC()
+		}
+		sessions = append(sessions, acc.finalize(now))
+	}
+	return sessions, rows.Err()
+}

--- a/internal/broker/postgres_telemetry_query_test.go
+++ b/internal/broker/postgres_telemetry_query_test.go
@@ -1,0 +1,229 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The parity tests feed one synthetic event set through the in-memory
+// aggregator (the JSONL sink's dashboard path) and the SQL aggregation, then
+// require byte-identical JSON. Only the two orderings that were already
+// nondeterministic in the in-memory path (top-relay and speed-test ties) are
+// kept tie-free in the fixture.
+
+// parityTelemetryRecords exercises the semantics the SQL path must reproduce:
+// latest-non-empty attribute precedence (including the android_api/ios_version
+// OS fallbacks and country_code), status transitions, cumulative byte maxima,
+// running-vs-final duration, source-IP preference, window boundaries (events
+// before the window, after "now", and received before the window started),
+// speed tests, and multi-client sessions.
+func parityTelemetryRecords(now time.Time) []TelemetryRecord {
+	sequence := 0
+	record := func(occurredMinutesAgo, receivedMinutesAgo int, event, clientID, sessionID, relayID, sourceIP string, attributes map[string]string, measurements map[string]int64) TelemetryRecord {
+		sequence++
+		return TelemetryRecord{
+			ReceivedAt: now.Add(-time.Duration(receivedMinutesAgo) * time.Minute),
+			SourceIP:   sourceIP,
+			Event: TelemetryEvent{
+				SchemaVersion: 1,
+				EventID:       fmt.Sprintf("parity-%03d", sequence),
+				Event:         event,
+				OccurredAt:    now.Add(-time.Duration(occurredMinutesAgo) * time.Minute),
+				ClientID:      clientID,
+				SessionID:     sessionID,
+				RelayID:       relayID,
+				Application:   attributes["_app"],
+				Attributes:    withoutKey(attributes, "_app"),
+				Measurements:  measurements,
+			},
+		}
+	}
+
+	return []TelemetryRecord{
+		// session-android: succeeded then still heartbeating (active). In the
+		// 1h window only the heartbeat survives, so its status degrades to
+		// "seen" with no attributes — a window-boundary case in itself.
+		record(85, 85, "client_seen", "client-android", "session-android", "", "203.0.113.10",
+			map[string]string{"android_api": "34", "device_manufacturer": "Google", "device_model": "Pixel 7", "app_version": "1.2.0", "country": "DE", "city": "Berlin", "isp": "Deutsche Telekom"}, nil),
+		record(84, 84, "connection_attempted", "client-android", "session-android", "relay-1", "203.0.113.10",
+			map[string]string{"client_ip": "10.1.2.3"}, nil),
+		record(83, 83, "connection_succeeded", "client-android", "session-android", "relay-1", "203.0.113.10",
+			map[string]string{"_app": "org.mozilla.firefox"}, map[string]int64{"bytes_sent": 100, "bytes_received": 200}),
+		record(1, 1, "session_heartbeat", "client-android", "session-android", "relay-1", "203.0.113.10",
+			nil, map[string]int64{"session_duration_ms": 500000, "bytes_sent": 5000, "bytes_received": 9000}),
+
+		// session-ios: attempted then failed (terminal), OS from ios_version,
+		// country from country_code, a relay failure for top-relay counts.
+		record(80, 80, "connection_attempted", "client-ios", "session-ios", "", "198.51.100.20",
+			map[string]string{"ios_version": "17.5", "app_version": "2.0.1", "country_code": "IR", "city": "Tehran", "_app": "org.mozilla.firefox"}, nil),
+		record(79, 79, "relay_attempt_failed", "client-ios", "session-ios", "relay-2", "198.51.100.20",
+			nil, map[string]int64{"relay_tcp_ms": 300}),
+		record(78, 78, "connection_failed", "client-ios", "session-ios", "", "198.51.100.20",
+			map[string]string{"failure_stage": "tcp_connect"}, nil),
+
+		// session-desktop: full lifecycle. The heartbeat reports larger byte
+		// counters than the final connection_ended (maxima must win), while
+		// connection_ended's duration overrides the running one. ISP falls
+		// back to organization.
+		record(30, 30, "client_seen", "client-desktop", "session-desktop", "", "198.51.100.7",
+			map[string]string{"operating_system": "macOS (arm64)", "organization": "Example Org", "asn": "AS64500", "app_version": "0.9.0"}, nil),
+		record(29, 29, "connection_attempted", "client-desktop", "session-desktop", "relay-2", "198.51.100.7", nil, nil),
+		record(28, 28, "connection_succeeded", "client-desktop", "session-desktop", "relay-2", "198.51.100.7",
+			map[string]string{"_app": "com.brave.browser"}, map[string]int64{"bytes_sent": 700}),
+		record(25, 25, "session_heartbeat", "client-desktop", "session-desktop", "relay-2", "198.51.100.7",
+			nil, map[string]int64{"session_duration_ms": 60000, "bytes_sent": 900, "bytes_received": 1500}),
+		record(20, 20, "connection_ended", "client-desktop", "session-desktop", "relay-2", "198.51.100.7",
+			nil, map[string]int64{"session_duration_ms": 540000, "bytes_sent": 800, "bytes_received": 1200}),
+
+		// session-precedence: latest non-empty attribute wins (city updated,
+		// country kept, then country_code), reported client_ip beats the
+		// transport source because no client_seen carries a source, and the
+		// session spans two client IDs (the first one names the session).
+		record(70, 70, "connection_attempted", "client-p1", "session-precedence", "", "192.0.2.50",
+			map[string]string{"operating_system": "Windows 11", "country": "US", "city": "Austin", "isp": "AT&T", "client_ip": "10.9.8.7"}, nil),
+		record(60, 60, "connection_attempted", "client-p1", "session-precedence", "", "192.0.2.50",
+			map[string]string{"city": "Dallas"}, nil),
+		record(50, 50, "connection_attempted", "client-p2", "session-precedence", "", "192.0.2.51",
+			map[string]string{"country_code": "CA"}, nil),
+
+		// session-boundary: attempted long ago (outside the 1h window), then a
+		// stale heartbeat — attempting-but-inactive in 24h, bare "seen" in 1h.
+		record(200, 200, "connection_attempted", "client-boundary", "session-boundary", "relay-1", "203.0.113.99", nil, nil),
+		record(55, 55, "session_heartbeat", "client-boundary", "session-boundary", "relay-1", "203.0.113.99",
+			nil, map[string]int64{"session_duration_ms": 120000}),
+		// Occurred after "now" (allowed by ingest skew): excluded everywhere.
+		// If either path counted it, session-boundary would turn failed.
+		record(-10, 5, "connection_failed", "client-boundary", "session-boundary", "", "203.0.113.99",
+			map[string]string{"failure_stage": "phantom"}, nil),
+
+		// session-skew: received before the 1h window opened but occurred
+		// inside it — the SQL received_at pruning margin must keep it.
+		record(50, 65, "client_seen", "client-skew", "session-skew", "", "192.0.2.99",
+			map[string]string{"operating_system": "Linux"}, nil),
+
+		// session-speed: speed tests with tie-free averages per relay.
+		record(40, 40, "speed_test_completed", "client-speed", "session-speed", "relay-1", "192.0.2.60",
+			nil, map[string]int64{"download_mbps_milli": 45000, "time_to_first_byte_ms": 120}),
+		record(39, 39, "speed_test_completed", "client-speed", "session-speed", "relay-3", "192.0.2.60",
+			nil, map[string]int64{"download_mbps_milli": 90000, "time_to_first_byte_ms": 80}),
+		record(38, 38, "speed_test_completed", "client-speed", "session-speed", "relay-3", "192.0.2.60",
+			nil, map[string]int64{"download_mbps_milli": 70000, "time_to_first_byte_ms": 100}),
+	}
+}
+
+func withoutKey(values map[string]string, key string) map[string]string {
+	if _, ok := values[key]; !ok {
+		return values
+	}
+	trimmed := make(map[string]string, len(values))
+	for name, value := range values {
+		if name != key {
+			trimmed[name] = value
+		}
+	}
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return trimmed
+}
+
+func TestPostgresTelemetryQuerierMatchesInMemoryOverview(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
+	sink := newTestPostgresTelemetrySink(t, now)
+	records := parityTelemetryRecords(now)
+	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatalf("write telemetry: %v", err)
+	}
+	memory := newTelemetryReaderQuerier(&dashboardTelemetryStore{records: records})
+
+	for _, window := range []time.Duration{time.Hour, 24 * time.Hour, telemetryRetention} {
+		want, err := memory.TelemetryOverview(now, window)
+		if err != nil {
+			t.Fatalf("in-memory overview (%s): %v", window, err)
+		}
+		got, err := sink.TelemetryOverview(now, window)
+		if err != nil {
+			t.Fatalf("postgres overview (%s): %v", window, err)
+		}
+		assertSameJSON(t, fmt.Sprintf("overview window=%s", window), want, got)
+	}
+}
+
+func TestPostgresTelemetryQuerierMatchesInMemorySessions(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
+	sink := newTestPostgresTelemetrySink(t, now)
+	records := parityTelemetryRecords(now)
+	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatalf("write telemetry: %v", err)
+	}
+	memory := newTelemetryReaderQuerier(&dashboardTelemetryStore{records: records})
+
+	window := 24 * time.Hour
+	for _, page := range []struct{ offset, limit int }{
+		{0, 3},    // first page
+		{3, 3},    // middle page
+		{0, 100},  // everything
+		{6, 2},    // tail page
+		{100, 10}, // offset beyond the window's sessions
+	} {
+		wantSessions, wantTotal, err := memory.TelemetrySessions(now, window, page.offset, page.limit)
+		if err != nil {
+			t.Fatalf("in-memory sessions (offset=%d): %v", page.offset, err)
+		}
+		gotSessions, gotTotal, err := sink.TelemetrySessions(now, window, page.offset, page.limit)
+		if err != nil {
+			t.Fatalf("postgres sessions (offset=%d): %v", page.offset, err)
+		}
+		if wantTotal != gotTotal {
+			t.Fatalf("sessions total mismatch at offset=%d: in-memory %d, postgres %d", page.offset, wantTotal, gotTotal)
+		}
+		assertSameJSON(t, fmt.Sprintf("sessions offset=%d limit=%d", page.offset, page.limit), wantSessions, gotSessions)
+	}
+}
+
+func TestPostgresTelemetryQuerierMatchesInMemoryWhenEmpty(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
+	sink := newTestPostgresTelemetrySink(t, now)
+	memory := newTelemetryReaderQuerier(&dashboardTelemetryStore{})
+
+	want, err := memory.TelemetryOverview(now, time.Hour)
+	if err != nil {
+		t.Fatalf("in-memory empty overview: %v", err)
+	}
+	got, err := sink.TelemetryOverview(now, time.Hour)
+	if err != nil {
+		t.Fatalf("postgres empty overview: %v", err)
+	}
+	assertSameJSON(t, "empty overview", want, got)
+
+	wantSessions, wantTotal, err := memory.TelemetrySessions(now, time.Hour, 0, 25)
+	if err != nil {
+		t.Fatalf("in-memory empty sessions: %v", err)
+	}
+	gotSessions, gotTotal, err := sink.TelemetrySessions(now, time.Hour, 0, 25)
+	if err != nil {
+		t.Fatalf("postgres empty sessions: %v", err)
+	}
+	if wantTotal != 0 || gotTotal != 0 {
+		t.Fatalf("expected zero totals, got in-memory %d, postgres %d", wantTotal, gotTotal)
+	}
+	assertSameJSON(t, "empty sessions", wantSessions, gotSessions)
+}
+
+func assertSameJSON(t *testing.T, context string, want, got any) {
+	t.Helper()
+	wantJSON, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal in-memory %s: %v", context, err)
+	}
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal postgres %s: %v", context, err)
+	}
+	if string(wantJSON) != string(gotJSON) {
+		t.Fatalf("%s diverges between backends:\n--- in-memory ---\n%s\n--- postgres ---\n%s", context, wantJSON, gotJSON)
+	}
+}

--- a/internal/broker/postgres_telemetry_test.go
+++ b/internal/broker/postgres_telemetry_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 )
 
-func TestPostgresTelemetrySinkPersistsAndReloads(t *testing.T) {
+func TestPostgresTelemetrySinkPersistsAndReadsBack(t *testing.T) {
 	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
-	sink := newTestPostgresTelemetrySink(t, now, maxTelemetryMemoryBytes)
+	sink := newTestPostgresTelemetrySink(t, now)
 
 	records := []TelemetryRecord{
 		{
@@ -47,40 +47,36 @@ func TestPostgresTelemetrySinkPersistsAndReloads(t *testing.T) {
 		t.Fatalf("write telemetry: %v", err)
 	}
 
-	// Writes buffer until the ticker or a full batch flushes them.
+	// Writes buffer until the ticker or a full batch flushes them; the reader
+	// flushes before selecting, so it sees them either way.
 	if got := countTelemetryRows(t, sink); got != 0 {
 		t.Fatalf("expected buffered records not yet inserted, found %d rows", got)
 	}
-	if err := sink.flush(); err != nil {
-		t.Fatalf("flush telemetry: %v", err)
+	if got := sink.TelemetryRecords(now.Add(-time.Hour)); len(got) != 2 {
+		t.Fatalf("expected reader to flush and return 2 records, got %d", len(got))
 	}
 	if got := countTelemetryRows(t, sink); got != 2 {
-		t.Fatalf("expected 2 rows after flush, found %d", got)
+		t.Fatalf("expected 2 rows after read-triggered flush, found %d", got)
 	}
 
-	// The unflushed reader still serves both records in the meantime.
-	if got := sink.TelemetryRecords(time.Time{}); len(got) != 2 {
-		t.Fatalf("expected 2 retained records, got %d", len(got))
-	}
-
-	reopened := newTestPostgresTelemetrySinkWithoutCleanup(t, now.Add(time.Minute), maxTelemetryMemoryBytes)
+	// A fresh instance must serve the same records straight from Postgres —
+	// there is no startup backfill or in-memory copy to rely on.
+	reopened := newTestPostgresTelemetrySinkWithoutCleanup(t, now.Add(time.Minute))
 	t.Cleanup(func() { reopened.Close() })
-	loaded := reopened.TelemetryRecords(time.Time{})
+	loaded := reopened.TelemetryRecords(now.Add(-time.Hour))
 	if len(loaded) != 2 {
-		t.Fatalf("expected 2 backfilled records, got %d", len(loaded))
+		t.Fatalf("expected 2 records from reopened sink, got %d", len(loaded))
 	}
-	// Identical received_at values reload in unspecified order; look records
-	// up by event ID.
 	byID := make(map[string]TelemetryRecord, len(loaded))
 	for _, record := range loaded {
 		byID[record.Event.EventID] = record
 	}
 	first, ok := byID["event-1"]
 	if !ok {
-		t.Fatalf("expected event-1 in backfill, got %+v", loaded)
+		t.Fatalf("expected event-1 in read-back, got %+v", loaded)
 	}
 	if !first.ReceivedAt.Equal(now) || first.SourceIP != "203.0.113.42" {
-		t.Fatalf("unexpected backfilled envelope: %+v", first)
+		t.Fatalf("unexpected read-back envelope: %+v", first)
 	}
 	want := records[0].Event
 	got := first.Event
@@ -88,11 +84,11 @@ func TestPostgresTelemetrySinkPersistsAndReloads(t *testing.T) {
 		got.ClientID != want.ClientID || got.SessionID != want.SessionID || got.RelayID != want.RelayID ||
 		got.SchemaVersion != want.SchemaVersion || got.Attributes["app_version"] != "1.2.3" ||
 		got.Measurements["relay_tcp_ms"] != 42 {
-		t.Fatalf("backfilled event does not round-trip: got %+v want %+v", got, want)
+		t.Fatalf("read-back event does not round-trip: got %+v want %+v", got, want)
 	}
 	second, ok := byID["event-2"]
 	if !ok {
-		t.Fatalf("expected event-2 in backfill, got %+v", loaded)
+		t.Fatalf("expected event-2 in read-back, got %+v", loaded)
 	}
 	if second.SourceIP != "" || second.Event.RelayID != "" {
 		t.Fatalf("expected empty source IP and relay ID to round-trip as empty, got %+v", second)
@@ -101,7 +97,7 @@ func TestPostgresTelemetrySinkPersistsAndReloads(t *testing.T) {
 
 func TestPostgresTelemetrySinkCreatesDailyPartitions(t *testing.T) {
 	now := time.Date(2026, 6, 24, 23, 30, 0, 0, time.UTC)
-	sink := newTestPostgresTelemetrySink(t, now, maxTelemetryMemoryBytes)
+	sink := newTestPostgresTelemetrySink(t, now)
 
 	// Startup pre-creates today's and tomorrow's partitions.
 	for _, day := range []string{"20260624", "20260625"} {
@@ -126,14 +122,14 @@ func TestPostgresTelemetrySinkCreatesDailyPartitions(t *testing.T) {
 	}
 }
 
-func TestPostgresTelemetrySinkBackfillHonorsMemoryBudget(t *testing.T) {
+func TestPostgresTelemetrySinkReaderIsWindowBounded(t *testing.T) {
 	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
-	sink := newTestPostgresTelemetrySink(t, now, maxTelemetryMemoryBytes)
+	sink := newTestPostgresTelemetrySink(t, now)
 
 	const total = 30
 	records := make([]TelemetryRecord, 0, total)
 	for i := 0; i < total; i++ {
-		records = append(records, validTelemetryRecord(now.Add(time.Duration(i)*time.Second), fmt.Sprintf("event-%03d", i)))
+		records = append(records, validTelemetryRecord(now.Add(-time.Duration(i)*time.Minute), fmt.Sprintf("event-%03d", i)))
 	}
 	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
 		t.Fatalf("write telemetry: %v", err)
@@ -142,26 +138,14 @@ func TestPostgresTelemetrySinkBackfillHonorsMemoryBudget(t *testing.T) {
 		t.Fatalf("flush telemetry: %v", err)
 	}
 
-	// Budget for roughly 10 fixed-width records; the reload must keep the
-	// newest ones and stay within the budget.
-	perRecord := telemetryRecordSize(records[0])
-	budget := 10 * perRecord
-	reopened := newTestPostgresTelemetrySinkWithoutCleanup(t, now.Add(time.Minute), budget)
-	t.Cleanup(func() { reopened.Close() })
-
-	if reopened.memoryBytes > budget {
-		t.Fatalf("loaded set exceeds budget: %d > %d", reopened.memoryBytes, budget)
-	}
-	loaded := reopened.TelemetryRecords(time.Time{})
-	if len(loaded) == 0 || len(loaded) >= total {
-		t.Fatalf("expected a trimmed backfill, got %d of %d records", len(loaded), total)
-	}
-	if got := loaded[len(loaded)-1].Event.EventID; got != fmt.Sprintf("event-%03d", total-1) {
-		t.Fatalf("expected newest record retained last, got %q", got)
+	// The operational reader returns only the requested window, oldest first.
+	loaded := sink.TelemetryRecords(now.Add(-5 * time.Minute))
+	if len(loaded) != 6 {
+		t.Fatalf("expected 6 records inside the 5-minute window, got %d", len(loaded))
 	}
 	for i := 1; i < len(loaded); i++ {
 		if loaded[i].ReceivedAt.Before(loaded[i-1].ReceivedAt) {
-			t.Fatal("expected backfilled records ordered oldest-first")
+			t.Fatal("expected records ordered oldest-received first")
 		}
 	}
 }
@@ -266,9 +250,9 @@ func validTelemetryRecord(at time.Time, eventID string) TelemetryRecord {
 	}
 }
 
-func newTestPostgresTelemetrySink(t *testing.T, now time.Time, memoryLimit int64) *PostgresTelemetrySink {
+func newTestPostgresTelemetrySink(t *testing.T, now time.Time) *PostgresTelemetrySink {
 	t.Helper()
-	sink := newTestPostgresTelemetrySinkWithoutCleanup(t, now, memoryLimit)
+	sink := newTestPostgresTelemetrySinkWithoutCleanup(t, now)
 	cleanupPostgresTelemetry(t, sink)
 	t.Cleanup(func() {
 		cleanupPostgresTelemetry(t, sink)
@@ -277,7 +261,7 @@ func newTestPostgresTelemetrySink(t *testing.T, now time.Time, memoryLimit int64
 	return sink
 }
 
-func newTestPostgresTelemetrySinkWithoutCleanup(t *testing.T, now time.Time, memoryLimit int64) *PostgresTelemetrySink {
+func newTestPostgresTelemetrySinkWithoutCleanup(t *testing.T, now time.Time) *PostgresTelemetrySink {
 	t.Helper()
 	databaseURL := os.Getenv("OPENRUNG_TEST_POSTGRES_URL")
 	if databaseURL == "" {
@@ -287,7 +271,7 @@ func newTestPostgresTelemetrySinkWithoutCleanup(t *testing.T, now time.Time, mem
 	defer cancel()
 	// An hour-long flush interval keeps the ticker out of the way; tests
 	// flush explicitly.
-	sink, err := newPostgresTelemetrySink(ctx, databaseURL, func() time.Time { return now }, time.Hour, memoryLimit)
+	sink, err := newPostgresTelemetrySink(ctx, databaseURL, func() time.Time { return now }, time.Hour)
 	if err != nil {
 		t.Fatalf("open postgres telemetry sink: %v", err)
 	}
@@ -299,11 +283,7 @@ func cleanupPostgresTelemetry(t *testing.T, sink *PostgresTelemetrySink) {
 	if _, err := sink.pool.Exec(context.Background(), `TRUNCATE telemetry_events`); err != nil {
 		t.Fatalf("cleanup telemetry events: %v", err)
 	}
-	// The sink backfilled whatever rows predated the truncate; drop that
-	// in-memory copy too so tests start from an empty retained set.
 	sink.mu.Lock()
-	sink.records = nil
-	sink.memoryBytes = 0
 	sink.pending = nil
 	sink.pendingBytes = 0
 	sink.mu.Unlock()

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -22,8 +22,12 @@ type Config struct {
 	RegistrationToken string
 	VolunteerLeaseTTL time.Duration
 	TelemetrySink     TelemetrySink
-	TelemetryReader   TelemetryReader
-	DashboardToken    string
+	// TelemetryReader backs the dashboard by aggregating records in Go on
+	// every request (the JSONL sink's path). TelemetryQuerier backs it with
+	// pre-aggregated queries (the Postgres store) and wins when both are set.
+	TelemetryReader  TelemetryReader
+	TelemetryQuerier TelemetryQuerier
+	DashboardToken   string
 	// TrustedProxyCIDRs are additional CIDRs (beyond Cloudflare's published ranges) whose forwarded
 	// CF-Connecting-IP / X-Forwarded-For headers the broker will trust for the real client IP.
 	TrustedProxyCIDRs []string
@@ -58,8 +62,12 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen)))
 	mux.HandleFunc("POST /api/v1/telemetry/events", rateLimited(telemetryLimiter, clientIP, 10, telemetryHandler(cfg.TelemetrySink, store, clientIP)))
 	mux.HandleFunc("GET /api/v1/speed-test", rateLimited(speedTestLimiter, clientIP, 30, speedTestHandler(speedTestMaxConcurrent)))
-	if cfg.DashboardToken != "" && cfg.TelemetryReader != nil {
-		dashboard := newDashboardServer(cfg.DashboardToken, cfg.TelemetryReader)
+	querier := cfg.TelemetryQuerier
+	if querier == nil && cfg.TelemetryReader != nil {
+		querier = newTelemetryReaderQuerier(cfg.TelemetryReader)
+	}
+	if cfg.DashboardToken != "" && querier != nil {
+		dashboard := newDashboardServer(cfg.DashboardToken, querier)
 		dashboard.relayLabels = relayLabelResolver(store)
 		dashboard.register(mux)
 	}

--- a/internal/broker/telemetry_query.go
+++ b/internal/broker/telemetry_query.go
@@ -1,0 +1,39 @@
+package broker
+
+import "time"
+
+// TelemetryQuerier is the dashboard's read path, mirroring its two admin API
+// endpoints. The in-memory implementation aggregates a TelemetryReader's
+// records in Go; the Postgres telemetry store aggregates in SQL so dashboard
+// cost does not scale with event volume.
+type TelemetryQuerier interface {
+	TelemetryOverview(now time.Time, window time.Duration) (telemetryOverview, error)
+	// TelemetrySessions returns one page of the window's sessions, newest
+	// last-seen first, plus the total session count in the window.
+	TelemetrySessions(now time.Time, window time.Duration, offset, limit int) ([]sessionSummary, int, error)
+}
+
+// telemetryReaderQuerier adapts any TelemetryReader (the JSONL sink's bounded
+// in-memory record set) to the dashboard's query interface by aggregating in
+// Go on every request.
+type telemetryReaderQuerier struct {
+	reader TelemetryReader
+}
+
+func newTelemetryReaderQuerier(reader TelemetryReader) telemetryReaderQuerier {
+	return telemetryReaderQuerier{reader: reader}
+}
+
+func (q telemetryReaderQuerier) TelemetryOverview(now time.Time, window time.Duration) (telemetryOverview, error) {
+	return buildTelemetryOverview(q.reader.TelemetryRecords(now.Add(-window)), now, window), nil
+}
+
+func (q telemetryReaderQuerier) TelemetrySessions(now time.Time, window time.Duration, offset, limit int) ([]sessionSummary, int, error) {
+	overview := buildTelemetryOverview(q.reader.TelemetryRecords(now.Add(-window)), now, window)
+	total := len(overview.Recent)
+	if offset > total {
+		offset = total
+	}
+	end := min(offset+limit, total)
+	return append([]sessionSummary{}, overview.Recent[offset:end]...), total, nil
+}


### PR DESCRIPTION
## What

PR B of the telemetry storage upgrade (follows #22). When `OPENRUNG_TELEMETRY_STORE=postgres`, the admin dashboard's overview and sessions endpoints now aggregate in SQL over `telemetry_events` instead of loading every record in the window into Go — and the broker no longer holds telemetry records in memory in postgres mode at all. JSONL mode (the dev/self-host default) is untouched. Retention/partition drops remain PR C.

## Design

**Query abstraction** — the dashboard consumes a new `TelemetryQuerier` interface mirroring its two admin API endpoints (`TelemetryOverview(now, window)` and `TelemetrySessions(now, window, offset, limit)`). The JSONL path is an adapter running the unchanged `buildTelemetryOverview` over its `TelemetryReader`; `NewServer` wraps `Config.TelemetryReader` automatically, so existing embedders keep working. Response JSON shapes are byte-compatible — `dashboard.html` needed no changes.

**SQL aggregation** — a handful of readable queries sharing two CTEs (`events` extracts the payload fields, `sessions` groups per session), always bounded by the dashboard window. `received_at` prunes the daily partitions, widened by the ingest clock-skew allowance so the `occurred_at` filter (what the in-memory path keys on) loses nothing. The subtle accumulator semantics are reproduced: latest-non-empty attribute wins ordered by `(received_at, occurred_at)`, the `android_api`/`ios_version` OS fallbacks, `country_code` fallback, source-IP preference (client_seen-observed > reported `client_ip` > any transport source), cumulative byte MAXima, last `connection_ended` duration with heartbeat-running fallback, status precedence, and heartbeat-based activity against `activeSessionTimeout`.

**Drift-proofing** — everything stylistic happens in shared Go code on both paths: the per-session finalization (`sessionAccumulator.finalize`), `sortedCounts` top-10 tiebreaks, relay ranking, and speed-test ordering are extracted and used by both backends. SQL returns raw grouped rows; Go assembles them exactly like the in-memory aggregator does.

**Stopgap removal** — `PostgresTelemetrySink` no longer keeps the PR-A retained set or does the startup backfill; startup reads no old events. The small write buffer for batched INSERTs stays, and dashboard queries flush it first so just-ingested events are visible. The sink still implements `TelemetryReader` — the periodic network-status log in `cmd/broker/main.go` consumes it over a 5-minute window — but as a short-window SELECT, not memory.

## Testing

- **Parity tests** (the core of the PR): one synthetic event set covering attribute precedence, multi-client sessions, status transitions, byte maxima, running-vs-final duration, IP preference, events occurring after "now", events received before the window opened (partition-pruning margin), and speed tests — pushed through both backends, asserting **byte-identical JSON** for the overview across the 1h/24h/7d windows and for paginated sessions (first/middle/tail/beyond-total pages), plus an empty-window case.
- Postgres-backed tests follow the existing `OPENRUNG_TEST_POSTGRES_URL` skip-guard convention; reworked PR-A tests cover the SQL-backed reader (window-bounded, flush-before-read, cross-instance read-back).
- Full `go test ./internal/broker/` against a real Postgres 16 (including `-race` and `-count=2`), `gofmt`, `go vet`, whole-repo suite.
- Manual smoke test: broker booted with `OPENRUNG_TELEMETRY_STORE=postgres` + dashboard token; login, `/admin/api/telemetry/overview`, and `/admin/api/telemetry/sessions` all served correct SQL-aggregated data for freshly ingested events.

## Out of scope

Retention/partition dropping (PR C), the ingestion API, further write-path changes, anything deploy-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)