### PR TITLE
Raise telemetry dashboard work_mem to keep aggregation in memory

### DIFF
--- a/internal/broker/postgres_telemetry.go
+++ b/internal/broker/postgres_telemetry.go
@@ -32,6 +32,11 @@ const (
 	postgresTelemetryFlushTimeout = 15 * time.Second
 	postgresTelemetryQueryTimeout = 30 * time.Second
 
+	// telemetryDashboardWorkMem is the per-connection work_mem for the telemetry
+	// pool, raised from the 4MB default so the dashboard's aggregation sorts stay
+	// in memory instead of spilling to disk (see newPostgresTelemetrySink).
+	telemetryDashboardWorkMem = "32MB"
+
 	// telemetryPartitionPrefix is the fixed prefix of a daily partition's
 	// table name; the suffix is the UTC day as YYYYMMDD. Both creating a
 	// partition and finding aged-out ones to drop route through it, so the
@@ -125,7 +130,19 @@ func newPostgresTelemetrySink(ctx context.Context, databaseURL string, now func(
 	if strings.TrimSpace(databaseURL) == "" {
 		return nil, errors.New("telemetry database URL is required")
 	}
-	pool, err := pgxpool.New(ctx, databaseURL)
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse telemetry database URL: %w", err)
+	}
+	// The dashboard aggregation sorts a lot: the sessions CTE runs ~15
+	// array_agg(... ORDER BY ...) per session group and the window's CTEs
+	// materialize, both of which spill to disk at the stock 4MB work_mem and
+	// dominate the multi-second query time. Raise it pool-wide — the insert
+	// path never sorts, so it consumes none of this, and dashboard concurrency
+	// is tiny (one admin, a 30s refresh), so the extra memory ceiling is safe
+	// on the small production box.
+	config.ConnConfig.RuntimeParams["work_mem"] = telemetryDashboardWorkMem
+	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("open telemetry database: %w", err)
 	}


### PR DESCRIPTION
## Motivation

Follow-up to #33. After that PR merged the dashboard's 9 SQL statements down to 3 and was deployed to prod (image `sha-12a3289`), the endpoints improved but plateaued at a multi-second floor: overview 24h ~9.4s → ~4.9s, but the **sessions endpoint did not move** (~4.4s → ~4.5s). Measured on the production Lightsail box (2 vCPU, Postgres + broker co-resident, ~362 sessions/24h).

The floor is a single evaluation of the `events`+`sessions` CTEs, which is **sort-heavy**: the sessions CTE runs ~15 `array_agg(... ORDER BY received_at DESC, occurred_at DESC)` per session group, and the window's multiply-referenced CTEs materialize. At the stock **4MB** `work_mem`, those sorts and materializations spill to disk, which dominates the query time.

## Change

Set `work_mem` to **32MB** on the telemetry connection pool via pgx `RuntimeParams` (one place, in `newPostgresTelemetrySink`). No schema change, no query change.

- Applies pool-wide, but the insert path never sorts, so it consumes none of it.
- Dashboard concurrency is tiny (one admin, a 30s auto-refresh), so the higher per-connection ceiling is safe on the 1.9GB production box.

## Verification

- `go build ./...`, `go vet ./internal/broker/`, gofmt: clean.
- Postgres-backed tests (`-run 'Postgres|Telemetry|Dashboard'`) pass against a disposable `postgres:16` container (no CI coverage for these — local Docker is the verification path).
- Confirmed end-to-end against real Postgres 16 that `SHOW work_mem` returns `32MB` on a pooled connection using this exact `ParseConfig` + `RuntimeParams` path.

Expected impact is a partial reduction (in-memory sorts instead of disk spills); the durable win for getting well under a second is still promoting the hot JSONB payload fields to real columns, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)