### PR TITLE
Point website desktop download links at latest GitHub release

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1527,15 +1527,15 @@
                 <svg aria-hidden="true"><use href="#dl-arrow"/></svg>
                 <span data-i18n="downloadAndroid">Download for Android (APK)</span>
               </a>
-              <a class="button ghost" href="https://github.com/openrung/openrung/releases/download/v0.1.0/OpenRung-macos-arm64.zip">
+              <a class="button ghost" href="https://github.com/openrung/openrung/releases/latest/download/OpenRung-macos-arm64.zip">
                 <svg aria-hidden="true"><use href="#dl-arrow"/></svg>
                 <span data-i18n="downloadMac">macOS (Apple Silicon)</span>
               </a>
-              <a class="button ghost" href="https://github.com/openrung/openrung/releases/download/v0.1.0/OpenRung-windows-amd64.zip">
+              <a class="button ghost" href="https://github.com/openrung/openrung/releases/latest/download/OpenRung-windows-amd64.zip">
                 <svg aria-hidden="true"><use href="#dl-arrow"/></svg>
                 <span data-i18n="downloadWindows">Windows (x64)</span>
               </a>
-              <a class="button ghost" href="https://github.com/openrung/openrung/releases/download/v0.1.0/OpenRung-linux-x86_64.tar.gz">
+              <a class="button ghost" href="https://github.com/openrung/openrung/releases/latest/download/OpenRung-linux-x86_64.tar.gz">
                 <svg aria-hidden="true"><use href="#dl-arrow"/></svg>
                 <span data-i18n="downloadLinux">Linux (x64)</span>
               </a>


### PR DESCRIPTION
## What

The macOS, Windows, and Linux download buttons in `docs/index.html` were hardcoded to the `v0.1.0` release URL. Switch them to GitHub's permanent `/releases/latest/download/` redirect so they always resolve to the newest desktop release.

```
releases/download/v0.1.0/OpenRung-macos-arm64.zip
        ↓
releases/latest/download/OpenRung-macos-arm64.zip
```

(same for Windows and Linux)

## Why

Previously every desktop release required a manual edit to the website to bump the pinned version. This removes that maintenance step — the Android APK link already used this pattern, so this brings the three desktop links in line.

## How it works

`https://github.com/openrung/openrung/releases/latest/download/<asset>` is a GitHub-served redirect that always points at the asset of that exact filename on whatever release is currently marked "Latest." The [`desktop-release`](.github/workflows/desktop-release.yml) workflow produces version-independent asset names — `OpenRung-macos-arm64.zip`, `OpenRung-windows-amd64.zip`, `OpenRung-linux-x86_64.tar.gz` — so the filenames stay stable release to release and the redirect keeps working with no site changes.

## Reviewer notes

- Two invariants keep this working: (1) don't rename the release assets in the workflow without updating the hrefs, and (2) new desktop releases must be published as normal (not pre-release/draft) so GitHub marks them "Latest." `softprops/action-gh-release` already does this by default for `v*` tags.
- The Android version badge text (`Android version 0.1.4`) is a static, Android-specific label and is intentionally left unchanged.