### PR TITLE
Broker: drop aged-out telemetry partitions from the maintenance loop (PR C)

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -198,6 +198,23 @@ func splitAndTrim(value string) []string {
 	return out
 }
 
+// pruneTelemetryPartitions drops aged-out telemetry partitions when the sink
+// supports it (the Postgres store); the JSONL sink prunes on write, so this is
+// a no-op for it. Partial progress is logged even when a later drop fails.
+func pruneTelemetryPartitions(telemetry broker.TelemetryReader, now time.Time) {
+	pruner, ok := telemetry.(broker.TelemetryPruner)
+	if !ok {
+		return
+	}
+	dropped, err := pruner.PruneTelemetry(now)
+	for _, name := range dropped {
+		slog.Info("telemetry partition dropped", "partition", name)
+	}
+	if err != nil {
+		slog.Error("could not prune telemetry partitions", "error", err)
+	}
+}
+
 func maintainBroker(store broker.RelayStore, telemetry broker.TelemetryReader, interval time.Duration, logStatus bool) {
 	const activityWindow = 5 * time.Minute
 	ticker := time.NewTicker(interval)
@@ -213,6 +230,7 @@ func maintainBroker(store broker.RelayStore, telemetry broker.TelemetryReader, i
 		for _, desc := range expired {
 			slog.Info("volunteer expired", "relay_id", desc.ID, "last_heartbeat_at", desc.LastHeartbeatAt)
 		}
+		pruneTelemetryPartitions(telemetry, now)
 		if !logStatus {
 			continue
 		}

--- a/internal/broker/postgres_telemetry.go
+++ b/internal/broker/postgres_telemetry.go
@@ -31,16 +31,27 @@ const (
 
 	postgresTelemetryFlushTimeout = 15 * time.Second
 	postgresTelemetryQueryTimeout = 30 * time.Second
+
+	// telemetryPartitionPrefix is the fixed prefix of a daily partition's
+	// table name; the suffix is the UTC day as YYYYMMDD. Both creating a
+	// partition and finding aged-out ones to drop route through it, so the
+	// naming scheme lives in exactly one place.
+	telemetryPartitionPrefix = "telemetry_events_"
 )
+
+// PostgresTelemetrySink drops whole aged-out daily partitions rather than
+// pruning on write, so it satisfies TelemetryPruner for the maintenance loop.
+var _ TelemetryPruner = (*PostgresTelemetrySink)(nil)
 
 // The envelope every query filters or sorts on lives in real columns; the
 // flexible remainder (attributes, measurements, destination, app identity,
 // schema_version) rides in one jsonb payload. Daily partitions on received_at
-// make the future retention job a cheap DROP TABLE instead of a bulk DELETE;
-// partitions themselves are created on demand (see ensurePartition), since
-// CREATE TABLE cannot be templated here. Indexes are defined on the parent so
-// every partition inherits them. Deliberately NO GIN index on payload — the
-// production box is small and nothing queries into the payload yet.
+// make retention a cheap DROP TABLE instead of a bulk DELETE (see
+// PruneTelemetry); partitions themselves are created on demand (see
+// ensurePartition), since CREATE TABLE cannot be templated here. Indexes are
+// defined on the parent so every partition inherits them. Deliberately NO GIN
+// index on payload — the production box is small and nothing queries into the
+// payload yet.
 const postgresTelemetrySchema = `
 CREATE TABLE IF NOT EXISTS telemetry_events (
 	received_at timestamptz NOT NULL,
@@ -421,9 +432,28 @@ func telemetryPartitionDay(at time.Time) time.Time {
 	return at.UTC().Truncate(24 * time.Hour)
 }
 
+func telemetryPartitionName(day time.Time) string {
+	return telemetryPartitionPrefix + telemetryPartitionDay(day).Format("20060102")
+}
+
+// telemetryPartitionNameDay recovers the UTC day a partition covers from its
+// table name, reporting false for any name that is not one of ours (so a
+// hand-created or unrelated child table is never mistaken for a drop target).
+func telemetryPartitionNameDay(name string) (time.Time, bool) {
+	suffix, ok := strings.CutPrefix(name, telemetryPartitionPrefix)
+	if !ok {
+		return time.Time{}, false
+	}
+	day, err := time.ParseInLocation("20060102", suffix, time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return day, true
+}
+
 func (s *PostgresTelemetrySink) ensurePartition(ctx context.Context, at time.Time) error {
 	day := telemetryPartitionDay(at)
-	name := "telemetry_events_" + day.Format("20060102")
+	name := telemetryPartitionName(day)
 
 	s.mu.Lock()
 	_, ensured := s.partitions[name]
@@ -454,6 +484,68 @@ func (s *PostgresTelemetrySink) ensurePartition(ctx context.Context, at time.Tim
 	s.partitions[name] = struct{}{}
 	s.mu.Unlock()
 	return nil
+}
+
+// PruneTelemetry drops the daily partitions whose entire received_at range has
+// aged out of the retention window, reclaiming their storage with a cheap DROP
+// TABLE rather than a bulk DELETE. It returns the names of the partitions it
+// dropped. Today's and any partition still holding a row inside the window are
+// left untouched, so the dashboard's 7-day view and the status-log reader
+// never lose data they would query.
+func (s *PostgresTelemetrySink) PruneTelemetry(now time.Time) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryQueryTimeout)
+	defer cancel()
+
+	// A partition covers [day, day+24h). It is safe to drop once its upper
+	// bound has reached the retention cutoff: every row it can hold is then
+	// strictly older than the window anything ever reads.
+	cutoff := now.UTC().Add(-telemetryRetention)
+	expired, err := s.expiredPartitions(ctx, cutoff)
+	if err != nil {
+		return nil, err
+	}
+
+	var dropped []string
+	for _, name := range expired {
+		// name came from the catalog and matched the daily-partition pattern,
+		// so interpolating it into the DDL is safe (DROP takes no parameters).
+		if _, err := s.pool.Exec(ctx, `DROP TABLE IF EXISTS `+name); err != nil {
+			return dropped, fmt.Errorf("drop telemetry partition %s: %w", name, err)
+		}
+		dropped = append(dropped, name)
+		s.mu.Lock()
+		delete(s.partitions, name)
+		s.mu.Unlock()
+	}
+	return dropped, nil
+}
+
+// expiredPartitions lists the telemetry partitions whose day is fully older
+// than cutoff. It enumerates the catalog rather than the in-process cache so
+// partitions left behind by an earlier broker process are collected too.
+func (s *PostgresTelemetrySink) expiredPartitions(ctx context.Context, cutoff time.Time) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		WHERE i.inhparent = 'telemetry_events'::regclass
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list telemetry partitions: %w", err)
+	}
+	defer rows.Close()
+
+	var expired []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan telemetry partition: %w", err)
+		}
+		if day, ok := telemetryPartitionNameDay(name); ok && !day.Add(24*time.Hour).After(cutoff) {
+			expired = append(expired, name)
+		}
+	}
+	return expired, rows.Err()
 }
 
 func (s *PostgresTelemetrySink) Close() error {

--- a/internal/broker/postgres_telemetry_test.go
+++ b/internal/broker/postgres_telemetry_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -235,6 +237,127 @@ func TestPostgresTelemetrySinkPendingCapDropsOldest(t *testing.T) {
 	}
 }
 
+func TestPostgresTelemetrySinkPruneDropsAgedPartitions(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	sink := newTestPostgresTelemetrySink(t, now)
+	dropAllTelemetryPartitions(t, sink)
+
+	// retention is 7 days, so d8/d10 have aged out while today/d3 have not.
+	records := []TelemetryRecord{
+		validTelemetryRecord(now, "today"),
+		validTelemetryRecord(now.Add(-3*24*time.Hour), "d3"),
+		validTelemetryRecord(now.Add(-8*24*time.Hour), "d8"),
+		validTelemetryRecord(now.Add(-10*24*time.Hour), "d10"),
+	}
+	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatalf("write telemetry: %v", err)
+	}
+	if err := sink.flush(); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
+	if got := countTelemetryRows(t, sink); got != 4 {
+		t.Fatalf("expected 4 rows before prune, got %d", got)
+	}
+
+	dropped, err := sink.PruneTelemetry(now)
+	if err != nil {
+		t.Fatalf("prune telemetry: %v", err)
+	}
+	sort.Strings(dropped)
+	want := []string{"telemetry_events_20260614", "telemetry_events_20260616"}
+	if !slices.Equal(dropped, want) {
+		t.Fatalf("dropped = %v, want %v", dropped, want)
+	}
+	for _, day := range []string{"20260614", "20260616"} {
+		if telemetryPartitionExists(t, sink, day) {
+			t.Fatalf("expected partition %s dropped", day)
+		}
+	}
+	for _, day := range []string{"20260621", "20260624"} {
+		if !telemetryPartitionExists(t, sink, day) {
+			t.Fatalf("expected partition %s kept", day)
+		}
+	}
+	if got := countTelemetryRows(t, sink); got != 2 {
+		t.Fatalf("expected 2 rows after prune, got %d", got)
+	}
+
+	// Dropped partitions must leave the in-process cache so it never reports a
+	// partition that no longer exists.
+	sink.mu.RLock()
+	_, cached := sink.partitions["telemetry_events_20260616"]
+	sink.mu.RUnlock()
+	if cached {
+		t.Fatal("expected dropped partition removed from the cache")
+	}
+
+	// Nothing else has aged out, so a second prune drops nothing.
+	again, err := sink.PruneTelemetry(now)
+	if err != nil {
+		t.Fatalf("second prune: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("expected no further drops, got %v", again)
+	}
+}
+
+func TestPostgresTelemetrySinkPruneBoundaryIsInclusive(t *testing.T) {
+	// Midnight now lands the retention cutoff exactly on a partition boundary.
+	now := time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)
+	sink := newTestPostgresTelemetrySink(t, now)
+	dropAllTelemetryPartitions(t, sink)
+
+	// cutoff = now - 7d = 2026-06-17 00:00. Partition 20260616 spans
+	// [06-16, 06-17): its upper bound equals the cutoff, so every row it can
+	// hold is older than retention and it must be dropped. Partition 20260617
+	// spans [06-17, 06-18): it still overlaps the window, so it must be kept.
+	records := []TelemetryRecord{
+		validTelemetryRecord(time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC), "edge-old"),
+		validTelemetryRecord(time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC), "edge-keep"),
+	}
+	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatalf("write telemetry: %v", err)
+	}
+	if err := sink.flush(); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
+
+	dropped, err := sink.PruneTelemetry(now)
+	if err != nil {
+		t.Fatalf("prune telemetry: %v", err)
+	}
+	if !slices.Equal(dropped, []string{"telemetry_events_20260616"}) {
+		t.Fatalf("dropped = %v, want [telemetry_events_20260616]", dropped)
+	}
+	if telemetryPartitionExists(t, sink, "20260616") {
+		t.Fatal("expected boundary-old partition dropped")
+	}
+	if !telemetryPartitionExists(t, sink, "20260617") {
+		t.Fatal("expected boundary-keep partition retained")
+	}
+}
+
+func TestTelemetryPartitionNameDay(t *testing.T) {
+	day, ok := telemetryPartitionNameDay("telemetry_events_20260624")
+	if !ok || !day.Equal(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("parse valid name: ok=%v day=%s", ok, day)
+	}
+	// A partition name always round-trips through the day helper.
+	if got := telemetryPartitionName(day); got != "telemetry_events_20260624" {
+		t.Fatalf("round-trip name = %q", got)
+	}
+	for _, name := range []string{
+		"telemetry_events",          // the parent table, no day suffix
+		"relay_metrics",             // an unrelated child table
+		"telemetry_events_2026june", // malformed suffix
+		"telemetry_events_",         // empty suffix
+	} {
+		if _, ok := telemetryPartitionNameDay(name); ok {
+			t.Errorf("expected %q to be rejected", name)
+		}
+	}
+}
+
 func validTelemetryRecord(at time.Time, eventID string) TelemetryRecord {
 	return TelemetryRecord{
 		ReceivedAt: at,
@@ -286,6 +409,42 @@ func cleanupPostgresTelemetry(t *testing.T, sink *PostgresTelemetrySink) {
 	sink.mu.Lock()
 	sink.pending = nil
 	sink.pendingBytes = 0
+	sink.mu.Unlock()
+}
+
+// dropAllTelemetryPartitions gives a test a clean partition slate regardless of
+// what earlier tests left in the shared database, keeping the in-process cache
+// in step so subsequent writes recreate partitions on demand.
+func dropAllTelemetryPartitions(t *testing.T, sink *PostgresTelemetrySink) {
+	t.Helper()
+	rows, err := sink.pool.Query(context.Background(), `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		WHERE i.inhparent = 'telemetry_events'::regclass`)
+	if err != nil {
+		t.Fatalf("list telemetry partitions: %v", err)
+	}
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			t.Fatalf("scan telemetry partition: %v", err)
+		}
+		names = append(names, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("list telemetry partitions: %v", err)
+	}
+	for _, name := range names {
+		if _, err := sink.pool.Exec(context.Background(), `DROP TABLE IF EXISTS `+name); err != nil {
+			t.Fatalf("drop telemetry partition %s: %v", name, err)
+		}
+	}
+	sink.mu.Lock()
+	sink.partitions = map[string]struct{}{}
 	sink.mu.Unlock()
 }
 

--- a/internal/broker/telemetry.go
+++ b/internal/broker/telemetry.go
@@ -132,6 +132,15 @@ type TelemetryReader interface {
 	TelemetryRecords(time.Time) []TelemetryRecord
 }
 
+// TelemetryPruner is implemented by telemetry stores whose retention is a
+// distinct reclamation step the broker's maintenance loop drives on its tick.
+// The Postgres store drops daily partitions that have aged out of the window
+// and returns their names; the JSONL sink prunes on write and does not
+// implement this.
+type TelemetryPruner interface {
+	PruneTelemetry(now time.Time) ([]string, error)
+}
+
 // storedTelemetryRecord pairs a record with its encoded JSONL size so the
 // memory and file budgets can be enforced without re-marshalling.
 type storedTelemetryRecord struct {


### PR DESCRIPTION
## What

Final PR of the telemetry storage upgrade (follows #22 and #23). Implements retention for the Postgres telemetry store: the broker's maintenance loop now drops daily `telemetry_events` partitions once they age out of the 7-day window. Before this, `telemetry_events` grew without bound in postgres mode. JSONL mode is untouched (it already prunes on write).

## Design

The daily-partition layout from PR A was chosen so retention is a cheap `DROP TABLE`, not a bulk `DELETE` — this is that payoff.

- **New `TelemetryPruner` interface** (`PruneTelemetry(now) ([]string, error)`), implemented by `PostgresTelemetrySink`. It enumerates the table's partitions from the catalog (`pg_inherits`) rather than the in-process cache, so partitions left behind by an **earlier** broker process get collected too, then drops each partition whose entire `[day, day+24h)` range has passed the cutoff (`now - telemetryRetention`). A partition that still overlaps the window — and today's/tomorrow's — is left alone, so the dashboard's 7-day view and the status-log reader never lose data they'd query. Dropped names are removed from the ensure-partition cache.
- **Boundary rule**: a partition is droppable once its **upper** bound has reached the cutoff, i.e. `day+24h <= now-7d`. At that point every row it can hold is strictly older than anything ever read. The cutoff is inclusive of the exact-boundary partition (upper bound == cutoff) and exclusive of the one that still straddles it.
- **Naming scheme** now lives in one build/parse pair (`telemetryPartitionName` / `telemetryPartitionNameDay`) shared by the create and drop paths; the parser rejects the parent table and any non-conforming child so only our own partitions are ever drop targets. DROP interpolates a catalog-sourced, pattern-matched identifier (DDL takes no bind params) — never client input.
- **Wiring**: `maintainBroker` calls it on the same tick that already prunes expired relays, via a type assertion — so it's a no-op for the JSONL sink and needs no new env var or flag. Each drop is logged (`telemetry partition dropped partition=…`); a mid-run failure still logs partitions already reclaimed and retries the rest next tick.

Deliberately **not** done here: `DETACH CONCURRENTLY` (plain `DROP TABLE` is fine at this box's volume and only ever touches 7+‑day‑old partitions), and any change to the write/read paths or ingestion API.

## Testing

- Postgres-backed tests (existing `OPENRUNG_TEST_POSTGRES_URL` skip-guard convention): aged partitions dropped while recent ones kept, row counts before/after, cache cleanup, idempotent second run, and an inclusive-boundary test at a midnight cutoff. A `dropAllTelemetryPartitions` helper gives each test a hermetic partition slate in the shared DB.
- Postgres-free unit test for the partition-name parser (accepts `telemetry_events_YYYYMMDD`, rejects the parent table, unrelated tables, and malformed suffixes).
- Full `go test ./internal/broker/` against a real Postgres 16 incl. `-race` and `-count=2`; `gofmt`, `go vet`, whole-repo suite.
- **End-to-end smoke test**: booted the broker in postgres mode with a fast maintenance tick, planted a 3-week-old partition with a row via SQL, and confirmed the loop dropped it (logged `telemetry partition dropped partition=telemetry_events_20260620`) within a tick while today's partition survived, zero errors.

## Out of scope

The write/read paths beyond the drop, the ingestion API, and anything deploy-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)