### PR TITLE
Uptime: downgrade front 403s from runner vantage to warnings

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -7,6 +7,16 @@ name: uptime
 # UNCENSORED vantage). A green run proves the endpoints are *available*;
 # it does NOT prove they are reachable from censored networks.
 #
+# Front 403s are expected from this vantage: the Cloudflare edge serves
+# 403 to datacenter IPs on this zone (verified on the first real-runner
+# run, 2026-07-10) — the same behavior that forces volunteers to register
+# against the origin. A front 403 therefore says nothing about real-client
+# availability and is downgraded to a warning; every other front failure
+# (5xx, timeout, staleness) still fails the job. If a WAF exception for
+# GET /healthz + GET /api/v1/relays is ever added (not possible if the
+# block comes from free-plan Bot Fight Mode, which supports no
+# exceptions), the 403 branch simply goes dead.
+#
 # Notifications: when a run fails, GitHub emails the workflow author
 # (Actions failure notifications). No extra alerting wiring is required.
 #
@@ -56,11 +66,20 @@ jobs:
 
           fail=0
 
+          # See the header comment: CDN-edge 403s against this datacenter
+          # vantage are expected and are not a front outage signal.
+          vantage_warn() {
+            echo "WARN  $1 -> HTTP 403 (datacenter vantage blocked by the CDN edge; not an outage signal)"
+            echo "::warning::$1 returned 403 from the GitHub-runner vantage (expected: the edge blocks datacenter IPs)"
+          }
+
           probe_health() {
-            local base=$1 code
+            local base=$1 kind=${2:-front} code
             code=$(curl "${CURL_OPTS[@]}" -o /dev/null -w '%{http_code}' "$base/healthz") || code=000
             if [[ "$code" == "200" ]]; then
               echo "ok    $base/healthz -> 200"
+            elif [[ "$kind" == "front" && "$code" == "403" ]]; then
+              vantage_warn "$base/healthz"
             else
               echo "FAIL  $base/healthz -> HTTP $code (expected 200)"
               fail=1
@@ -72,6 +91,10 @@ jobs:
             hdrs=$(mktemp)
             body=$(mktemp)
             code=$(curl "${CURL_OPTS[@]}" -D "$hdrs" -o "$body" -w '%{http_code}' "$base/api/v1/relays?limit=1") || code=000
+            if [[ "$code" == "403" ]]; then
+              vantage_warn "$base/api/v1/relays"
+              return
+            fi
             if [[ "$code" != "200" ]]; then
               echo "FAIL  $base/api/v1/relays -> HTTP $code (expected 200)"
               fail=1
@@ -103,12 +126,12 @@ jobs:
           }
 
           for base in "${FRONTS[@]}"; do
-            probe_health "$base"
+            probe_health "$base" front
             probe_relays_fresh "$base"
           done
 
           for base in "${ORIGINS[@]}"; do
-            probe_health "$base"
+            probe_health "$base" origin
           done
 
           if (( fail )); then

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -50,7 +50,10 @@ jobs:
           # CDN-cache staleness regression like the 2026-07-06 incident).
           FRONTS=(
             "https://broker.openrung.org"
-            # "https://dXXXXXXXXXXXXXX.cloudfront.net"  # upcoming independent CloudFront front
+            # Independent second front (AWS CloudFront, dist E2PLKW8FO3JZSA). Unlike
+            # Cloudflare it does not block datacenter IPs, so the runner gets a real
+            # 200 here — a genuine health signal rather than the vantage-warned 403.
+            "https://d2r7mdpyevvs1m.cloudfront.net"
           )
 
           # Origins: direct broker endpoints, bypassing the CDN. /healthz only.


### PR DESCRIPTION
## What & why

The first real-runner dispatch of the new uptime workflow (#37) failed exactly as its own reviewer note predicted: the Cloudflare edge 403s GitHub's datacenter IPs on both front checks ([run 29062941208](https://github.com/openrung/openrung/actions/runs/29062941208)), while the origin check passed. Left as-is, the */15 schedule pages every 15 minutes about a non-outage.

A front 403 from this vantage carries no signal about real-client availability, so exactly that case (front probes only, HTTP 403 only) is downgraded to a `WARN` line + an Actions `::warning::` annotation. Origin probes and every other front failure mode (5xx, timeout, stale header, skew, invalid JSON) still fail the job.

If a WAF exception for `GET /healthz` + `GET /api/v1/relays` is added later the 403 branch simply goes dead — but note that if the datacenter block comes from free-plan Bot Fight Mode, Cloudflare supports no exceptions for it, making this vantage handling the durable design rather than a stopgap.

## Verification

Extracted run block executed against stub servers: front-403 + origin-200 → two WARNs, origin ok, exit 0; front-500 → structured FAILs, exit 1.

## Note

The workflow's schedule is currently failing on main — merging this stops the failure emails. After merge, a `workflow_dispatch` run should come back green with two vantage warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)