### PR TITLE
Add scheduled uptime monitoring for broker front and origin

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,114 @@
+name: uptime
+
+# External uptime monitoring for the OpenRung broker, probed from
+# GitHub-hosted runners.
+#
+# Vantage point caveat: runners sit in ordinary datacenter networks (an
+# UNCENSORED vantage). A green run proves the endpoints are *available*;
+# it does NOT prove they are reachable from censored networks.
+#
+# Notifications: when a run fails, GitHub emails the workflow author
+# (Actions failure notifications). No extra alerting wiring is required.
+#
+# Note: GitHub disables cron schedules on public repos after ~60 days
+# without repo activity; any push re-enables them.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Probe broker endpoints
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ------------------------------------------------------------------
+          # Endpoint inventory. Adding a front or origin is a one-line change.
+          # ------------------------------------------------------------------
+
+          # CDN fronts: each gets a /healthz check plus a relay-list freshness
+          # check (catches the stale-on-error worker being engaged and any
+          # CDN-cache staleness regression like the 2026-07-06 incident).
+          FRONTS=(
+            "https://broker.openrung.org"
+            # "https://dXXXXXXXXXXXXXX.cloudfront.net"  # upcoming independent CloudFront front
+          )
+
+          # Origins: direct broker endpoints, bypassing the CDN. /healthz only.
+          ORIGINS=(
+            "http://broker-origin.openrung.org:8080"
+          )
+
+          # Relay-list freshness budget: |runner time - server_time| in seconds.
+          MAX_SKEW_SECONDS=600
+
+          # Retries absorb single network hiccups so one blip does not page.
+          CURL_OPTS=(--silent --show-error --max-time 15 --retry 2 --retry-delay 5 --retry-all-errors)
+
+          fail=0
+
+          probe_health() {
+            local base=$1 code
+            code=$(curl "${CURL_OPTS[@]}" -o /dev/null -w '%{http_code}' "$base/healthz") || code=000
+            if [[ "$code" == "200" ]]; then
+              echo "ok    $base/healthz -> 200"
+            else
+              echo "FAIL  $base/healthz -> HTTP $code (expected 200)"
+              fail=1
+            fi
+          }
+
+          probe_relays_fresh() {
+            local base=$1 hdrs body code server_time skew
+            hdrs=$(mktemp)
+            body=$(mktemp)
+            code=$(curl "${CURL_OPTS[@]}" -D "$hdrs" -o "$body" -w '%{http_code}' "$base/api/v1/relays?limit=1") || code=000
+            if [[ "$code" != "200" ]]; then
+              echo "FAIL  $base/api/v1/relays -> HTTP $code (expected 200)"
+              fail=1
+              return
+            fi
+            if grep -qi '^x-openrung-stale:' "$hdrs"; then
+              echo "FAIL  $base/api/v1/relays served stale data (X-OpenRung-Stale header present)"
+              fail=1
+              return
+            fi
+            server_time=$(jq -r '.server_time // empty' "$body")
+            if ! skew=$(jq -rn --arg st "$server_time" --argjson now "$(date +%s)" '
+                  ($st | sub("\\.[0-9]+"; "") | fromdateiso8601) as $s
+                  | ($now - $s) | if . < 0 then -. else . end' 2>/dev/null); then
+              echo "FAIL  $base/api/v1/relays -> unparseable server_time '${server_time:-<missing>}'"
+              fail=1
+              return
+            fi
+            if (( skew > MAX_SKEW_SECONDS )); then
+              echo "FAIL  $base/api/v1/relays -> server_time skew ${skew}s exceeds ${MAX_SKEW_SECONDS}s (stale relay list)"
+              fail=1
+              return
+            fi
+            echo "ok    $base/api/v1/relays -> 200, fresh (skew ${skew}s, no stale header)"
+          }
+
+          for base in "${FRONTS[@]}"; do
+            probe_health "$base"
+            probe_relays_fresh "$base"
+          done
+
+          for base in "${ORIGINS[@]}"; do
+            probe_health "$base"
+          done
+
+          if (( fail )); then
+            echo "one or more uptime checks failed"
+            exit 1
+          fi
+          echo "all uptime checks passed"

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -82,7 +82,11 @@ jobs:
               fail=1
               return
             fi
-            server_time=$(jq -r '.server_time // empty' "$body")
+            if ! server_time=$(jq -r '.server_time // empty' "$body" 2>/dev/null); then
+              echo "FAIL  $base/api/v1/relays -> HTTP 200 but body is not valid relay JSON"
+              fail=1
+              return
+            fi
             if ! skew=$(jq -rn --arg st "$server_time" --argjson now "$(date +%s)" '
                   ($st | sub("\\.[0-9]+"; "") | fromdateiso8601) as $s
                   | ($now - $s) | if . < 0 then -. else . end' 2>/dev/null); then


### PR DESCRIPTION
## What & why

The broker had no external monitoring at all — an outage was discovered by users failing to connect. This adds `.github/workflows/uptime.yml`: a scheduled GitHub Actions probe (every 15 min + `workflow_dispatch`) running from GitHub-hosted runners. Free on this public repo.

Three checks, each failing the job (→ failure email to the workflow author):

1. **Front health**: `https://broker.openrung.org/healthz` → 200.
2. **Origin health** (bypasses Cloudflare): `http://broker-origin.openrung.org:8080/healthz` → 200 — distinguishes "front down" from "origin down".
3. **Relay-list freshness through the front**: 200, no `X-OpenRung-Stale` header, and `server_time` within 10 min of runner time — catches both the (upcoming) stale-on-error Worker being engaged for a prolonged period and any CDN-cache staleness regression like the 2026-07-06 incident.

Every curl retries twice with backoff, so a single network hiccup doesn't page. The endpoint list is structured for one-line addition of the CloudFront second front (commented placeholder included). All failure modes route through a structured `FAIL` line — including HTTP-200-but-not-JSON bodies — so a partial failure still runs the remaining probes and prints the summary.

## Verification

- YAML validated with `yaml.safe_load`; the literal run block executed against live prod: all three checks pass, exit 0.
- Fault injection: a local server returning non-JSON 200 produces the structured `FAIL ... body is not valid relay JSON`, remaining probes still run, exit 1 (the pre-fix version aborted mid-script with a raw jq parse error, skipping the origin probe).

## Reviewer notes / known caveats

- **Run `workflow_dispatch` right after merging**: the schedule only activates once the file is on the default branch, and GitHub runners are datacenter (Azure) IPs — per project history Cloudflare 403s datacenter IPs on this zone for volunteer registration, so the front checks need one real-runner smoke test. If they 403, we add a CF WAF skip rule for `GET /healthz` + `GET /api/v1/relays`.
- Monitors from an uncensored vantage: proves availability, not reachability from censored networks.
- GitHub auto-disables cron on public repos after ~60 days without repo activity (noted in the file header).
- Follow-up (relay-list signing spec §8): upgrade to a verifying probe that checks the signature, key_id, and `not_after` margins once the broker signs responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)