### PR TITLE
Hide sing-box console on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/quic-go/quic-go v0.60.0
+	golang.org/x/sys v0.45.0
 )
 
 require (
@@ -15,6 +16,5 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )

--- a/internal/client/engine.go
+++ b/internal/client/engine.go
@@ -31,6 +31,7 @@ func (r SingBoxRunner) Run(ctx context.Context, configPath string) error {
 	}
 
 	cmd := exec.Command(resolved, "run", "-c", configPath)
+	configureSingBoxProcess(cmd)
 	cmd.Stdout = r.Stdout
 	if cmd.Stdout == nil {
 		cmd.Stdout = io.Discard

--- a/internal/client/process_other.go
+++ b/internal/client/process_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package client
+
+import "os/exec"
+
+// configureSingBoxProcess applies platform-specific process settings before
+// sing-box starts.
+func configureSingBoxProcess(cmd *exec.Cmd) {}

--- a/internal/client/process_windows.go
+++ b/internal/client/process_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package client
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// configureSingBoxProcess prevents the console-subsystem sing-box.exe from
+// creating a blank Command Prompt window when launched by the desktop GUI.
+func configureSingBoxProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
+}


### PR DESCRIPTION
## Summary

- start the bundled `sing-box.exe` with Windows `CREATE_NO_WINDOW`
- keep the process setup a no-op on macOS and Linux
- prevent the blank Command Prompt window from appearing when connecting

## Root cause

The desktop GUI launched the console-subsystem `sing-box.exe` without Windows process creation flags, so Windows created a visible blank console window.

## Validation

- `go test ./internal/client`
- `GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./internal/client`
- `go vet ./internal/client`
- `go test ./vpnservice` (from `desktop/`)
- `GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./vpnservice` (from `desktop/`)
- `git diff --check`
