### PR TITLE
Add Hetzner Cloud provisioning for volunteer relays

### DIFF
--- a/deploy/volunteer/hetzner-up.sh
+++ b/deploy/volunteer/hetzner-up.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Provision an OpenRung volunteer relay on Hetzner Cloud.
+#
+#   deploy/volunteer/hetzner-up.sh [name]
+#
+# If no name is given, a random "adjective-noun" name is generated and used as
+# BOTH the Hetzner server name and the relay label (OPENRUNG_LABEL), so the relay
+# shows up in the broker dashboard under the same friendly name as the box.
+#
+# Requires the `hcloud` CLI with an active context (`hcloud context list`); the
+# API token is read from that context. The SSH public key at
+# ~/.ssh/id_ed25519_openrung.pub is uploaded so the fleet's standard key can
+# reach the box.
+#
+# Overridable via env: OPENRUNG_LOCATION, OPENRUNG_SERVER_TYPE, OPENRUNG_OS_IMAGE,
+# OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_VOLUNTEER_TOKEN,
+# OPENRUNG_SSH_KEY_NAME, OPENRUNG_FIREWALL_NAME.
+set -euo pipefail
+
+LOCATION="${OPENRUNG_LOCATION:-hel1}"          # Helsinki (EU: 20TB included traffic)
+SERVER_TYPE="${OPENRUNG_SERVER_TYPE:-cax11}"   # ARM Ampere, 2 vCPU / 4GB / 40GB
+OS_IMAGE="${OPENRUNG_OS_IMAGE:-ubuntu-24.04}"
+IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-volunteer:main}"  # multi-arch: pulls arm64 on CAX
+# Register against the broker ORIGIN, not the Cloudflare front (broker.openrung.org).
+# That hostname is a Worker front for *client* discovery; its edge serves a Managed
+# Challenge to datacenter IP ranges (incl. Hetzner), which a volunteer's HTTP client
+# cannot solve (403). The origin is plaintext HTTP and takes registrations directly,
+# exactly like the Lightsail fleet (see lightsail-up.sh).
+BROKER_URL="${OPENRUNG_BROKER_URL:-http://54.238.185.205:8080}"
+TOKEN="${OPENRUNG_VOLUNTEER_TOKEN:-}"          # empty = anonymous (origin allows it)
+SSH_KEY_NAME="${OPENRUNG_SSH_KEY_NAME:-openrung}"
+FIREWALL_NAME="${OPENRUNG_FIREWALL_NAME:-openrung-volunteer}"
+
+adjectives=(happy grumpy glorious sleepy brave clever gentle jolly mighty nimble plucky quiet rapid shiny snappy spry sturdy sunny swift witty zesty breezy cosmic dapper eager fuzzy golden hardy lucky merry noble proud quirky rustic silly valiant)
+nouns=(hippo walrus castle otter falcon badger lantern comet maple harbor meadow beacon pebble willow cactus cobra ferret gecko heron ibex jaguar koala lemur marmot narwhal ocelot panther quokka raven salmon tapir urchin viper wombat yak zebra)
+
+NAME="${1:-${adjectives[RANDOM % ${#adjectives[@]}]}-${nouns[RANDOM % ${#nouns[@]}]}}"
+
+echo "Provisioning Hetzner relay '${NAME}' in ${LOCATION} (${SERVER_TYPE}, ${OS_IMAGE})"
+
+# SSH key: upload the fleet's standard public key so the box is reachable with it.
+# Idempotent — ignore "key already exists / name in use".
+SSH_PUBKEY_FILE="${OPENRUNG_SSH_PUBKEY_FILE:-$HOME/.ssh/id_ed25519_openrung.pub}"
+if [ -f "$SSH_PUBKEY_FILE" ]; then
+  hcloud ssh-key create --name "$SSH_KEY_NAME" --public-key-from-file "$SSH_PUBKEY_FILE" >/dev/null 2>&1 || true
+else
+  echo "warning: $SSH_PUBKEY_FILE not found — creating server without an SSH key" >&2
+  SSH_KEY_NAME=""
+fi
+
+# Firewall: default-deny inbound, allow SSH (22), the relay's public port (443),
+# and ICMP, over both IPv4 and IPv6. Create once, then reuse. Rule adds are
+# idempotent (a duplicate rule is a no-op error we swallow).
+if ! hcloud firewall describe "$FIREWALL_NAME" >/dev/null 2>&1; then
+  hcloud firewall create --name "$FIREWALL_NAME" >/dev/null
+fi
+hcloud firewall add-rule "$FIREWALL_NAME" --direction in --protocol tcp  --port 22  --source-ips 0.0.0.0/0 --source-ips ::/0 >/dev/null 2>&1 || true
+hcloud firewall add-rule "$FIREWALL_NAME" --direction in --protocol tcp  --port 443 --source-ips 0.0.0.0/0 --source-ips ::/0 >/dev/null 2>&1 || true
+hcloud firewall add-rule "$FIREWALL_NAME" --direction in --protocol icmp             --source-ips 0.0.0.0/0 --source-ips ::/0 >/dev/null 2>&1 || true
+
+# Cloud-init user-data: install Docker, pull the public image, run the relay. The
+# public IP is not known until the server exists, so the box self-discovers it
+# from Hetzner's metadata service at boot and bakes it into OPENRUNG_PUBLIC_HOST.
+# Inline fragment (not its own line): an empty optional line would land mid
+# backslash-continuation and terminate `docker run` before the image argument.
+TOKEN_INLINE=""
+if [ -n "$TOKEN" ]; then TOKEN_INLINE="-e OPENRUNG_VOLUNTEER_TOKEN=${TOKEN} "; fi
+
+USERDATA_FILE="$(mktemp)"
+trap 'rm -f "$USERDATA_FILE"' EXIT
+cat >"$USERDATA_FILE" <<EOF
+#!/bin/bash
+set -eux
+exec > /var/log/openrung-init.log 2>&1
+export DEBIAN_FRONTEND=noninteractive
+# DPkg::Lock::Timeout waits for cloud-init's own apt activity to release the lock.
+apt-get -o DPkg::Lock::Timeout=300 update
+apt-get -o DPkg::Lock::Timeout=300 install -y docker.io curl
+systemctl enable --now docker
+# Public IPv4 from the Hetzner metadata service; clients reach the relay here.
+PUBLIC_IP="\$(curl -fsS http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
+docker pull ${IMAGE}
+docker rm -f openrung-volunteer 2>/dev/null || true
+docker run -d --name openrung-volunteer --restart unless-stopped \\
+  --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\
+  -e OPENRUNG_BROKER_URL=${BROKER_URL} \\
+  -e OPENRUNG_PUBLIC_HOST="\$PUBLIC_IP" \\
+  -e OPENRUNG_LISTEN_HOST=0.0.0.0 \\
+  -e OPENRUNG_LABEL=${NAME} ${TOKEN_INLINE}\\
+  ${IMAGE}
+EOF
+
+SSH_ARG=()
+if [ -n "$SSH_KEY_NAME" ]; then SSH_ARG=(--ssh-key "$SSH_KEY_NAME"); fi
+
+hcloud server create \
+  --name "$NAME" \
+  --type "$SERVER_TYPE" \
+  --image "$OS_IMAGE" \
+  --location "$LOCATION" \
+  --firewall "$FIREWALL_NAME" \
+  --label openrung=volunteer \
+  "${SSH_ARG[@]}" \
+  --user-data-from-file "$USERDATA_FILE" >/dev/null
+
+PUBLIC_IP="$(hcloud server ip "$NAME")"
+
+echo "Done. '${NAME}' is at ${PUBLIC_IP}:443 and registers with ${BROKER_URL} after boot (~2-3 min)."
+echo "  logs:  ssh -i ~/.ssh/id_ed25519_openrung root@${PUBLIC_IP} 'tail -f /var/log/openrung-init.log'"
+echo "OPENRUNG_RELAY name=${NAME} ip=${PUBLIC_IP}"


