### PR TITLE
Ignore Claude agents directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ openrung-telemetry.jsonl
 .wrangler/
 
 # Claude Code local worktrees (may contain absolute paths / local branch content)
+.claude/agents/
 .claude/worktrees/


### PR DESCRIPTION
## Summary
- Add .claude/agents/ to .gitignore so local Claude agent definitions do not appear as untracked files.

## Verification
- git check-ignore -v .claude/agents/opus-worker.md