### PR TITLE
desktop: build Linux release against webkit2gtk 4.1

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,9 +46,12 @@ jobs:
 
       - name: Install Linux webview deps
         if: runner.os == 'Linux'
+        # webkit2gtk 4.1 (not 4.0): modern distros (Ubuntu 24.04+, Debian 13,
+        # Fedora 40+) dropped the 4.0 runtime. The 22.04 runner still has an old
+        # enough glibc that the resulting binary also runs on those newer distros.
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Fetch sing-box (unix)
         if: runner.os != 'Windows'
@@ -75,7 +78,8 @@ jobs:
 
       - name: Package (Linux)
         if: runner.os == 'Linux'
-        run: ./desktop/scripts/package-linux.sh
+        # -tags webkit2_41 links libwebkit2gtk-4.1.so.0 instead of the 4.0 soname.
+        run: ./desktop/scripts/package-linux.sh -tags webkit2_41
 
       - name: Package (Windows)
         if: runner.os == 'Windows'

--- a/desktop/scripts/package-linux.sh
+++ b/desktop/scripts/package-linux.sh
@@ -4,7 +4,11 @@
 # tar.gz. Run this ON Linux (Wails cannot cross-compile from macOS/Windows).
 #
 # Prereqs (Debian/Ubuntu): Go, Node >=22, the Wails CLI, and
-#   sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.0-dev
+#   sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev
+#
+# Build against webkit2gtk 4.1 (not the removed-on-modern-distros 4.0) by passing
+# the Wails tag through to this script:
+#   ./package-linux.sh -tags webkit2_41
 #
 # Provide a Linux sing-box binary via SING_BOX=/path/to/sing-box (matching the
 # target arch), or have sing-box on PATH.


### PR DESCRIPTION
## Problem

Running the released Linux binary on a current distro fails at startup:

```
./OpenRung: error while loading shared libraries: libwebkit2gtk-4.0.so.37: cannot open shared object file: No such file or directory
```

The release is built against `libwebkit2gtk-4.0-dev`, so it dynamically links `libwebkit2gtk-4.0.so.37`. Modern distros (Ubuntu 24.04+, Debian 13, Fedora 40+) dropped webkit2gtk **4.0** and ship only **4.1** — same WebKit engine, just linking libsoup3 instead of libsoup2 — so the loader can't find the 4.0 soname.

## Fix

Build against webkit2gtk **4.1**:
- Install `libwebkit2gtk-4.1-dev` in CI instead of `-4.0-dev`.
- Package with Wails' `-tags webkit2_41`, which links `libwebkit2gtk-4.1.so.0`.
- Keep the runner on `ubuntu-22.04` on purpose — its older glibc keeps the binary runnable on both 22.04 and newer distros, while linking the 4.1 soname those distros actually ship.

`package-linux.sh` docs updated to match (prereq package + the `-tags webkit2_41` invocation for local builds).

## Compatibility

- ✅ Ubuntu 24.04+, Debian 13, Fedora 40+ — works out of the box.
- ✅ Ubuntu 22.04 — works (4.1 is in its repos).
- ⚠️ Stock Ubuntu 20.04 (4.0-only, near EOL) — dropped; those users can `apt install libwebkit2gtk-4.1-0`.

## Note

This only fixes future builds. The currently-published binary is still 4.0 — a new tagged release (or a manual `desktop-release` dispatch) is needed to produce a 4.1 binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)