### PR DESCRIPTION
## Summary
- Adds `deploy/volunteer/hetzner-up.sh`, the Hetzner Cloud analog of `lightsail-up.sh` — one command to stand up a volunteer relay via the `hcloud` CLI.
- Creates/reuses the fleet SSH key and a `openrung-volunteer` firewall (22/443/ICMP over IPv4+IPv6), then boots a box whose cloud-init installs Docker, pulls `ghcr.io/openrung/openrung-volunteer:main`, and runs it with the public IP self-discovered from Hetzner's metadata service.
- Registers against the broker **origin** (`http://54.238.185.205:8080`), not the Cloudflare-fronted `broker.openrung.org` — that hostname serves a Managed Challenge to datacenter IP ranges (Hetzner included), which returns 403 to a volunteer's HTTP client. Matches how the existing Lightsail fleet registers.
- Defaults to CAX11 (ARM)/hel1 (20TB included EU traffic); CAX11 is currently out of stock fleet-wide, so `OPENRUNG_SERVER_TYPE=cpx12` is a documented in-stock x86 fallback.

## Test plan
- [x] Deployed live on hel1/cpx12 (`eager-raven`) — registered and heartbeating in the broker directory.
- [x] Deployed live on nbg1/cpx12 (`cosmic-otter`), including a dual-stack → strip-IPv4 flow to confirm registration works over the broker's IPv6 as well.
- [x] `bash -n` syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)