### PR TITLE
Serve stale relay list from the edge when the broker origin fails

### DIFF
--- a/deploy/broker-proxy/README.md
+++ b/deploy/broker-proxy/README.md
@@ -8,8 +8,9 @@ single plaintext IP that a one-line ACL can null-route.
 China client ──HTTPS──► Cloudflare edge ──Worker──HTTP:8080──► broker-origin.openrung.org ──► 54.238.185.205
 ```
 
-- The broker is a stateless JSON control-plane API; the Worker just forwards bytes and forces
-  no-caching (relay candidates are short-lived).
+- The broker is a stateless JSON control-plane API; the Worker forwards bytes and never serves
+  cached data on the freshness path (relay candidates are short-lived). The one exception is
+  stale-on-error for relay discovery — see below.
 - This Cloudflare front is currently the **only** discovery endpoint the apps ship: every client's
   `DEFAULT_BROKER_URLS` / `defaultBrokerURLs` contains just this one HTTPS URL. There is **no raw-IP
   fallback** — the relay list is unsigned, so the clients refuse any non-HTTPS broker URL
@@ -26,6 +27,40 @@ Cloudflare error **1003 "Direct IP Access Not Allowed"**, which the Worker passe
 **`broker-origin.openrung.org`**, a **DNS-only (grey-cloud) A record → 54.238.185.205** in the
 zone. It must stay DNS-only; proxying (orange-cloud) it would loop the subrequest back into the
 edge. If you ever change the origin IP, update that DNS record (not the Worker).
+
+## Stale-on-error (`GET /api/v1/relays`)
+
+An origin blip must not take relay discovery down — this front is the only discovery path the
+apps ship. For `GET /api/v1/relays` (exact path) only, the Worker:
+
+- proxies to the origin with a **10 s timeout**;
+- on a **2xx**, returns the origin response to the client unchanged and stores a copy in the
+  colo's Cache API with `Cache-Control: public, s-maxage=180` (the origin's `no-store` still
+  reaches clients; the override applies only to this deliberately stored fallback copy);
+- on **failure** (timeout, network error, or origin ≥ 500), serves that stored copy with
+  **`X-OpenRung-Stale: 1`** and `Cache-Control: no-store`;
+- on failure with a **cold cache**, passes an origin 5xx through, and turns a network error into
+  a JSON `502` (previously the exception surfaced as an opaque Cloudflare error page);
+- passes **4xx through unmasked** — a `429`/`404` is a semantic answer, not an outage.
+
+Notes:
+
+- **The freshness path is unchanged.** Healthy responses always come straight from the origin.
+  The cached copy is written on every success but only ever *read* on failure; no healthy
+  response is served from cache.
+- **Why 180 s.** Relay leases are ~3 min, and all clients validate `expires_at` against the
+  `server_time` carried in the *same* response body — so a stale cached list passes client-side
+  expiry checks self-consistently and clients cannot detect the staleness themselves. The edge
+  must bound it: 180 s keeps a served-stale list within roughly one lease of reality.
+- **Per-colo.** The Cache API is colo-local, so the stale copy exists only in Cloudflare colos
+  that recently served a fresh response. A colo that never saw a healthy response has nothing to
+  fall back on and returns the error as before.
+- Degraded responses are detectable (by clients and in telemetry) via `X-OpenRung-Stale: 1`.
+- All other paths and methods remain untouched passthrough with **no timeout** (the speed-test
+  endpoint is long-lived by design).
+
+Unit tests: `npm test` (Node's built-in runner) from this directory covers the fresh, stale,
+cold-cache, 4xx-unmasked, and passthrough paths with injected fetch/cache fakes.
 
 ## Deploy
 

--- a/deploy/broker-proxy/README.md
+++ b/deploy/broker-proxy/README.md
@@ -34,11 +34,13 @@ An origin blip must not take relay discovery down — this front is the only dis
 apps ship. For `GET /api/v1/relays` (exact path) only, the Worker:
 
 - proxies to the origin with a **10 s timeout**;
-- on a **2xx**, returns the origin response to the client unchanged and stores a copy in the
-  colo's Cache API with `Cache-Control: public, s-maxage=180` (the origin's `no-store` still
-  reaches clients; the override applies only to this deliberately stored fallback copy);
-- on **failure** (timeout, network error, or origin ≥ 500), serves that stored copy with
-  **`X-OpenRung-Stale: 1`** and `Cache-Control: no-store`;
+- on a **200**, returns the origin response to the client unchanged and stores a complete copy —
+  body **and all headers** — in the colo's Cache API with `Cache-Control: public, max-age=900`
+  (the origin's `no-store` still reaches clients; the override applies only to this deliberately
+  stored fallback copy). Only a full `200` is stored: a `206` partial body would poison the
+  fallback, so any other 2xx passes through to the client unchanged but is never cached;
+- on **failure** (timeout, network error, or origin ≥ 500), serves that stored copy — original
+  headers intact — with **`X-OpenRung-Stale: 1`** and `Cache-Control: no-store, no-transform`;
 - on failure with a **cold cache**, passes an origin 5xx through, and turns a network error into
   a JSON `502` (previously the exception surfaced as an opaque Cloudflare error page);
 - passes **4xx through unmasked** — a `429`/`404` is a semantic answer, not an outage.
@@ -48,10 +50,17 @@ Notes:
 - **The freshness path is unchanged.** Healthy responses always come straight from the origin.
   The cached copy is written on every success but only ever *read* on failure; no healthy
   response is served from cache.
-- **Why 180 s.** Relay leases are ~3 min, and all clients validate `expires_at` against the
-  `server_time` carried in the *same* response body — so a stale cached list passes client-side
-  expiry checks self-consistently and clients cannot detect the staleness themselves. The edge
-  must bound it: 180 s keeps a served-stale list within roughly one lease of reality.
+- **Why 900 s (15 min).** All clients validate relay `expires_at` against the `server_time`
+  carried in the *same* response body — a stale cached list passes client-side expiry checks
+  self-consistently, so client-side expiry checks cannot bound edge staleness either way. The
+  bound has to live at the edge, and the relay-list signing spec fixes it: a **15-minute stale
+  window** inside a 30-minute signed `not_after`. The edge cap is 900 s to match.
+- **Signing-ready.** The stored copy preserves *all* origin headers (only `Cache-Control` is
+  overridden and `Set-Cookie` dropped), so the upcoming `X-OpenRung-Relays-Signature` — computed
+  over the exact body bytes — survives a stale serve intact; signature-requiring clients would
+  reject a stale body served without it. The cache key is version-namespaced
+  (`__or_cache_v=1`); bump it to `2` when the signing broker deploys so pre-signing headerless
+  bodies can never replay to signature-requiring clients.
 - **Per-colo.** The Cache API is colo-local, so the stale copy exists only in Cloudflare colos
   that recently served a fresh response. A colo that never saw a healthy response has nothing to
   fall back on and returns the error as before.

--- a/deploy/broker-proxy/package.json
+++ b/deploy/broker-proxy/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "openrung-broker-proxy",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/deploy/broker-proxy/src/handler.js
+++ b/deploy/broker-proxy/src/handler.js
@@ -1,0 +1,138 @@
+// Core request-handling logic for the broker proxy Worker, factored out of src/index.js so it
+// can be unit-tested under Node with injected fetch/cache fakes (see test/handler.test.mjs).
+//
+// Behavior:
+//   - GET /api/v1/relays (exact path): proxied to the origin with a 10 s timeout. Every 2xx
+//     response is returned to the client unchanged AND a copy is stored in this colo's Cache API
+//     for 180 s. If the origin times out, errors at the network layer, or returns >= 500, the
+//     stored copy is served with `X-OpenRung-Stale: 1` instead of the failure. 3xx/4xx responses
+//     (404, 429 back-pressure) are semantic answers and pass through unmasked. A network error
+//     with a cold cache returns a JSON 502 (previously the exception bubbled up as an opaque
+//     Cloudflare error page).
+//   - Everything else: byte-for-byte passthrough with fetch-layer caching disabled and NO
+//     timeout (the speed-test endpoint deliberately holds the connection open).
+
+export const DEFAULT_ORIGIN = "http://broker-origin.openrung.org:8080";
+
+const RELAYS_PATH = "/api/v1/relays";
+const ORIGIN_TIMEOUT_MS = 10_000;
+
+// How long a stale copy may be served after the last healthy response. Relay leases are ~3 min,
+// and every client validates `expires_at` against the `server_time` carried in the SAME response
+// body — so a stale cached list passes client-side expiry checks self-consistently and the
+// client CANNOT detect the staleness. The edge must bound it instead: 180 s keeps a served-stale
+// list within roughly one lease of reality.
+const STALE_TTL_SECONDS = 180;
+
+// Never let Cloudflare's fetch layer cache origin responses. The Cache API copy above is the
+// only cache, and it is only ever READ on origin failure — the freshness path always hits the
+// origin.
+const NO_FETCH_CACHE = { cacheTtl: 0, cacheEverything: false };
+
+// Factory so tests can inject a fake fetch and cache. `fetchImpl(request, init)` must behave
+// like global fetch; `cache` must expose the Cache API's put/match.
+export function createHandler({ fetchImpl, cache }) {
+  return async function handle(request, env, ctx) {
+    const originBase = env && env.ORIGIN ? env.ORIGIN : DEFAULT_ORIGIN;
+    const url = new URL(request.url);
+    const proxied = buildProxiedRequest(request, url, originBase);
+
+    if (request.method === "GET" && url.pathname === RELAYS_PATH) {
+      return relaysWithStaleFallback(proxied, request.url, ctx, fetchImpl, cache);
+    }
+
+    // All other paths/methods: passthrough exactly as before. No timeout — the speed-test
+    // endpoint is long-lived by design.
+    return fetchImpl(proxied, { cf: NO_FETCH_CACHE });
+  };
+}
+
+function buildProxiedRequest(request, url, originBase) {
+  const origin = new URL(originBase);
+  const target = new URL(url);
+
+  // Preserve path + query; swap scheme/host/port to the origin.
+  target.protocol = origin.protocol;
+  target.hostname = origin.hostname;
+  target.port = origin.port;
+
+  const proxied = new Request(target, request);
+
+  // Surface the real client IP to the origin. The broker honors X-Forwarded-For only when the
+  // request arrives from a trusted proxy (Cloudflare egress ranges), so this cannot be spoofed
+  // by direct origin hits.
+  const clientIp = request.headers.get("CF-Connecting-IP");
+  if (clientIp) {
+    proxied.headers.set("X-Forwarded-For", clientIp);
+  }
+  proxied.headers.set("X-Forwarded-Proto", "https");
+
+  return proxied;
+}
+
+async function relaysWithStaleFallback(proxied, requestUrl, ctx, fetchImpl, cache) {
+  // Cache key: a bare GET on the full client URL. Query string included — `limit` etc. vary
+  // the response body.
+  const cacheKey = new Request(requestUrl, { method: "GET" });
+
+  let originResponse = null;
+  try {
+    originResponse = await fetchImpl(proxied, {
+      cf: NO_FETCH_CACHE,
+      signal: AbortSignal.timeout(ORIGIN_TIMEOUT_MS),
+    });
+  } catch {
+    // Network error or 10 s timeout — fall through to the stale path below.
+  }
+
+  if (originResponse !== null && originResponse.ok) {
+    // Healthy: hand the origin response to the client unchanged and stash a copy for later.
+    // The stored copy must override the origin's `no-store` (the Cache API refuses to store a
+    // no-store response) with a hard 180 s cap; it is only ever read on origin failure.
+    const copy = originResponse.clone();
+    const headers = new Headers({
+      "Cache-Control": `public, s-maxage=${STALE_TTL_SECONDS}`,
+    });
+    const contentType = copy.headers.get("Content-Type");
+    if (contentType) {
+      headers.set("Content-Type", contentType);
+    }
+    ctx.waitUntil(cache.put(cacheKey, new Response(copy.body, { status: 200, headers })));
+    return originResponse;
+  }
+
+  if (originResponse !== null && originResponse.status < 500) {
+    // 3xx/4xx are semantic answers (404, 429 back-pressure): never mask them with stale data.
+    return originResponse;
+  }
+
+  // Origin failed (network error, timeout, or 5xx): serve the last healthy list if this colo
+  // still holds one.
+  const cached = await cache.match(cacheKey);
+  if (cached) {
+    const headers = new Headers({
+      "X-OpenRung-Stale": "1",
+      "Cache-Control": "no-store",
+    });
+    const contentType = cached.headers.get("Content-Type");
+    if (contentType) {
+      headers.set("Content-Type", contentType);
+    }
+    return new Response(cached.body, { status: 200, headers });
+  }
+
+  if (originResponse !== null) {
+    // 5xx with a cold cache: nothing better to offer — pass the origin error through.
+    return originResponse;
+  }
+
+  // Network error with a cold cache: return a real JSON 502 instead of letting the exception
+  // surface as an opaque Cloudflare error page.
+  return new Response(JSON.stringify({ error: "broker origin unreachable" }), {
+    status: 502,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/deploy/broker-proxy/src/handler.js
+++ b/deploy/broker-proxy/src/handler.js
@@ -2,13 +2,14 @@
 // can be unit-tested under Node with injected fetch/cache fakes (see test/handler.test.mjs).
 //
 // Behavior:
-//   - GET /api/v1/relays (exact path): proxied to the origin with a 10 s timeout. Every 2xx
-//     response is returned to the client unchanged AND a copy is stored in this colo's Cache API
-//     for 180 s. If the origin times out, errors at the network layer, or returns >= 500, the
-//     stored copy is served with `X-OpenRung-Stale: 1` instead of the failure. 3xx/4xx responses
-//     (404, 429 back-pressure) are semantic answers and pass through unmasked. A network error
-//     with a cold cache returns a JSON 502 (previously the exception bubbled up as an opaque
-//     Cloudflare error page).
+//   - GET /api/v1/relays (exact path): proxied to the origin with a 10 s timeout. A 200 response
+//     is returned to the client unchanged AND a complete copy (body + ALL headers) is stored in
+//     this colo's Cache API for 900 s. If the origin times out, errors at the network layer, or
+//     returns >= 500, the stored copy is served with `X-OpenRung-Stale: 1` instead of the
+//     failure. Non-200 2xx (a 206 partial body would poison the fallback), 3xx, and 4xx
+//     responses (404, 429 back-pressure) are semantic answers and pass through unmasked, never
+//     stored. A network error with a cold cache returns a JSON 502 (previously the exception
+//     bubbled up as an opaque Cloudflare error page).
 //   - Everything else: byte-for-byte passthrough with fetch-layer caching disabled and NO
 //     timeout (the speed-test endpoint deliberately holds the connection open).
 
@@ -17,12 +18,18 @@ export const DEFAULT_ORIGIN = "http://broker-origin.openrung.org:8080";
 const RELAYS_PATH = "/api/v1/relays";
 const ORIGIN_TIMEOUT_MS = 10_000;
 
-// How long a stale copy may be served after the last healthy response. Relay leases are ~3 min,
-// and every client validates `expires_at` against the `server_time` carried in the SAME response
-// body — so a stale cached list passes client-side expiry checks self-consistently and the
-// client CANNOT detect the staleness. The edge must bound it instead: 180 s keeps a served-stale
-// list within roughly one lease of reality.
-const STALE_TTL_SECONDS = 180;
+// How long a stale copy may be served after the last healthy 200. Every client validates relay
+// `expires_at` against the `server_time` carried in the SAME response body, so client-side
+// expiry checks are self-consistent and CANNOT bound edge staleness either way — the bound has
+// to live at the edge. The relay-list signing spec fixes the stale window at 15 minutes inside
+// a 30-minute signed `not_after`, so the edge cap is 900 s to match. Exported so the tests can
+// couple the header value and the TTL bound to this one constant.
+export const STALE_TTL_SECONDS = 900;
+
+// Version namespace for stored fallback copies, appended to the cache-key URL as
+// `__or_cache_v`. Bump to 2 when the signing broker deploys, so pre-signing headerless bodies
+// can never replay to signature-requiring clients.
+const CACHE_KEY_VERSION = "1";
 
 // Never let Cloudflare's fetch layer cache origin responses. The Cache API copy above is the
 // only cache, and it is only ever READ on origin failure — the freshness path always hits the
@@ -71,9 +78,13 @@ function buildProxiedRequest(request, url, originBase) {
 }
 
 async function relaysWithStaleFallback(proxied, requestUrl, ctx, fetchImpl, cache) {
-  // Cache key: a bare GET on the full client URL. Query string included — `limit` etc. vary
-  // the response body.
-  const cacheKey = new Request(requestUrl, { method: "GET" });
+  // Cache key: a bare GET on the full client URL (query string included — `limit` etc. vary the
+  // response body) plus the version-namespace param (see CACHE_KEY_VERSION: bump to 2 when the
+  // signing broker deploys, so pre-signing headerless bodies can never replay to
+  // signature-requiring clients).
+  const keyUrl = new URL(requestUrl);
+  keyUrl.searchParams.set("__or_cache_v", CACHE_KEY_VERSION);
+  const cacheKey = new Request(keyUrl, { method: "GET" });
 
   let originResponse = null;
   try {
@@ -85,24 +96,17 @@ async function relaysWithStaleFallback(proxied, requestUrl, ctx, fetchImpl, cach
     // Network error or 10 s timeout — fall through to the stale path below.
   }
 
-  if (originResponse !== null && originResponse.ok) {
-    // Healthy: hand the origin response to the client unchanged and stash a copy for later.
-    // The stored copy must override the origin's `no-store` (the Cache API refuses to store a
-    // no-store response) with a hard 180 s cap; it is only ever read on origin failure.
-    const copy = originResponse.clone();
-    const headers = new Headers({
-      "Cache-Control": `public, s-maxage=${STALE_TTL_SECONDS}`,
-    });
-    const contentType = copy.headers.get("Content-Type");
-    if (contentType) {
-      headers.set("Content-Type", contentType);
-    }
-    ctx.waitUntil(cache.put(cacheKey, new Response(copy.body, { status: 200, headers })));
+  if (originResponse !== null && originResponse.status === 200) {
+    // Healthy: hand the origin response to the client unchanged and stash a complete copy for
+    // later. Only a full 200 may be stored — a 206 partial body would poison the fallback with
+    // a truncated relay list.
+    ctx.waitUntil(storeFallbackCopy(cache, cacheKey, originResponse.clone()));
     return originResponse;
   }
 
   if (originResponse !== null && originResponse.status < 500) {
-    // 3xx/4xx are semantic answers (404, 429 back-pressure): never mask them with stale data.
+    // Non-200 2xx (204, 206) and 3xx/4xx are semantic answers (404, 429 back-pressure): pass
+    // them through unchanged, never store them, never mask them with stale data.
     return originResponse;
   }
 
@@ -110,15 +114,18 @@ async function relaysWithStaleFallback(proxied, requestUrl, ctx, fetchImpl, cach
   // still holds one.
   const cached = await cache.match(cacheKey);
   if (cached) {
-    const headers = new Headers({
-      "X-OpenRung-Stale": "1",
-      "Cache-Control": "no-store",
-    });
-    const contentType = cached.headers.get("Content-Type");
-    if (contentType) {
-      headers.set("Content-Type", contentType);
+    if (originResponse !== null) {
+      // Discard the unconsumed 5xx body we are about to drop on the floor; leaving the stream
+      // unread leaks it in workerd ("response body not consumed").
+      ctx.waitUntil(Promise.resolve(originResponse.body?.cancel()).catch(() => {}));
     }
-    return new Response(cached.body, { status: 200, headers });
+    // Serve the stored copy with ALL of its headers intact — body + X-OpenRung-Relays-Signature
+    // must survive byte-for-byte (see storeFallbackCopy) — re-marked so nothing downstream
+    // re-caches or rewrites it, and so clients/telemetry can detect the degraded serve.
+    const stale = new Response(cached.body, cached);
+    stale.headers.set("Cache-Control", "no-store, no-transform");
+    stale.headers.set("X-OpenRung-Stale", "1");
+    return stale;
   }
 
   if (originResponse !== null) {
@@ -135,4 +142,19 @@ async function relaysWithStaleFallback(proxied, requestUrl, ctx, fetchImpl, cach
       "Cache-Control": "no-store",
     },
   });
+}
+
+// Store a fallback copy of a healthy 200, preserving ALL origin headers — not just
+// Content-Type: the broker will soon send X-OpenRung-Relays-Signature computed over the exact
+// body bytes, and a stale-served response must keep body + signature intact or
+// signature-requiring clients will reject it. Two edits only: the origin's `no-store` is
+// replaced with the hard stale cap (the Cache API refuses to store a no-store response; the
+// stored copy is only ever read on origin failure), and Set-Cookie is dropped so no per-client
+// cookie can be replayed to other clients.
+async function storeFallbackCopy(cache, cacheKey, copy) {
+  const buf = await copy.arrayBuffer();
+  const cached = new Response(buf, copy);
+  cached.headers.set("Cache-Control", `public, max-age=${STALE_TTL_SECONDS}`);
+  cached.headers.delete("Set-Cookie");
+  await cache.put(cacheKey, cached);
 }

--- a/deploy/broker-proxy/src/index.js
+++ b/deploy/broker-proxy/src/index.js
@@ -4,47 +4,40 @@
 // (real cert for the hostname) and this Worker forwards each request to the broker origin,
 // which speaks plaintext HTTP on a non-standard port. This gives China clients an HTTPS,
 // CDN-fronted discovery endpoint whose blocking incurs Cloudflare-edge collateral damage,
-// instead of a single null-routable plaintext IP. The raw origin IP stays in the app's
-// broker fallback list, so a blocked edge degrades to the direct IP rather than failing.
+// instead of a single null-routable plaintext IP.
 //
-// The broker is a stateless JSON control-plane API (relay discovery, telemetry, speed-test).
-// Responses MUST NOT be cached — relay candidates are short-lived (≈3 min lease).
+// This front is currently the ONLY discovery endpoint the apps ship: clients are HTTPS-only
+// (EnforceSecureBrokerURL) and carry no raw-IP fallback, so a blocked or dead front fails
+// discovery CLOSED. The real fixes are front diversity (an independent second front, not
+// same-zone) and relay-list signing — see README.md. What this Worker adds in the meantime is
+// stale-on-error for GET /api/v1/relays: an origin blip (timeout, network error, 5xx) is
+// answered with this colo's last healthy relay list (≤ 180 s old, marked X-OpenRung-Stale: 1)
+// instead of an error.
+//
+// The freshness path is unchanged: healthy responses are never served from cache — relay
+// candidates are short-lived (≈3 min lease) — and every other endpoint is a plain passthrough.
+// See src/handler.js for the logic and test/ for the unit tests.
 //
 // The origin MUST be a hostname, not a bare IP: Cloudflare Workers cannot fetch() an IP literal
 // (e.g. http://54.238.185.205:8080) — that returns Cloudflare error 1003 "Direct IP Access Not
 // Allowed". broker-origin.openrung.org is a DNS-only (grey-cloud) A record → 54.238.185.205, so
 // the Worker resolves the name and connects straight to the AWS origin (bypassing Cloudflare's
 // proxy, which avoids a loop). It must stay DNS-only; proxying it would loop back into the edge.
+// The origin is overridable via the ORIGIN var (wrangler dev --var ORIGIN:... / tests).
 //
 // Caveat: the Worker → origin leg is plaintext HTTP over the public internet (the origin has no
 // TLS cert). The censorship-relevant leg (client → Cloudflare) is encrypted; hardening the origin
 // leg (Origin CA cert + Full(strict), or Cloudflare Tunnel, or an IP allowlist that only admits
 // Cloudflare egress) is a follow-up. See README.md.
 
-const ORIGIN = "http://broker-origin.openrung.org:8080";
+import { createHandler } from "./handler.js";
 
 export default {
-  async fetch(request) {
-    const target = new URL(request.url);
-    const origin = new URL(ORIGIN);
-
-    // Preserve path + query; swap scheme/host/port to the origin.
-    target.protocol = origin.protocol;
-    target.hostname = origin.hostname;
-    target.port = origin.port;
-
-    const proxied = new Request(target, request);
-
-    // Surface the real client IP to the origin. The broker only reads RemoteAddr today (so it
-    // currently sees Cloudflare's IP), but this future-proofs it for X-Forwarded-For parsing and
-    // keeps the client_seen telemetry meaningful once the broker honors the header.
-    const clientIp = request.headers.get("CF-Connecting-IP");
-    if (clientIp) {
-      proxied.headers.set("X-Forwarded-For", clientIp);
-    }
-    proxied.headers.set("X-Forwarded-Proto", "https");
-
-    // Never cache control-plane responses; relay candidates are short-lived.
-    return fetch(proxied, { cf: { cacheTtl: 0, cacheEverything: false } });
+  async fetch(request, env, ctx) {
+    const handler = createHandler({
+      fetchImpl: (req, init) => fetch(req, init),
+      cache: caches.default,
+    });
+    return handler(request, env, ctx);
   },
 };

--- a/deploy/broker-proxy/src/index.js
+++ b/deploy/broker-proxy/src/index.js
@@ -11,8 +11,8 @@
 // discovery CLOSED. The real fixes are front diversity (an independent second front, not
 // same-zone) and relay-list signing — see README.md. What this Worker adds in the meantime is
 // stale-on-error for GET /api/v1/relays: an origin blip (timeout, network error, 5xx) is
-// answered with this colo's last healthy relay list (≤ 180 s old, marked X-OpenRung-Stale: 1)
-// instead of an error.
+// answered with this colo's last healthy relay list (≤ 900 s old — the 15-minute stale window
+// fixed by the relay-list signing spec — marked X-OpenRung-Stale: 1) instead of an error.
 //
 // The freshness path is unchanged: healthy responses are never served from cache — relay
 // candidates are short-lived (≈3 min lease) — and every other endpoint is a plain passthrough.

--- a/deploy/broker-proxy/test/handler.test.mjs
+++ b/deploy/broker-proxy/test/handler.test.mjs
@@ -1,0 +1,256 @@
+// Unit tests for the broker-proxy request handler (stale-on-error behavior).
+// Run from deploy/broker-proxy: `node --test` (or `npm test`).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createHandler, DEFAULT_ORIGIN } from "../src/handler.js";
+
+const EDGE = "https://broker.openrung.org";
+const RELAYS_URL = `${EDGE}/api/v1/relays?limit=1`;
+
+// Minimal Cache API fake: stores immutable snapshots keyed by URL, counts interactions.
+class FakeCache {
+  constructor() {
+    this.entries = new Map(); // url -> { status, headers, body: ArrayBuffer }
+    this.putCalls = [];
+    this.matchCalls = 0;
+  }
+
+  async put(key, response) {
+    const url = key instanceof Request ? key.url : String(key);
+    const method = key instanceof Request ? key.method : "GET";
+    const body = await response.arrayBuffer();
+    const entry = { status: response.status, headers: new Headers(response.headers), body };
+    this.putCalls.push({ url, method, ...entry });
+    this.entries.set(url, entry);
+  }
+
+  async match(key) {
+    this.matchCalls += 1;
+    const url = key instanceof Request ? key.url : String(key);
+    const hit = this.entries.get(url);
+    if (!hit) return undefined;
+    return new Response(hit.body.slice(0), { status: hit.status, headers: hit.headers });
+  }
+
+  seed(url, body, contentType = "application/json") {
+    this.entries.set(url, {
+      status: 200,
+      headers: new Headers({
+        "Content-Type": contentType,
+        "Cache-Control": "public, s-maxage=180",
+      }),
+      body: new TextEncoder().encode(body).buffer,
+    });
+  }
+}
+
+// Minimal ExecutionContext fake.
+class FakeCtx {
+  constructor() {
+    this.pending = [];
+  }
+  waitUntil(promise) {
+    this.pending.push(promise);
+  }
+  async settle() {
+    await Promise.all(this.pending);
+  }
+}
+
+// Wraps a responder so tests can inspect what the handler fetched and with which init.
+function recordingFetch(responder) {
+  const impl = async (request, init) => {
+    impl.calls.push({ request, init });
+    return responder(request, init);
+  };
+  impl.calls = [];
+  return impl;
+}
+
+function setup(responder) {
+  const cache = new FakeCache();
+  const ctx = new FakeCtx();
+  const fetchImpl = recordingFetch(responder);
+  const handler = createHandler({ fetchImpl, cache });
+  return { handler, cache, ctx, fetchImpl };
+}
+
+test("fresh 2xx: returned unchanged, proxied with timeout, cache populated via waitUntil", async () => {
+  const body = JSON.stringify({ server_time: "2026-07-10T00:00:00Z", relays: [{ id: "r1" }] });
+  const { handler, cache, ctx, fetchImpl } = setup(
+    () =>
+      new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      }),
+  );
+
+  const request = new Request(RELAYS_URL, { headers: { "CF-Connecting-IP": "203.0.113.7" } });
+  const response = await handler(request, undefined, ctx);
+
+  // Client sees the origin response unchanged (origin's no-store intact, no stale marker).
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), body);
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  assert.equal(response.headers.get("X-OpenRung-Stale"), null);
+
+  // Proxied to the default origin with path+query preserved, forwarded headers, and a timeout.
+  assert.equal(fetchImpl.calls.length, 1);
+  const { request: proxied, init } = fetchImpl.calls[0];
+  const originUrl = new URL(DEFAULT_ORIGIN);
+  const proxiedUrl = new URL(proxied.url);
+  assert.equal(proxiedUrl.protocol, originUrl.protocol);
+  assert.equal(proxiedUrl.hostname, originUrl.hostname);
+  assert.equal(proxiedUrl.port, originUrl.port);
+  assert.equal(proxiedUrl.pathname, "/api/v1/relays");
+  assert.equal(proxiedUrl.search, "?limit=1");
+  assert.ok(init.signal instanceof AbortSignal, "relays fetch must carry a timeout signal");
+  assert.deepEqual(init.cf, { cacheTtl: 0, cacheEverything: false });
+  assert.equal(proxied.headers.get("X-Forwarded-For"), "203.0.113.7");
+  assert.equal(proxied.headers.get("X-Forwarded-Proto"), "https");
+
+  // The cached copy is written via ctx.waitUntil, keyed on the bare-GET edge URL, with the
+  // origin's no-store replaced by a 180 s cap and the Content-Type preserved.
+  await ctx.settle();
+  assert.equal(cache.putCalls.length, 1);
+  const put = cache.putCalls[0];
+  assert.equal(put.url, RELAYS_URL);
+  assert.equal(put.method, "GET");
+  assert.equal(put.status, 200);
+  assert.equal(put.headers.get("Cache-Control"), "public, s-maxage=180");
+  assert.equal(put.headers.get("Content-Type"), "application/json");
+  const stored = await cache.match(new Request(RELAYS_URL));
+  assert.equal(await stored.text(), body);
+});
+
+test("ORIGIN env var overrides the proxy target", async () => {
+  const { handler, ctx, fetchImpl } = setup(() => new Response("{}", { status: 200 }));
+
+  await handler(new Request(RELAYS_URL), { ORIGIN: "http://127.0.0.1:19999" }, ctx);
+
+  const proxiedUrl = new URL(fetchImpl.calls[0].request.url);
+  assert.equal(proxiedUrl.protocol, "http:");
+  assert.equal(proxiedUrl.host, "127.0.0.1:19999");
+  assert.equal(proxiedUrl.pathname, "/api/v1/relays");
+});
+
+test("origin 500 with warm cache: 200 + X-OpenRung-Stale, Content-Type preserved", async () => {
+  const staleBody = '{"server_time":"2026-07-10T00:00:00Z","relays":[{"id":"stale"}]}';
+  const { handler, cache, ctx } = setup(() => new Response("boom", { status: 500 }));
+  cache.seed(RELAYS_URL, staleBody);
+
+  const response = await handler(new Request(RELAYS_URL), undefined, ctx);
+
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), staleBody);
+  assert.equal(response.headers.get("X-OpenRung-Stale"), "1");
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  assert.equal(response.headers.get("Content-Type"), "application/json");
+  await ctx.settle();
+  assert.equal(cache.putCalls.length, 0, "a failed response must not be cached");
+});
+
+test("origin timeout (fetch rejects) with warm cache: stale copy served", async () => {
+  const staleBody = '{"relays":[{"id":"stale"}]}';
+  const { handler, cache, ctx } = setup(() => {
+    throw new DOMException("The operation timed out.", "TimeoutError");
+  });
+  cache.seed(RELAYS_URL, staleBody);
+
+  const response = await handler(new Request(RELAYS_URL), undefined, ctx);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("X-OpenRung-Stale"), "1");
+  assert.equal(await response.text(), staleBody);
+});
+
+test("origin network error with cold cache: JSON 502, not an unhandled exception", async () => {
+  const { handler, cache, ctx } = setup(() => {
+    throw new TypeError("fetch failed");
+  });
+
+  const response = await handler(new Request(RELAYS_URL), undefined, ctx);
+
+  assert.equal(response.status, 502);
+  assert.equal(response.headers.get("Content-Type"), "application/json");
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  const parsed = JSON.parse(await response.text());
+  assert.ok(parsed.error, "502 body must carry a JSON error field");
+  assert.equal(cache.matchCalls, 1, "the stale copy must have been looked up first");
+});
+
+test("origin 5xx with cold cache: origin response passed through", async () => {
+  const { handler, cache, ctx } = setup(() => new Response("upstream sad", { status: 503 }));
+
+  const response = await handler(new Request(RELAYS_URL), undefined, ctx);
+
+  assert.equal(response.status, 503);
+  assert.equal(await response.text(), "upstream sad");
+  assert.equal(response.headers.get("X-OpenRung-Stale"), null);
+  assert.equal(cache.matchCalls, 1);
+});
+
+test("origin 4xx passes through unmasked, even with a warm cache", async () => {
+  for (const status of [404, 429]) {
+    const { handler, cache, ctx } = setup(
+      () => new Response(`err ${status}`, { status, headers: { "Retry-After": "30" } }),
+    );
+    cache.seed(RELAYS_URL, '{"relays":[{"id":"stale"}]}');
+
+    const response = await handler(new Request(RELAYS_URL), undefined, ctx);
+
+    assert.equal(response.status, status);
+    assert.equal(await response.text(), `err ${status}`);
+    assert.equal(response.headers.get("Retry-After"), "30");
+    assert.equal(response.headers.get("X-OpenRung-Stale"), null);
+    assert.equal(cache.matchCalls, 0, `a ${status} must not trigger a stale lookup`);
+    await ctx.settle();
+    assert.equal(cache.putCalls.length, 0);
+  }
+});
+
+test("non-relays path: exact passthrough, no timeout, cache never touched", async () => {
+  for (const path of ["/healthz", "/api/v1/speedtest", "/api/v1/relays/extra"]) {
+    const { handler, cache, ctx, fetchImpl } = setup(() => new Response("ok", { status: 200 }));
+
+    const response = await handler(new Request(`${EDGE}${path}`), undefined, ctx);
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+    const { request: proxied, init } = fetchImpl.calls[0];
+    assert.equal(new URL(proxied.url).pathname, path);
+    assert.equal(init.signal, undefined, `${path} must not get a timeout signal`);
+    assert.deepEqual(init.cf, { cacheTtl: 0, cacheEverything: false });
+    assert.equal(cache.matchCalls, 0);
+    assert.equal(cache.putCalls.length, 0);
+    assert.equal(ctx.pending.length, 0);
+  }
+});
+
+test("non-relays 5xx: passed through with no stale substitution", async () => {
+  const { handler, cache, ctx } = setup(() => new Response("down", { status: 500 }));
+  cache.seed(`${EDGE}/healthz`, "should never be served");
+
+  const response = await handler(new Request(`${EDGE}/healthz`), undefined, ctx);
+
+  assert.equal(response.status, 500);
+  assert.equal(await response.text(), "down");
+  assert.equal(cache.matchCalls, 0);
+});
+
+test("non-GET on /api/v1/relays: passthrough, no timeout, cache never touched", async () => {
+  const { handler, cache, ctx, fetchImpl } = setup(() => new Response("created", { status: 200 }));
+
+  const request = new Request(`${EDGE}/api/v1/relays`, { method: "POST" });
+  const response = await handler(request, undefined, ctx);
+
+  assert.equal(response.status, 200);
+  const { request: proxied, init } = fetchImpl.calls[0];
+  assert.equal(proxied.method, "POST");
+  assert.equal(init.signal, undefined, "non-GET must not get a timeout signal");
+  assert.equal(cache.matchCalls, 0);
+  assert.equal(cache.putCalls.length, 0);
+  assert.equal(ctx.pending.length, 0);
+});

--- a/deploy/broker-proxy/test/handler.test.mjs
+++ b/deploy/broker-proxy/test/handler.test.mjs
@@ -4,15 +4,21 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createHandler, DEFAULT_ORIGIN } from "../src/handler.js";
+import { createHandler, DEFAULT_ORIGIN, STALE_TTL_SECONDS } from "../src/handler.js";
 
 const EDGE = "https://broker.openrung.org";
 const RELAYS_URL = `${EDGE}/api/v1/relays?limit=1`;
+// The handler namespaces its cache key with a version param (bumped when the signing broker
+// deploys, so pre-signing bodies cannot replay to signature-requiring clients).
+const CACHE_KEY_URL = `${RELAYS_URL}&__or_cache_v=1`;
 
-// Minimal Cache API fake: stores immutable snapshots keyed by URL, counts interactions.
+// Minimal Cache API fake: stores immutable snapshots keyed by URL, counts interactions, and —
+// like the real Cache API — honors the stored copy's max-age/s-maxage on match (against an
+// injectable clock), so the handler's stale-TTL bound is actually exercised by tests.
 class FakeCache {
-  constructor() {
-    this.entries = new Map(); // url -> { status, headers, body: ArrayBuffer }
+  constructor(clock = () => 0) {
+    this.clock = clock; // milliseconds
+    this.entries = new Map(); // url -> { status, headers, body: ArrayBuffer, storedAt }
     this.putCalls = [];
     this.matchCalls = 0;
   }
@@ -21,7 +27,12 @@ class FakeCache {
     const url = key instanceof Request ? key.url : String(key);
     const method = key instanceof Request ? key.method : "GET";
     const body = await response.arrayBuffer();
-    const entry = { status: response.status, headers: new Headers(response.headers), body };
+    const entry = {
+      status: response.status,
+      headers: new Headers(response.headers),
+      body,
+      storedAt: this.clock(),
+    };
     this.putCalls.push({ url, method, ...entry });
     this.entries.set(url, entry);
   }
@@ -31,6 +42,13 @@ class FakeCache {
     const url = key instanceof Request ? key.url : String(key);
     const hit = this.entries.get(url);
     if (!hit) return undefined;
+    // Freshness check, s-maxage winning over max-age as in the real Cache API. An entry past
+    // its lifetime no longer matches.
+    const cacheControl = hit.headers.get("Cache-Control") ?? "";
+    const ttl = /s-maxage=(\d+)/i.exec(cacheControl) ?? /max-age=(\d+)/i.exec(cacheControl);
+    if (ttl && this.clock() - hit.storedAt > Number(ttl[1]) * 1000) {
+      return undefined;
+    }
     return new Response(hit.body.slice(0), { status: hit.status, headers: hit.headers });
   }
 
@@ -39,9 +57,10 @@ class FakeCache {
       status: 200,
       headers: new Headers({
         "Content-Type": contentType,
-        "Cache-Control": "public, s-maxage=180",
+        "Cache-Control": `public, max-age=${STALE_TTL_SECONDS}`,
       }),
       body: new TextEncoder().encode(body).buffer,
+      storedAt: this.clock(),
     });
   }
 }
@@ -69,15 +88,15 @@ function recordingFetch(responder) {
   return impl;
 }
 
-function setup(responder) {
-  const cache = new FakeCache();
+function setup(responder, { clock } = {}) {
+  const cache = new FakeCache(clock);
   const ctx = new FakeCtx();
   const fetchImpl = recordingFetch(responder);
   const handler = createHandler({ fetchImpl, cache });
   return { handler, cache, ctx, fetchImpl };
 }
 
-test("fresh 2xx: returned unchanged, proxied with timeout, cache populated via waitUntil", async () => {
+test("fresh 200: returned unchanged, proxied with timeout, cache populated via waitUntil", async () => {
   const body = JSON.stringify({ server_time: "2026-07-10T00:00:00Z", relays: [{ id: "r1" }] });
   const { handler, cache, ctx, fetchImpl } = setup(
     () =>
@@ -111,17 +130,18 @@ test("fresh 2xx: returned unchanged, proxied with timeout, cache populated via w
   assert.equal(proxied.headers.get("X-Forwarded-For"), "203.0.113.7");
   assert.equal(proxied.headers.get("X-Forwarded-Proto"), "https");
 
-  // The cached copy is written via ctx.waitUntil, keyed on the bare-GET edge URL, with the
-  // origin's no-store replaced by a 180 s cap and the Content-Type preserved.
+  // The cached copy is written via ctx.waitUntil, keyed on the version-namespaced bare-GET edge
+  // URL, with the origin's no-store replaced by the stale-TTL cap and the Content-Type
+  // preserved.
   await ctx.settle();
   assert.equal(cache.putCalls.length, 1);
   const put = cache.putCalls[0];
-  assert.equal(put.url, RELAYS_URL);
+  assert.equal(put.url, CACHE_KEY_URL);
   assert.equal(put.method, "GET");
   assert.equal(put.status, 200);
-  assert.equal(put.headers.get("Cache-Control"), "public, s-maxage=180");
+  assert.equal(put.headers.get("Cache-Control"), `public, max-age=${STALE_TTL_SECONDS}`);
   assert.equal(put.headers.get("Content-Type"), "application/json");
-  const stored = await cache.match(new Request(RELAYS_URL));
+  const stored = await cache.match(new Request(CACHE_KEY_URL));
   assert.equal(await stored.text(), body);
 });
 
@@ -139,14 +159,14 @@ test("ORIGIN env var overrides the proxy target", async () => {
 test("origin 500 with warm cache: 200 + X-OpenRung-Stale, Content-Type preserved", async () => {
   const staleBody = '{"server_time":"2026-07-10T00:00:00Z","relays":[{"id":"stale"}]}';
   const { handler, cache, ctx } = setup(() => new Response("boom", { status: 500 }));
-  cache.seed(RELAYS_URL, staleBody);
+  cache.seed(CACHE_KEY_URL, staleBody);
 
   const response = await handler(new Request(RELAYS_URL), undefined, ctx);
 
   assert.equal(response.status, 200);
   assert.equal(await response.text(), staleBody);
   assert.equal(response.headers.get("X-OpenRung-Stale"), "1");
-  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  assert.equal(response.headers.get("Cache-Control"), "no-store, no-transform");
   assert.equal(response.headers.get("Content-Type"), "application/json");
   await ctx.settle();
   assert.equal(cache.putCalls.length, 0, "a failed response must not be cached");
@@ -157,7 +177,7 @@ test("origin timeout (fetch rejects) with warm cache: stale copy served", async 
   const { handler, cache, ctx } = setup(() => {
     throw new DOMException("The operation timed out.", "TimeoutError");
   });
-  cache.seed(RELAYS_URL, staleBody);
+  cache.seed(CACHE_KEY_URL, staleBody);
 
   const response = await handler(new Request(RELAYS_URL), undefined, ctx);
 
@@ -197,7 +217,7 @@ test("origin 4xx passes through unmasked, even with a warm cache", async () => {
     const { handler, cache, ctx } = setup(
       () => new Response(`err ${status}`, { status, headers: { "Retry-After": "30" } }),
     );
-    cache.seed(RELAYS_URL, '{"relays":[{"id":"stale"}]}');
+    cache.seed(CACHE_KEY_URL, '{"relays":[{"id":"stale"}]}');
 
     const response = await handler(new Request(RELAYS_URL), undefined, ctx);
 
@@ -209,6 +229,113 @@ test("origin 4xx passes through unmasked, even with a warm cache", async () => {
     await ctx.settle();
     assert.equal(cache.putCalls.length, 0);
   }
+});
+
+test("non-200 2xx (204, 206) passes through and is never cached", async () => {
+  // A 206 partial body would poison the fallback with a truncated relay list; a 204 has no
+  // body worth serving. Both reach the client unchanged but must not trigger cache.put.
+  for (const status of [204, 206]) {
+    const body = status === 204 ? null : "partial body";
+    const { handler, cache, ctx } = setup(() => new Response(body, { status }));
+
+    const response = await handler(new Request(RELAYS_URL), undefined, ctx);
+
+    assert.equal(response.status, status);
+    if (body !== null) {
+      assert.equal(await response.text(), body);
+    }
+    assert.equal(response.headers.get("X-OpenRung-Stale"), null);
+    await ctx.settle();
+    assert.equal(cache.putCalls.length, 0, `a ${status} must never be cached`);
+    assert.equal(cache.matchCalls, 0, `a ${status} must not trigger a stale lookup`);
+  }
+});
+
+test("stored copy preserves ALL origin headers; signature survives a stale serve intact", async () => {
+  // The broker will soon send X-OpenRung-Relays-Signature over the exact body bytes; a
+  // stale-served response must keep body + signature intact or signature-requiring clients
+  // will reject it.
+  const body = '{"server_time":"2026-07-10T00:00:00Z","relays":[{"id":"r1"}]}';
+  let calls = 0;
+  const { handler, cache, ctx } = setup(() => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+          "X-OpenRung-Relays-Signature": "test-sig",
+          "Set-Cookie": "session=abc",
+        },
+      });
+    }
+    return new Response("boom", { status: 500 });
+  });
+
+  // Warm the cache through the real fresh path.
+  const fresh = await handler(new Request(RELAYS_URL), undefined, ctx);
+  assert.equal(await fresh.text(), body);
+  await ctx.settle();
+
+  // Stored copy: every origin header preserved except the Cache-Control override and the
+  // dropped Set-Cookie.
+  assert.equal(cache.putCalls.length, 1);
+  const put = cache.putCalls[0];
+  assert.equal(put.headers.get("X-OpenRung-Relays-Signature"), "test-sig");
+  assert.equal(put.headers.get("Content-Type"), "application/json");
+  assert.equal(put.headers.get("Cache-Control"), `public, max-age=${STALE_TTL_SECONDS}`);
+  assert.equal(put.headers.get("Set-Cookie"), null, "cookies must never be stored");
+
+  // Origin now fails: the stale serve must carry the identical body byte-for-byte alongside
+  // the signature header.
+  const stale = await handler(new Request(RELAYS_URL), undefined, ctx);
+  assert.equal(stale.status, 200);
+  assert.equal(await stale.text(), body);
+  assert.equal(stale.headers.get("X-OpenRung-Relays-Signature"), "test-sig");
+  assert.equal(stale.headers.get("Content-Type"), "application/json");
+  assert.equal(stale.headers.get("X-OpenRung-Stale"), "1");
+  assert.equal(stale.headers.get("Cache-Control"), "no-store, no-transform");
+  await ctx.settle();
+});
+
+test("stale copy no longer matches once older than STALE_TTL_SECONDS", async () => {
+  // The FakeCache honors max-age against an injected clock, and the entry is written by the
+  // real fresh path — coupling the stored Cache-Control header to the exported TTL constant so
+  // neither can drift without this test failing.
+  let nowMs = 0;
+  let calls = 0;
+  const { handler, cache, ctx } = setup(
+    () => {
+      calls += 1;
+      return calls === 1
+        ? new Response('{"relays":[{"id":"r1"}]}', {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        : new Response("boom", { status: 500 });
+    },
+    { clock: () => nowMs },
+  );
+
+  await handler(new Request(RELAYS_URL), undefined, ctx);
+  await ctx.settle();
+  assert.equal(cache.putCalls.length, 1);
+
+  // Just inside the TTL: the warm copy is still served on failure.
+  nowMs = (STALE_TTL_SECONDS - 1) * 1000;
+  const inside = await handler(new Request(RELAYS_URL), undefined, ctx);
+  assert.equal(inside.status, 200);
+  assert.equal(inside.headers.get("X-OpenRung-Stale"), "1");
+  await inside.text();
+
+  // Just past the TTL: the entry no longer matches, so the origin failure passes through.
+  nowMs = (STALE_TTL_SECONDS + 1) * 1000;
+  const past = await handler(new Request(RELAYS_URL), undefined, ctx);
+  assert.equal(past.status, 500);
+  assert.equal(await past.text(), "boom");
+  assert.equal(past.headers.get("X-OpenRung-Stale"), null);
+  await ctx.settle();
 });
 
 test("non-relays path: exact passthrough, no timeout, cache never touched", async () => {


### PR DESCRIPTION
## What & why

The broker origin is a single Lightsail box; today any origin blip is a client-visible discovery failure at the Cloudflare front. This teaches the broker-proxy Worker stale-on-error semantics for `GET /api/v1/relays` only:

- **Fresh path unchanged**: healthy responses proxy through exactly as before (`no-store` to clients), now with an explicit 10 s origin timeout instead of an opaque hang.
- On each **200**, a copy is stored in `caches.default` (Cache-Control rewritten to `public, max-age=900` — the origin's `no-store` would otherwise make the Cache API silently store nothing, ever).
- On **origin failure** (network error, timeout, ≥500), the last-good copy ≤15 min old is served with `X-OpenRung-Stale: 1` + `Cache-Control: no-store, no-transform`. Cold cache: a structured 502 JSON instead of today's opaque Cloudflare error page. 4xx (429/404) pass through unmasked — never substituted.
- Also fixes the stale header comment in `src/index.js` that still claimed a raw-IP fallback exists (same false claim #34 fixed in the README).

Design notes (aligned with the relay-list signing spec finalized today):
- **200-only cache gate** (a 206 partial body must not poison the fallback).
- **All origin headers preserved** in the stored copy — when the broker starts sending `X-OpenRung-Relays-Signature`, stale responses must keep body+signature byte-intact or signature-requiring clients will reject them (tested byte-for-byte).
- Cache key carries `__or_cache_v=1`; bump to 2 at signing-broker deploy so pre-signing bodies can never replay to signature-requiring clients.
- 15-min bound: clients validate relay `expires_at` against the `server_time` in the same body, so client-side checks cannot bound edge staleness either way; the signing spec fixes 15 min stale inside a 30-min signed `not_after`.
- Known limitation: `caches.default` is per-colo — coverage exists only where that PoP served a recent success.

## Verification

- `node --test`: 13/13 — fresh passthrough + cache write, stale serve on 500/timeout with warm cache, 502 JSON on cold-cache network error, 4xx unmasked, 204/206 never cached, non-relays/non-GET untouched, signature-header + body byte-survival through store→stale-serve, and a TTL-honoring FakeCache proving entries stop matching at >900 s (couples the header value to the constant).
- `ORIGIN` is now env-overridable (`wrangler dev --var`) for smoke testing; the deploy plan is `wrangler deploy` + a live fresh-path check, with the stale path already covered by unit tests against a fake cache honoring real Cache API semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)