### PR TITLE
Broker: mark admin telemetry API responses no-store

### DIFF
--- a/internal/broker/dashboard.go
+++ b/internal/broker/dashboard.go
@@ -120,8 +120,15 @@ func (d *dashboardServer) logout(w http.ResponseWriter, r *http.Request) {
 
 func (d *dashboardServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Everything behind the admin gate is private and per-request — the
+		// data API recomputes every few seconds — so no browser or shared
+		// cache may store it. Set before dispatch so it covers the authorized
+		// responses too, not just the redirect/401 below. Without this a plain
+		// refresh (and the in-page Refresh button) could re-render a stale
+		// cached response; only a hard reload, which bypasses the cache,
+		// fetched fresh data.
+		w.Header().Set("Cache-Control", "no-store")
 		if !d.authenticated(r) {
-			w.Header().Set("Cache-Control", "no-store")
 			if strings.HasPrefix(r.URL.Path, "/admin/api/") {
 				writeError(w, http.StatusUnauthorized, "dashboard session expired")
 			} else {

--- a/internal/broker/dashboard_test.go
+++ b/internal/broker/dashboard_test.go
@@ -109,6 +109,37 @@ func TestDashboardLoginOverviewAndLogout(t *testing.T) {
 	}
 }
 
+func TestDashboardAPIResponsesSetNoStore(t *testing.T) {
+	store := &dashboardTelemetryStore{}
+	dashboard := newDashboardServer("secret", newTelemetryReaderQuerier(store))
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	dashboard.now = func() time.Time { return now }
+	dashboard.sessions["valid"] = now.Add(time.Hour)
+
+	// The dashboard's data changes every few seconds; a cached API response is
+	// what forced users to hard-reload to see fresh numbers.
+	cases := []struct {
+		name    string
+		path    string
+		handler http.HandlerFunc
+	}{
+		{"overview", "/admin/api/telemetry/overview?window=24h", dashboard.overview},
+		{"sessions", "/admin/api/telemetry/sessions?window=24h", dashboard.listSessions},
+	}
+	for _, tc := range cases {
+		request := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		request.AddCookie(&http.Cookie{Name: dashboardCookieName, Value: "valid"})
+		response := httptest.NewRecorder()
+		dashboard.requireAuth(tc.handler).ServeHTTP(response, request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", tc.name, response.Code)
+		}
+		if got := response.Header().Get("Cache-Control"); got != "no-store" {
+			t.Errorf("%s: Cache-Control = %q, want no-store", tc.name, got)
+		}
+	}
+}
+
 func TestDashboardRejectsExpiredSessionAndInvalidWindow(t *testing.T) {
 	store := &dashboardTelemetryStore{}
 	dashboard := newDashboardServer("secret", newTelemetryReaderQuerier(store))


### PR DESCRIPTION
## What

The admin dashboard's data API (`/admin/api/telemetry/overview` and `/admin/api/telemetry/sessions`) returned JSON with **no `Cache-Control` header**. `requireAuth` now sets `Cache-Control: no-store` before dispatch, so every response behind the admin gate is uncacheable — matching the relay-list endpoint (`/api/v1/relays`), which is likewise per-request and already `no-store`.

## Why (the bug report)

On the dashboard, switching to "Last 24 hours" showed all-zero metrics, and a plain browser refresh / the in-page **Refresh** button didn't fix it — only a hard reload (Cmd/Ctrl-Shift-R) did.

Root cause: with no `Cache-Control` on the responses, the browser cached them. A normal refresh and the in-page button (both `fetch()` with default cache mode) were served the **stale cached copy**; a hard reload bypasses the cache and fetched live data. This became stark right after the broker cut over to the Postgres telemetry store: the telemetry table started empty, the dashboard defaults to the 24h window, and that first empty response stuck in cache — while the three windows, fetched/cached at different moments, showed mismatched snapshots.

Verified on production before the fix:
- `/admin/api/telemetry/overview` returned only `Content-Type: application/json` (no cache headers); `/api/v1/relays` correctly returned `Cache-Control: no-store`.
- The underlying data was always correct and monotonic across windows (e.g. 1h=5, 24h=6, 7d=6 sessions) — this is purely a client-caching bug, not a query bug.

## Testing

- New `TestDashboardAPIResponsesSetNoStore` asserts both the overview and sessions endpoints carry `Cache-Control: no-store` on authenticated 200s (uses the in-memory querier, no Postgres needed).
- Full `go test ./internal/broker/`, `gofmt`, `go vet`, whole-repo build.

## Deploy

Needs a rebuilt broker image (the header is set in Go). Once merged and CI publishes the image, redeploy `typhoon-broker` with the usual command. No config/env change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)