### PR TITLE
Fix stale broker-proxy README and ready multi-front discovery list

### DIFF
--- a/deploy/broker-proxy/README.md
+++ b/deploy/broker-proxy/README.md
@@ -10,9 +10,13 @@ China client ──HTTPS──► Cloudflare edge ──Worker──HTTP:8080─
 
 - The broker is a stateless JSON control-plane API; the Worker just forwards bytes and forces
   no-caching (relay candidates are short-lived).
-- The raw origin IP remains in the apps' broker fallback list
-  (`AppConfig.DEFAULT_BROKER_URLS` / `AppConfig.defaultBrokerURLs`), so a blocked edge degrades to
-  the direct IP rather than failing.
+- This Cloudflare front is currently the **only** discovery endpoint the apps ship: every client's
+  `DEFAULT_BROKER_URLS` / `defaultBrokerURLs` contains just this one HTTPS URL. There is **no raw-IP
+  fallback** — the relay list is unsigned, so the clients refuse any non-HTTPS broker URL
+  (`EnforceSecureBrokerURL`); a bare-IP/plaintext entry would let an on-path censor inject a
+  malicious relay set. A blocked edge therefore fails discovery **closed** (offline). That single
+  point of failure is what the front-diversity work (multiple HTTPS fronts across independent
+  CDNs/domains) and relay-list signing are meant to remove.
 
 ## Origin must be a hostname, not an IP (important)
 
@@ -58,5 +62,8 @@ Logs: `wrangler tail openrung-broker-proxy`.
   is open — low stakes for `client_seen` analytics; close it off with Authenticated Origin Pulls or a
   shared-secret header if that ever matters.
 - **SNI blocking.** A determined censor can SNI-block `broker.openrung.org` specifically (classic
-  domain fronting is dead). This raises cost (the hostname must be discovered first, and the
-  fallback IP still works) but is not absolute. Encrypted Client Hello (ECH) is a future lever.
+  domain fronting is dead). Because this is currently the only front and there is no raw-IP fallback
+  (see above), an SNI block takes discovery fully offline. Mitigations, in order of leverage:
+  additional HTTPS fronts on other CDNs/domains (so one SNI rule no longer suffices), Encrypted
+  Client Hello (ECH) to hide the SNI, and — to unlock non-TLS / out-of-band channels — signing the
+  relay list so a fetched directory is trustworthy regardless of the channel that carried it.

--- a/desktop/config/config.go
+++ b/desktop/config/config.go
@@ -41,13 +41,28 @@ const (
 	MinDirectoryRefreshInterval = 30 * time.Second
 )
 
-// DefaultBrokerURLs are the ordered discovery candidates. HTTPS only: discovery
-// runs BEFORE the tunnel, so a cleartext bare-IP fallback would let an on-path
-// censor read or rewrite the relay list — and observe the client identity
-// headers — exactly the adversary this tool exists to defeat. A pinned bare-IP
-// HTTPS fallback for a blocked edge can be added later.
+// DefaultBrokerURLs are the ordered discovery candidates, tried in order until
+// one returns relays (see discovery.FirstReachable).
+//
+// Every entry MUST be HTTPS. The relay list is not yet signed, so it is
+// authenticated only by the TLS certificate of the host that serves it; a
+// cleartext or bare-IP entry would let an on-path censor read or rewrite the
+// relay list — and observe the client identity headers — exactly the adversary
+// this tool exists to defeat (EnforceSecureBrokerURL rejects non-HTTPS hosts).
+//
+// Only one front is deployed today, so a censor who blocks broker.openrung.org
+// fails discovery CLOSED (offline). Closing that single point of failure is the
+// front-diversity resilience layer: adding more *HTTPS* fronts on independent
+// CDNs/domains is safe right now (still TLS-authenticated) and just needs the
+// extra fronts stood up — see deploy/broker-proxy. Non-TLS or out-of-band
+// channels (raw IP, cached/gossiped blobs) stay OFF this list until the broker
+// signs the relay list. Keep this list in sync with the mobile clients'
+// AppConfig so every client discovers identically.
 var DefaultBrokerURLs = []string{
 	"https://broker.openrung.org/",
+	// Additional HTTPS fronts go here once deployed, e.g. a second CDN or domain:
+	//   "https://broker2.openrung.org/",          // EXAMPLE — second domain
+	//   "https://openrung-broker.<other-cdn>/",   // EXAMPLE — second CDN provider
 }
 
 // BrokerCandidates returns the ordered, de-duplicated discovery candidates for


### PR DESCRIPTION
## What & why

Groundwork for the **broker front-diversity resilience layer** — reducing the single-point-of-failure where blocking one Cloudflare-fronted domain (`broker.openrung.org`) takes relay discovery fully offline for all clients.

Two changes, both low-risk:

### 1. Fix a stale/false claim in the broker-proxy README
`deploy/broker-proxy/README.md` claimed the apps keep the raw origin IP in their broker fallback list, so *"a blocked edge degrades to the direct IP rather than failing"* — and that during SNI blocking *"the fallback IP still works."*

That is **false**. The raw-IP fallback was removed, and the clients now refuse any non-HTTPS broker URL via `EnforceSecureBrokerURL` (the relay list is unsigned, so it must be TLS-authenticated). A blocked edge actually fails discovery **closed** (offline). The stale note advertised resilience the code does not have — dangerous because a reader believes the network is resilient when it is one SNI rule from total discovery failure.

Both spots are corrected to describe the real single point of failure and the two fixes that remove it: additional HTTPS fronts, and relay-list signing.

### 2. Ready `DefaultBrokerURLs` for multiple HTTPS fronts
`desktop/config/config.go` — restructure the candidate array for multiple entries with a one-uncomment-away slot, and replace the "deliberately no fallback" rationale with the accurate rule:

- Additional **HTTPS-authenticated** fronts (second CDN, second domain) are safe to add **now** — still TLS-verified, so no injection risk.
- **Non-TLS / out-of-band** channels (raw IP, cached/gossiped blobs) stay off the list until the broker signs the relay list.

## Behavior

**Unchanged.** The active candidate list is still the single working Cloudflare front — no dead endpoint is introduced, no runtime behavior changes. This is a docs + structure/comment change that makes activating multi-front a one-line uncomment once alternate fronts are deployed.

## Verification

- `gofmt -l`, `go vet ./config/`, `go build ./config/` — clean
- `go test ./config/` — passes

## Reviewer notes

- **Companion PR needed.** The parallel `AppConfig` changes for the iOS / Android / React Native clients (`defaultBrokerURLs` / `DEFAULT_BROKER_URLS`) live in the separate **`openrung-mobile-app`** repo and are staged there; they need their own PR so all four clients stay in sync.
- **Follow-up (keystone):** relay-list signing — broker signs `ListResponse` (add `signature` + `not_after` to `internal/relay/types.go`), clients verify a pinned key. That unlocks the non-TLS channels referenced here. Decision already taken: on-broker online signing key.
- Actually deploying alternate fronts (a second domain and/or a second CDN in front of the same origin) is an infra task, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)