### PR TITLE
Clients: classify and report connection failure reasons

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -133,8 +133,14 @@ func runConnect(args []string) error {
 
 	relayTCPMs, err := tcpReachMs(ctx, connectHost, connectPort)
 	if err != nil {
-		mgr.Record("relay_attempt_failed", selected.ID,
-			map[string]string{"error_type": errorType(err)},
+		attemptAttrs := map[string]string{"error_type": errorType(err)}
+		if reason := clienttelemetry.ClassifyError(err); reason != "" {
+			attemptAttrs["failure_reason"] = reason
+		}
+		if detail := clienttelemetry.ErrorDetail(err); detail != "" {
+			attemptAttrs["failure_detail"] = detail
+		}
+		mgr.Record("relay_attempt_failed", selected.ID, attemptAttrs,
 			map[string]int64{"attempt": 1})
 		recordConnectFailure(ctx, mgr, "relay_connect", selected.ID, err)
 		return fmt.Errorf("relay %s unreachable at %s:%d: %w", selected.ID, connectHost, connectPort, err)
@@ -210,10 +216,17 @@ func sessionIdentity(session *clienttelemetry.Session) (clientID, sessionID stri
 
 // recordConnectFailure emits connection_failed, ends the session, and flushes.
 func recordConnectFailure(ctx context.Context, mgr *clienttelemetry.Manager, stage, relayID string, err error) {
-	mgr.Record("connection_failed", relayID, map[string]string{
+	attrs := map[string]string{
 		"failure_stage": stage,
 		"error_type":    errorType(err),
-	}, nil)
+	}
+	if reason := clienttelemetry.ClassifyError(err); reason != "" {
+		attrs["failure_reason"] = reason
+	}
+	if detail := clienttelemetry.ErrorDetail(err); detail != "" {
+		attrs["failure_detail"] = detail
+	}
+	mgr.Record("connection_failed", relayID, attrs, nil)
 	mgr.EndSession("connection_failed")
 	flushOnShutdown(mgr)
 }

--- a/desktop/discovery/discovery.go
+++ b/desktop/discovery/discovery.go
@@ -48,6 +48,10 @@ func (e *RateLimitedError) Error() string {
 	return fmt.Sprintf("broker %s rate-limited", e.BrokerURL)
 }
 
+// HTTPStatus reports the 429 status so error classification labels a
+// rate-limited fetch as rate_limited without importing this concrete type.
+func (e *RateLimitedError) HTTPStatus() int { return http.StatusTooManyRequests }
+
 // Options identify the caller to the broker. When ClientID and SessionID are
 // both set they are sent as identity headers so the broker records a
 // client_seen telemetry event for the request.
@@ -166,5 +170,5 @@ func brokerStatusError(resp *http.Response) error {
 	if apiErr.Error == "" {
 		apiErr.Error = resp.Status
 	}
-	return fmt.Errorf("broker list relays: %s", apiErr.Error)
+	return &client.BrokerStatusError{StatusCode: resp.StatusCode, Message: apiErr.Error}
 }

--- a/desktop/vpnservice/connect_helpers.go
+++ b/desktop/vpnservice/connect_helpers.go
@@ -2,7 +2,7 @@ package vpnservice
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -14,8 +14,6 @@ import (
 	"openrung/internal/clienttelemetry"
 	"openrung/internal/relay"
 )
-
-var errNoMatchingRelay = errors.New("no usable relay matched the request")
 
 // newManager builds a best-effort telemetry manager (parity with the mobile
 // apps). A nil result means telemetry is unavailable; every call site guards
@@ -66,13 +64,19 @@ func selectRelay(resp relay.ListResponse, targetCountry, targetRelayID string) (
 		now = time.Now()
 	}
 
+	// Distinguish "broker returned nothing" up front from the narrower
+	// no-match cases below, so telemetry can tell them apart.
+	if len(resp.Relays) == 0 {
+		return relay.Descriptor{}, client.ErrNoRelaysAvailable
+	}
+
 	if id := strings.TrimSpace(targetRelayID); id != "" {
 		for _, candidate := range resp.Relays {
 			if candidate.ID == id && client.IsUsableRelay(candidate, now) {
 				return candidate, nil
 			}
 		}
-		return relay.Descriptor{}, errNoMatchingRelay
+		return relay.Descriptor{}, fmt.Errorf("relay %q: %w", id, client.ErrRelayNotInList)
 	}
 
 	if cc := strings.ToUpper(strings.TrimSpace(targetCountry)); cc != "" {
@@ -82,7 +86,7 @@ func selectRelay(resp relay.ListResponse, targetCountry, targetRelayID string) (
 				return candidate, nil
 			}
 		}
-		return relay.Descriptor{}, errNoMatchingRelay
+		return relay.Descriptor{}, fmt.Errorf("country %s: %w", cc, client.ErrNoRelayInCountry)
 	}
 
 	return client.SelectRelayForFamily(resp, client.RelayFamilyAuto)

--- a/desktop/vpnservice/service.go
+++ b/desktop/vpnservice/service.go
@@ -361,7 +361,14 @@ func (s *Service) failConnect(conn *connection, stage string, err error) {
 	s.appendLog("connect failed: " + msg)
 	s.setStatus(StatusFailed, keepLabel, setError(msg))
 	if conn.mgr != nil {
-		conn.mgr.Record("connection_failed", "", map[string]string{"failure_stage": stage}, nil)
+		attrs := map[string]string{"failure_stage": stage}
+		if reason := clienttelemetry.ClassifyError(err); reason != "" {
+			attrs["failure_reason"] = reason
+		}
+		if detail := clienttelemetry.ErrorDetail(err); detail != "" {
+			attrs["failure_detail"] = detail
+		}
+		conn.mgr.Record("connection_failed", "", attrs, nil)
 		conn.mgr.EndSession("connection_failed")
 		flushOnShutdown(conn.mgr)
 	}

--- a/internal/client/broker.go
+++ b/internal/client/broker.go
@@ -131,6 +131,22 @@ func hostIsLoopback(host string) bool {
 	return false
 }
 
+// BrokerStatusError reports a broker non-2xx response and carries the status
+// code so error classification can label it (429 → rate_limited, otherwise
+// http_<code>) without matching on the message string. The discovery fetch path
+// reuses this type for the same reason.
+type BrokerStatusError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *BrokerStatusError) Error() string {
+	return fmt.Sprintf("broker list relays: %s", e.Message)
+}
+
+// HTTPStatus exposes the broker response status for error classification.
+func (e *BrokerStatusError) HTTPStatus() int { return e.StatusCode }
+
 func brokerStatusError(resp *http.Response) error {
 	var apiErr relay.ErrorResponse
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
@@ -141,5 +157,5 @@ func brokerStatusError(resp *http.Response) error {
 	if apiErr.Error == "" {
 		apiErr.Error = resp.Status
 	}
-	return fmt.Errorf("broker list relays: %s", apiErr.Error)
+	return &BrokerStatusError{StatusCode: resp.StatusCode, Message: apiErr.Error}
 }

--- a/internal/client/selector.go
+++ b/internal/client/selector.go
@@ -7,7 +7,14 @@ import (
 	"openrung/internal/relay"
 )
 
-var ErrNoUsableRelay = errors.New("no usable relay")
+// Relay-selection sentinels. Kept in this package (not desktop) so
+// clienttelemetry.ClassifyError can map them without importing a GUI package.
+var (
+	ErrNoUsableRelay     = errors.New("no usable relay")
+	ErrNoRelaysAvailable = errors.New("broker returned no relays")
+	ErrRelayNotInList    = errors.New("target relay not offered by the broker")
+	ErrNoRelayInCountry  = errors.New("no usable relay in the requested country")
+)
 
 type RelayFamily string
 

--- a/internal/clienttelemetry/classify.go
+++ b/internal/clienttelemetry/classify.go
@@ -1,0 +1,147 @@
+package clienttelemetry
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+	"unicode/utf8"
+
+	"openrung/internal/client"
+)
+
+// detailMaxBytes caps failure_detail at the broker's per-attribute value length,
+// so the classifier never emits a value the broker would reject.
+const detailMaxBytes = 256
+
+// httpStatusError is implemented by broker errors that carry an HTTP status
+// code (internal/client.BrokerStatusError, discovery.RateLimitedError). Matching
+// on this interface keeps the classifier free of any fetch-package import.
+type httpStatusError interface {
+	HTTPStatus() int
+}
+
+// ClassifyError maps err to a stable lowercase snake_case failure_reason token.
+// It inspects the whole error chain with typed checks (errors.Is/errors.As); the
+// returned tokens are a fixed enum the iOS/Android clients must mirror. "" for a
+// nil error; "unknown" when nothing matches.
+func ClassifyError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Context outcomes take precedence: a cancelled or timed-out connect can wrap
+	// any lower-level error, and the intent is what the dashboard wants to see.
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "cancelled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	}
+
+	// Relay-selection sentinels (internal/client), distinct so the dashboard can
+	// tell "broker gave nothing" from "none usable" from a bad target id/country.
+	switch {
+	case errors.Is(err, client.ErrNoRelaysAvailable):
+		return "no_relays_available"
+	case errors.Is(err, client.ErrRelayNotInList):
+		return "relay_not_in_list"
+	case errors.Is(err, client.ErrNoRelayInCountry):
+		return "no_relay_in_country"
+	case errors.Is(err, client.ErrNoUsableRelay):
+		return "no_usable_relay"
+	}
+
+	// Broker HTTP status, via the interface so no fetch package is imported.
+	var statusErr httpStatusError
+	if errors.As(err, &statusErr) {
+		if statusErr.HTTPStatus() == http.StatusTooManyRequests {
+			return "rate_limited"
+		}
+		return fmt.Sprintf("http_%d", statusErr.HTTPStatus())
+	}
+
+	// Syscall-level network errors (dial/read failures wrap a syscall.Errno).
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.ECONNREFUSED:
+			return "connection_refused"
+		case syscall.ECONNRESET:
+			return "connection_reset"
+		case syscall.ENETUNREACH, syscall.EHOSTUNREACH:
+			return "network_unreachable"
+		}
+	}
+
+	// DNS resolution failure, before the generic timeout check so a name-lookup
+	// timeout still classifies as dns_failure (the more actionable signal).
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "dns_failure"
+	}
+
+	// TLS: a plaintext/garbled record header, or any certificate rejection.
+	var recordHeaderErr tls.RecordHeaderError
+	if errors.As(err, &recordHeaderErr) {
+		return "tls_handshake"
+	}
+	var (
+		unknownAuthErr x509.UnknownAuthorityError
+		certInvalidErr x509.CertificateInvalidError
+		hostnameErr    x509.HostnameError
+	)
+	if errors.As(err, &unknownAuthErr) ||
+		errors.As(err, &certInvalidErr) ||
+		errors.As(err, &hostnameErr) {
+		return "tls_handshake"
+	}
+
+	// os.ErrPermission also catches EACCES/EPERM via syscall.Errno.Is.
+	if errors.Is(err, os.ErrPermission) {
+		return "permission_denied"
+	}
+
+	// sing-box (or any exec'd tunnel) died on arrival.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return "process_exited"
+	}
+
+	// Generic i/o timeout, after the typed checks above so a refused/reset dial
+	// (Timeout()==false) is never mislabeled.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	if os.IsTimeout(err) {
+		return "timeout"
+	}
+
+	return "unknown"
+}
+
+// ErrorDetail returns err.Error() truncated to at most detailMaxBytes, on a
+// UTF-8 rune boundary so the broker never sees an invalid attribute value. "" for
+// a nil error.
+func ErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if len(msg) <= detailMaxBytes {
+		return msg
+	}
+	truncated := msg[:detailMaxBytes]
+	// Drop a trailing partial rune left by the byte-length cut.
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
+}

