### PR TITLE
Try a genuine broker override strictly before racing default fronts

### DIFF
--- a/desktop/config/config.go
+++ b/desktop/config/config.go
@@ -76,16 +76,33 @@ var DefaultBrokerURLs = []string{
 	//   "https://openrung-broker.<other-cdn>/",   // EXAMPLE — second CDN provider
 }
 
+// Candidates are the ordered discovery endpoints for one request, plus
+// whether URLs[0] is a genuine user override. Built by BrokerCandidates and
+// consumed by discovery.FirstReachable; carrying the flag alongside the list
+// keeps the two from being computed inconsistently.
+type Candidates struct {
+	URLs []string
+	// OverrideFirst marks URLs[0] as a genuine user override — a non-blank
+	// primary that is not one of DefaultBrokerURLs. discovery.FirstReachable
+	// then tries it strictly first (full per-attempt timeout) and only races
+	// the remaining defaults after it fails, so a custom broker that is merely
+	// slower than the stagger is never silently outrun by a default front.
+	OverrideFirst bool
+}
+
 // BrokerCandidates returns the ordered, de-duplicated discovery candidates for
-// a request: a genuine primary override first, then the built-in defaults.
+// a request: a genuine primary override first (with OverrideFirst set), then
+// the built-in defaults.
 //
 // Ported from the mobile app's candidates() (src/net/brokerClient.ts): a
 // non-blank primary is tried FIRST only when it is a genuine override, i.e.
-// not already one of the defaults. A persisted value that merely echoes a
-// default must not reorder the defaults' HTTPS-first preference, otherwise an
-// upgrader whose last-used default was the raw IP would keep hitting the IP
-// before the Cloudflare-fronted endpoint.
-func BrokerCandidates(primary string) []string {
+// not already one of the defaults — and only such an override sets
+// OverrideFirst, giving it the strict head phase described on Candidates. A
+// persisted value that merely echoes a default must not reorder the defaults'
+// HTTPS-first preference (or claim the override phase), otherwise an upgrader
+// whose last-used default was the raw IP would keep hitting the IP before the
+// Cloudflare-fronted endpoint.
+func BrokerCandidates(primary string) Candidates {
 	ordered := make([]string, 0, len(DefaultBrokerURLs)+1)
 	seen := make(map[string]struct{}, len(DefaultBrokerURLs)+1)
 	add := func(value string) {
@@ -96,6 +113,7 @@ func BrokerCandidates(primary string) []string {
 		ordered = append(ordered, value)
 	}
 
+	overrideFirst := false
 	trimmedPrimary := strings.TrimSpace(primary)
 	if trimmedPrimary != "" {
 		isDefault := false
@@ -107,6 +125,7 @@ func BrokerCandidates(primary string) []string {
 		}
 		if !isDefault {
 			add(trimmedPrimary)
+			overrideFirst = true
 		}
 	}
 	for _, fallback := range DefaultBrokerURLs {
@@ -114,5 +133,5 @@ func BrokerCandidates(primary string) []string {
 			add(trimmed)
 		}
 	}
-	return ordered
+	return Candidates{URLs: ordered, OverrideFirst: overrideFirst}
 }

--- a/desktop/config/config_test.go
+++ b/desktop/config/config_test.go
@@ -20,27 +20,27 @@ func TestBrokerCandidates(t *testing.T) {
 	tests := []struct {
 		name    string
 		primary string
-		want    []string
+		want    Candidates
 	}{
 		{
 			name:    "empty primary yields the HTTPS default",
 			primary: "",
-			want:    []string{https},
+			want:    Candidates{URLs: []string{https}},
 		},
 		{
 			name:    "blank primary is ignored",
 			primary: "   ",
-			want:    []string{https},
+			want:    Candidates{URLs: []string{https}},
 		},
 		{
-			name:    "genuine override is tried first",
+			name:    "genuine override is tried first and flagged as an override",
 			primary: "https://mirror.example/",
-			want:    []string{"https://mirror.example/", https},
+			want:    Candidates{URLs: []string{"https://mirror.example/", https}, OverrideFirst: true},
 		},
 		{
-			name:    "primary echoing a default does not duplicate it",
+			name:    "primary echoing a default does not duplicate it or claim the override phase",
 			primary: https,
-			want:    []string{https},
+			want:    Candidates{URLs: []string{https}},
 		},
 	}
 

--- a/desktop/discovery/discovery.go
+++ b/desktop/discovery/discovery.go
@@ -139,11 +139,50 @@ func ListRelays(ctx context.Context, brokerURL string, opts Options) (relay.List
 // carries a Retry-After when the primary was rate-limited). With a single
 // candidate this reduces to exactly one attempt whose error propagates
 // unchanged.
-func FirstReachable(ctx context.Context, candidates []string, opts Options) (Fetch, error) {
-	if len(candidates) == 0 {
+//
+// When candidates.OverrideFirst is set, URLs[0] is a GENUINE user override
+// (see config.BrokerCandidates) and racing it would betray the user's choice:
+// a custom broker that is merely slower than the stagger would silently lose
+// to a default front. The override is therefore attempted strictly first,
+// alone, with its full per-attempt timeout — no default is contacted while it
+// is pending — and it wins on any success, exactly like the old sequential
+// loop. Only when the override FAILS does the staggered race above start over
+// the REMAINING candidates (the first of them immediately, the next one
+// stagger later, and so on). If the override and every remaining candidate
+// fail, the override's error is surfaced — it is candidates.URLs[0], so the
+// all-fail diagnostic is unchanged — except when the caller's ctx was
+// cancelled mid-race, which still surfaces the cancellation.
+func FirstReachable(ctx context.Context, candidates config.Candidates, opts Options) (Fetch, error) {
+	urls := candidates.URLs
+	if len(urls) == 0 {
 		return Fetch{}, errors.New("no broker endpoints configured")
 	}
 
+	if candidates.OverrideFirst {
+		response, overrideErr := ListRelays(ctx, urls[0], opts)
+		if overrideErr == nil {
+			return Fetch{BrokerURL: urls[0], Response: response}, nil
+		}
+		if len(urls) == 1 || ctx.Err() != nil {
+			return Fetch{}, overrideErr
+		}
+		fetch, raceErr := race(ctx, urls[1:], opts)
+		if raceErr == nil {
+			return fetch, nil
+		}
+		if ctx.Err() != nil {
+			// The caller gave up mid-race; its error wraps the cancellation,
+			// which callers classify on — the override's earlier failure does not.
+			return Fetch{}, raceErr
+		}
+		return Fetch{}, overrideErr
+	}
+	return race(ctx, urls, opts)
+}
+
+// race is the staggered-race core behind FirstReachable, running the pure
+// no-override semantics over the given endpoint list.
+func race(ctx context.Context, candidates []string, opts Options) (Fetch, error) {
 	stagger := opts.Stagger
 	if stagger <= 0 {
 		stagger = config.DiscoveryStagger

--- a/desktop/discovery/discovery_test.go
+++ b/desktop/discovery/discovery_test.go
@@ -9,10 +9,23 @@ import (
 	"testing"
 	"time"
 
+	"openrung/desktop/config"
 	"openrung/internal/client"
 )
 
 const relayBody = `{"count":1,"server_time":"2026-07-06T00:00:00Z","relays":[{"id":"r1","public_host":"1.2.3.4","public_port":443}]}`
+
+// noOverride wraps urls as a pure-race candidate list — what
+// config.BrokerCandidates builds when no genuine user override is set.
+func noOverride(urls ...string) config.Candidates {
+	return config.Candidates{URLs: urls}
+}
+
+// withOverride wraps urls as a candidate list whose FIRST entry is a genuine
+// user override, matching what config.BrokerCandidates builds for one.
+func withOverride(urls ...string) config.Candidates {
+	return config.Candidates{URLs: urls, OverrideFirst: true}
+}
 
 func TestListRelaysSuccess(t *testing.T) {
 	var gotVersion, gotPlatform string
@@ -68,7 +81,7 @@ func TestFirstReachableFailsOverToSecond(t *testing.T) {
 	}))
 	defer good.Close()
 
-	fetch, err := FirstReachable(context.Background(), []string{limited.URL, good.URL}, Options{Stagger: 100 * time.Millisecond})
+	fetch, err := FirstReachable(context.Background(), noOverride(limited.URL, good.URL), Options{Stagger: 100 * time.Millisecond})
 	if err != nil {
 		t.Fatalf("FirstReachable: %v", err)
 	}
@@ -97,7 +110,7 @@ func TestFirstReachableHealthyPrimaryWinsWithoutStartingFallback(t *testing.T) {
 	}))
 	defer fallback.Close()
 
-	fetch, err := FirstReachable(context.Background(), []string{primary.URL, fallback.URL}, Options{Stagger: stagger})
+	fetch, err := FirstReachable(context.Background(), noOverride(primary.URL, fallback.URL), Options{Stagger: stagger})
 	if err != nil {
 		t.Fatalf("FirstReachable: %v", err)
 	}
@@ -130,7 +143,7 @@ func TestFirstReachableHangingPrimaryLosesToSecondAfterStagger(t *testing.T) {
 	defer good.Close()
 
 	begun := time.Now()
-	fetch, err := FirstReachable(context.Background(), []string{hung.URL, good.URL}, Options{Stagger: stagger})
+	fetch, err := FirstReachable(context.Background(), noOverride(hung.URL, good.URL), Options{Stagger: stagger})
 	elapsed := time.Since(begun)
 	if err != nil {
 		t.Fatalf("FirstReachable: %v", err)
@@ -161,7 +174,7 @@ func TestFirstReachableAllFailReturnsPrimaryError(t *testing.T) {
 	}))
 	defer secondary.Close()
 
-	_, err := FirstReachable(context.Background(), []string{primary.URL, secondary.URL}, Options{Stagger: 50 * time.Millisecond})
+	_, err := FirstReachable(context.Background(), noOverride(primary.URL, secondary.URL), Options{Stagger: 50 * time.Millisecond})
 	if err == nil {
 		t.Fatal("want error when every candidate fails")
 	}
@@ -184,7 +197,7 @@ func TestFirstReachableSingleCandidateBehavesSequentially(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		fetch, err := FirstReachable(context.Background(), []string{srv.URL}, Options{})
+		fetch, err := FirstReachable(context.Background(), noOverride(srv.URL), Options{})
 		if err != nil {
 			t.Fatalf("FirstReachable: %v", err)
 		}
@@ -208,7 +221,7 @@ func TestFirstReachableSingleCandidateBehavesSequentially(t *testing.T) {
 		begun := time.Now()
 		// Default stagger on purpose: a lone failing candidate must return
 		// immediately, not wait out config.DiscoveryStagger.
-		_, err := FirstReachable(context.Background(), []string{srv.URL}, Options{})
+		_, err := FirstReachable(context.Background(), noOverride(srv.URL), Options{})
 		elapsed := time.Since(begun)
 
 		var rl *RateLimitedError
@@ -243,7 +256,7 @@ func TestFirstReachableCancelsLosersOnceWinnerReturns(t *testing.T) {
 	}))
 	defer winner.Close()
 
-	fetch, err := FirstReachable(context.Background(), []string{loser.URL, winner.URL}, Options{Stagger: stagger})
+	fetch, err := FirstReachable(context.Background(), noOverride(loser.URL, winner.URL), Options{Stagger: stagger})
 	if err != nil {
 		t.Fatalf("FirstReachable: %v", err)
 	}
@@ -287,7 +300,7 @@ func TestFirstReachableParentCancelDrainsStartedAttempts(t *testing.T) {
 	}
 	done := make(chan outcome, 1)
 	go func() {
-		fetch, err := FirstReachable(ctx, []string{primary.URL, secondary.URL}, Options{Stagger: stagger})
+		fetch, err := FirstReachable(ctx, noOverride(primary.URL, secondary.URL), Options{Stagger: stagger})
 		done <- outcome{fetch: fetch, err: err}
 	}()
 
@@ -346,7 +359,7 @@ func TestFirstReachableParentCancelBeforeStaggerSkipsUnstartedCandidate(t *testi
 	}
 	done := make(chan outcome, 1)
 	go func() {
-		fetch, err := FirstReachable(ctx, []string{primary.URL, fallback.URL}, Options{Stagger: stagger})
+		fetch, err := FirstReachable(ctx, noOverride(primary.URL, fallback.URL), Options{Stagger: stagger})
 		done <- outcome{fetch: fetch, err: err}
 	}()
 
@@ -372,8 +385,167 @@ func TestFirstReachableParentCancelBeforeStaggerSkipsUnstartedCandidate(t *testi
 	}
 }
 
+func TestFirstReachableOverrideSlowerThanStaggerStillWins(t *testing.T) {
+	// A GENUINE user override that is merely slower than the stagger must not
+	// be outrun by a default front: the override phase runs alone with its full
+	// per-attempt timeout, so the default is never contacted — neither while
+	// the override is pending nor after it wins.
+	const stagger = 100 * time.Millisecond
+
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(4 * stagger) // slower than the stagger, well inside the 15s attempt timeout
+		w.Write([]byte(relayBody))
+	}))
+	defer override.Close()
+	var defaultHits atomic.Int64
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultHits.Add(1)
+		w.Write([]byte(relayBody))
+	}))
+	defer fallback.Close()
+
+	fetch, err := FirstReachable(context.Background(), withOverride(override.URL, fallback.URL), Options{Stagger: stagger})
+	if err != nil {
+		t.Fatalf("FirstReachable: %v", err)
+	}
+	if fetch.BrokerURL != override.URL {
+		t.Fatalf("served by %q, want the override %q", fetch.BrokerURL, override.URL)
+	}
+	if hits := defaultHits.Load(); hits != 0 {
+		t.Fatalf("default front received %d request(s) while the override was pending, want 0", hits)
+	}
+}
+
+func TestFirstReachableOverrideFailureRacesRemainingDefaults(t *testing.T) {
+	// Once the override FAILS, the staggered race starts over the remaining
+	// candidates with the usual semantics: the first default immediately, the
+	// next one stagger later, first success wins.
+	const stagger = 200 * time.Millisecond
+
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer override.Close()
+	hangingDefault := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // hang until the race aborts this attempt
+	}))
+	defer hangingDefault.Close()
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(relayBody))
+	}))
+	defer good.Close()
+
+	fetch, err := FirstReachable(context.Background(), withOverride(override.URL, hangingDefault.URL, good.URL), Options{Stagger: stagger})
+	if err != nil {
+		t.Fatalf("FirstReachable: %v", err)
+	}
+	if fetch.BrokerURL != good.URL {
+		t.Fatalf("served by %q, want %q", fetch.BrokerURL, good.URL)
+	}
+}
+
+func TestFirstReachableOverrideAllFailSurfacesOverrideError(t *testing.T) {
+	// The override is candidates[0]: when it and every default fail, ITS error
+	// is the surfaced diagnostic — the user configured that broker, so its
+	// failure is what they need to see, not a default front's.
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"error":"override exploded"}`))
+	}))
+	defer override.Close()
+	rateLimited := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer rateLimited.Close()
+
+	_, err := FirstReachable(context.Background(), withOverride(override.URL, rateLimited.URL), Options{Stagger: 50 * time.Millisecond})
+	if err == nil {
+		t.Fatal("want error when every candidate fails")
+	}
+	var rl *RateLimitedError
+	if errors.As(err, &rl) {
+		t.Fatalf("got the default front's rate-limit error %v, want the override's error", err)
+	}
+	var statusErr *client.BrokerStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want the override's 503, got %v", err)
+	}
+}
+
+func TestFirstReachableOverrideSingleCandidateFailurePropagatesUnchanged(t *testing.T) {
+	// A lone override reduces to exactly one attempt whose error keeps its
+	// detail — there is no remainder to race and no stagger wait.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := FirstReachable(context.Background(), withOverride(srv.URL), Options{})
+	var rl *RateLimitedError
+	if !errors.As(err, &rl) {
+		t.Fatalf("want *RateLimitedError, got %v", err)
+	}
+	if rl.BrokerURL != srv.URL || rl.RetryAfter != 7*time.Second {
+		t.Fatalf("error lost detail: %+v", rl)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("override received %d requests, want exactly 1", got)
+	}
+}
+
+func TestFirstReachableOverrideParentCancelMidRaceSurfacesCancellation(t *testing.T) {
+	// The override fails fast, the remaining default hangs, then the caller
+	// cancels. The surfaced error must be the cancellation — what the caller
+	// classifies on — not the override's stale failure.
+	const stagger = 100 * time.Millisecond
+
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer override.Close()
+	defaultStarted := make(chan struct{})
+	hangingDefault := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(defaultStarted)
+		<-r.Context().Done()
+	}))
+	defer hangingDefault.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type outcome struct {
+		fetch Fetch
+		err   error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		fetch, err := FirstReachable(ctx, withOverride(override.URL, hangingDefault.URL), Options{Stagger: stagger})
+		done <- outcome{fetch: fetch, err: err}
+	}()
+
+	select {
+	case <-defaultStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("default attempt never reached its server")
+	}
+	cancel()
+
+	select {
+	case res := <-done:
+		if !errors.Is(res.err, context.Canceled) {
+			t.Fatalf("want context.Canceled, got %v (fetch %+v)", res.err, res.fetch)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FirstReachable did not return within 5s of parent cancellation")
+	}
+}
+
 func TestFirstReachableNoCandidates(t *testing.T) {
-	_, err := FirstReachable(context.Background(), nil, Options{})
+	_, err := FirstReachable(context.Background(), config.Candidates{}, Options{})
 	if err == nil {
 		t.Fatal("want error for empty candidate list")
 	}


### PR DESCRIPTION
## Problem

The staggered discovery race (PR #36) gave a GENUINE user broker override only a 2.5 s head start: an override merely slower than `config.DiscoveryStagger` silently lost to the default Cloudflare front, and the session pinned to a broker the user did not choose. Under the old sequential loop the override won whenever it answered within its 15 s attempt timeout.

## Semantics (uniform across all 4 clients)

- `config.BrokerCandidates` now returns a **`config.Candidates`** value — the ordered URL list **plus an `OverrideFirst` flag** set only for a genuine override (a non-blank primary that is not one of `DefaultBrokerURLs`). Carrying the flag alongside the list keeps the two from being computed inconsistently, and both production call sites (`vpnservice/service.go`, `vpnservice/directory.go`) keep their exact shape.
- `discovery.FirstReachable` consumes it:
  - **Override present:** the override is attempted strictly first, alone, with its full 15 s per-attempt timeout — no default is contacted while it is pending. Only when it **fails** does the staggered race (unchanged, now the unexported `race` core) start over the remaining candidates.
  - **No override** (including a primary that merely echoes a default): pure race, byte-for-byte unchanged.
  - **All fail:** still returns `candidates[0]`'s error — now the override's, which is the diagnostic the user needs (a Retry-After is carried when the override itself was rate-limited).
  - **Caller cancellation** mid-race still surfaces `context.Canceled`, never a stale override error.

Mirrors the identical change to the three mobile clients (RN TS reference, Kotlin, Swift): openrung/openrung-mobile-app#36.

## Testing

`go build`, `go vet`, and `go test ./config/ ./discovery/ ./vpnservice/` all pass; the five new override tests also pass under `-race` (override-slower-than-stagger wins with zero default hits; failure starts the remainder race; all-fail surfaces the override's 503 over a default's 429; single-candidate error fidelity; cancellation mid-remainder-race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)