--- a/internal/clienttelemetry/classify_test.go
+++ b/internal/clienttelemetry/classify_test.go
@@ -1,0 +1,141 @@
+package clienttelemetry
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"unicode/utf8"
+
+	"openrung/internal/client"
+)
+
+// statusStub is an error carrying an HTTP status, mirroring what the broker
+// fetch paths return (BrokerStatusError / RateLimitedError).
+type statusStub struct{ code int }
+
+func (s statusStub) Error() string   { return fmt.Sprintf("broker status %d", s.code) }
+func (s statusStub) HTTPStatus() int { return s.code }
+
+// timeoutStub is a net.Error reporting a timeout without any underlying errno.
+type timeoutStub struct{}
+
+func (timeoutStub) Error() string   { return "i/o timeout" }
+func (timeoutStub) Timeout() bool   { return true }
+func (timeoutStub) Temporary() bool { return false }
+
+func exitError(t *testing.T) *exec.ExitError {
+	t.Helper()
+	// `false` exits non-zero, yielding an *exec.ExitError from Run.
+	err := exec.Command("false").Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Skipf("could not produce *exec.ExitError: %v", err)
+	}
+	return exitErr
+}
+
+func TestClassifyError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"cancelled", context.Canceled, "cancelled"},
+		{"cancelled_wrapped", fmt.Errorf("connect: %w", context.Canceled), "cancelled"},
+		{"deadline", context.DeadlineExceeded, "timeout"},
+		{"no_relays_available", client.ErrNoRelaysAvailable, "no_relays_available"},
+		{"relay_not_in_list", fmt.Errorf("relay %q: %w", "x", client.ErrRelayNotInList), "relay_not_in_list"},
+		{"no_relay_in_country", fmt.Errorf("country US: %w", client.ErrNoRelayInCountry), "no_relay_in_country"},
+		{"no_usable_relay", client.ErrNoUsableRelay, "no_usable_relay"},
+		{"rate_limited", statusStub{code: 429}, "rate_limited"},
+		{"http_503", statusStub{code: 503}, "http_503"},
+		{"http_wrapped", fmt.Errorf("fetch: %w", statusStub{code: 500}), "http_500"},
+		{"connection_refused", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), "connection_refused"},
+		{"connection_reset", fmt.Errorf("read: %w", syscall.ECONNRESET), "connection_reset"},
+		{"network_unreachable_net", fmt.Errorf("dial: %w", syscall.ENETUNREACH), "network_unreachable"},
+		{"network_unreachable_host", fmt.Errorf("dial: %w", syscall.EHOSTUNREACH), "network_unreachable"},
+		{
+			"connection_refused_syscallerror",
+			&os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+			"connection_refused",
+		},
+		{
+			"connection_refused_opError",
+			&net.OpError{Op: "dial", Net: "tcp", Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}},
+			"connection_refused",
+		},
+		{"dns_failure", &net.DNSError{Err: "no such host", Name: "broker"}, "dns_failure"},
+		{"dns_failure_urlwrapped", &url.Error{Op: "Get", URL: "https://b", Err: &net.DNSError{Err: "nxdomain"}}, "dns_failure"},
+		{"tls_record_header", tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}, "tls_handshake"},
+		{"tls_unknown_authority", x509.UnknownAuthorityError{}, "tls_handshake"},
+		{"tls_hostname", x509.HostnameError{Host: "broker"}, "tls_handshake"},
+		{"tls_cert_invalid", x509.CertificateInvalidError{Reason: x509.Expired}, "tls_handshake"},
+		{"permission_denied", os.ErrPermission, "permission_denied"},
+		{"permission_denied_eacces", fmt.Errorf("open: %w", syscall.EACCES), "permission_denied"},
+		{"timeout_net", timeoutStub{}, "timeout"},
+		{"timeout_net_wrapped", fmt.Errorf("dial: %w", timeoutStub{}), "timeout"},
+		{"unknown", errors.New("something odd"), "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyError(tc.err); got != tc.want {
+				t.Fatalf("ClassifyError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("process_exited", func(t *testing.T) {
+		if got := ClassifyError(fmt.Errorf("sing-box exited: %w", exitError(t))); got != "process_exited" {
+			t.Fatalf("process_exited: got %q", got)
+		}
+	})
+}
+
+func TestErrorDetail(t *testing.T) {
+	if got := ErrorDetail(nil); got != "" {
+		t.Fatalf("nil detail = %q, want empty", got)
+	}
+
+	short := errors.New("boom")
+	if got := ErrorDetail(short); got != "boom" {
+		t.Fatalf("short detail = %q", got)
+	}
+
+	// Exactly at the cap: preserved verbatim.
+	exact := errors.New(strings.Repeat("a", detailMaxBytes))
+	if got := ErrorDetail(exact); len(got) != detailMaxBytes || got != strings.Repeat("a", detailMaxBytes) {
+		t.Fatalf("exact detail len = %d, want %d", len(got), detailMaxBytes)
+	}
+
+	// Over the cap (ASCII): truncated to the cap.
+	long := errors.New(strings.Repeat("b", detailMaxBytes+50))
+	if got := ErrorDetail(long); len(got) != detailMaxBytes {
+		t.Fatalf("long detail len = %d, want %d", len(got), detailMaxBytes)
+	}
+
+	// Multi-byte runes straddling the cap: never split a rune.
+	multi := errors.New(strings.Repeat("界", detailMaxBytes)) // 3 bytes each
+	got := ErrorDetail(multi)
+	if len(got) > detailMaxBytes {
+		t.Fatalf("multibyte detail len = %d, exceeds cap %d", len(got), detailMaxBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("multibyte detail is not valid UTF-8: %q", got)
+	}
+	// The cap (256) is not a multiple of 3, so a naive cut would leave a partial
+	// rune; the trimmed result must be the largest whole-rune prefix that fits.
+	if want := strings.Repeat("界", detailMaxBytes/3); got != want {
+		t.Fatalf("multibyte detail = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Phase 2 of the failure-diagnostics work. [PR #26](https://github.com/openrung/openrung/pull/26) taught the broker dashboard to surface `failure_reason` / `failure_detail` attributes on `connection_failed` and `relay_attempt_failed` events (falling back to `error_type`), but the two Go clients never sent them. This makes them:

- **Shared classifier** (`internal/clienttelemetry/classify.go`): `ClassifyError(err)` maps an error to a stable snake_case reason token via typed `errors.Is`/`errors.As` checks over the whole chain — no string matching. `ErrorDetail(err)` truncates the message to the broker's 256-byte attribute cap on a UTF-8 rune boundary. Ordering is deliberate: context cancel/timeout first, DNS before the generic timeout check, refused/reset before the `net.Error.Timeout()` fallback.
- **Relay selection split**: desktop's `selectRelay` previously collapsed three distinct outcomes into one opaque error — this is the `relay_select · unknown ×14` currently dominating the live dashboard. Now returns distinct sentinels (`no_relays_available` / `relay_not_in_list` / `no_relay_in_country` / `no_usable_relay`), kept in `internal/client` so the classifier maps them without importing a GUI package.
- **Typed HTTP errors**: both broker-fetch paths (`internal/client/broker.go` and `desktop/discovery`) now carry a `BrokerStatusError` exposing `HTTPStatus()`, so non-2xx and 429 responses classify as `http_<code>` / `rate_limited` through an interface check — the classifier stays free of any fetch-package import. This means a client hitting the PR #5 rate limits will now show up on the dashboard as `rate_limited` instead of a mystery failure.
- **Emit sites wired**: desktop `failConnect` and both CLI sites attach `failure_reason` + `failure_detail`, omitting empty values; the CLI keeps `error_type` for continuity.

## Emitted reason enum

`cancelled, timeout, no_relays_available, relay_not_in_list, no_relay_in_country, no_usable_relay, rate_limited, http_<code>, connection_refused, connection_reset, network_unreachable, dns_failure, tls_handshake, permission_denied, process_exited, unknown`

This is the contract the iOS/Android clients (phase 3) must mirror. Treat `http_*` as a prefix pattern, not an enumeration.

## Testing

- New `classify_test.go`: table-driven, covers every branch including wrapped errors (`fmt.Errorf(... %w ...)`, `*url.Error` → `*net.DNSError`, `*os.SyscallError` chains, an `HTTPStatus`-bearing stub) and the multi-byte truncation boundary.
- `gofmt -l`, `go vet ./...`, `go build ./...`, `go test ./...` clean on both the root and `desktop/` modules for every touched package.
- Reviewed by a separate adversarial pass: classifier ordering, byte-cap truncation, sentinel wiring, and both emit sites all confirmed correct; zero bugs found.

## Reviewer notes

- The `openrung/desktop` **root** package (`main.go`) does not `go build` without the Wails frontend built first (`//go:embed all:frontend/dist`, a gitignored build artifact). This is pre-existing and untouched by this change; all other desktop packages build and test cleanly.
- `internal/broker` is untouched (server side shipped in #26 and is already deployed to prod).
- Desktop users pick this up only on the next release; `dev` builds get it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)