### PR TITLE
landing: link volunteer section to the relay setup guide

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1575,8 +1575,8 @@
           <div class="split">
             <div class="promo" data-reveal>
               <h3 data-i18n="volunteerTitle">Become a volunteer</h3>
-              <p data-i18n="volunteerBody">If you're on the open internet, you can run a volunteer relay and give others a path to it. Volunteers run a desktop command-line app. Note: in the current version, volunteers act as direct exit nodes, which carries real legal and privacy risk — please review what's involved first.</p>
-              <a class="button ghost" href="mailto:admin@openrung.org?subject=Volunteer%20with%20OpenRung" data-i18n="volunteerButton">Contact us to volunteer</a>
+              <p data-i18n="volunteerBody">If you're on the open internet, you can run a volunteer relay and give others a path to it. Relays run as a Docker container on any server with a public IP, and the setup guide walks you through it in a few minutes. Note: in the current version, volunteers act as direct exit nodes, which carries real legal and privacy risk — please review what's involved first.</p>
+              <a class="button ghost" href="https://github.com/openrung/openrung/blob/main/deploy/volunteer/README.md" rel="noopener" data-i18n="volunteerButton">Set up a volunteer relay</a>
             </div>
             <div class="promo" id="donate" data-reveal style="--d:.08s">
               <h3 data-i18n="donateTitle">Donate</h3>
@@ -1801,8 +1801,8 @@
           supportTitle: "Help the network grow",
           supportLead: "OpenRung relies on volunteers for relay capacity and donors to keep it running.",
           volunteerTitle: "Become a volunteer",
-          volunteerBody: "If you're on the open internet, you can run a volunteer relay and give others a path to it. Volunteers run a desktop command-line app. Note: in the current version, volunteers act as direct exit nodes, which carries real legal and privacy risk — please review what's involved first.",
-          volunteerButton: "Contact us to volunteer",
+          volunteerBody: "If you're on the open internet, you can run a volunteer relay and give others a path to it. Relays run as a Docker container on any server with a public IP, and the setup guide walks you through it in a few minutes. Note: in the current version, volunteers act as direct exit nodes, which carries real legal and privacy risk — please review what's involved first.",
+          volunteerButton: "Set up a volunteer relay",
           donateTitle: "Donate",
           donateBody: "Your support keeps OpenRung free and funds infrastructure, security, volunteer tools, and user support. Online donations are coming soon.",
           donateButton: "Contact us to donate",
@@ -1913,8 +1913,8 @@
           supportTitle: "帮助网络成长",
           supportLead: "OpenRung 依靠志愿者提供中继、依靠捐赠者维持运转。",
           volunteerTitle: "成为志愿者",
-          volunteerBody: "如果你身处自由的网络环境，可以运行一个志愿者中继，为他人提供通往开放互联网的通道。志愿者通过桌面命令行程序运行。请注意：在当前阶段，志愿者作为直接出口节点，存在一定的法律与隐私风险，请先了解相关须知。",
-          volunteerButton: "联系我们参与志愿",
+          volunteerBody: "如果你身处自由的网络环境，可以运行一个志愿者中继，为他人提供通往开放互联网的通道。中继以 Docker 容器的形式运行在任何拥有公网 IP 的服务器上，按照部署指南几分钟即可完成。请注意：在当前阶段，志愿者作为直接出口节点，存在一定的法律与隐私风险，请先了解相关须知。",
+          volunteerButton: "部署志愿者中继",
           donateTitle: "捐赠支持",
           donateBody: "你的支持帮助 OpenRung 保持免费，并用于基础设施、安全、志愿者工具与用户支持。在线捐赠通道即将开放。",
           donateButton: "联系我们捐赠",
@@ -2025,8 +2025,8 @@
           supportTitle: "به رشد شبکه کمک کنید",
           supportLead: "OpenRung برای ظرفیت رله به داوطلبان و برای ادامهٔ فعالیت به حامیان مالی متکی است.",
           volunteerTitle: "داوطلب شوید",
-          volunteerBody: "اگر به اینترنت آزاد دسترسی دارید، می‌توانید یک رلهٔ داوطلب اجرا کنید و راهی به آن را برای دیگران فراهم کنید. داوطلبان از یک برنامهٔ خط فرمان دسکتاپ استفاده می‌کنند. توجه: در نسخهٔ کنونی، داوطلبان به‌عنوان گرهٔ خروجی مستقیم عمل می‌کنند که خطرهای حقوقی و حریم خصوصی واقعی به همراه دارد — لطفاً ابتدا جزئیات را مطالعه کنید.",
-          volunteerButton: "برای داوطلب‌شدن تماس بگیرید",
+          volunteerBody: "اگر به اینترنت آزاد دسترسی دارید، می‌توانید یک رلهٔ داوطلب اجرا کنید و راهی به آن را برای دیگران فراهم کنید. رله به‌صورت یک کانتینر Docker روی هر سروری با IP عمومی اجرا می‌شود و راهنمای راه‌اندازی، مراحل را در چند دقیقه به شما نشان می‌دهد. توجه: در نسخهٔ کنونی، داوطلبان به‌عنوان گرهٔ خروجی مستقیم عمل می‌کنند که خطرهای حقوقی و حریم خصوصی واقعی به همراه دارد — لطفاً ابتدا جزئیات را مطالعه کنید.",
+          volunteerButton: "راه‌اندازی رلهٔ داوطلب",
           donateTitle: "حمایت مالی",
           donateBody: "حمایت شما کمک می‌کند OpenRung رایگان بماند و هزینهٔ زیرساخت، امنیت، ابزارهای داوطلبان و پشتیبانی کاربران را تأمین می‌کند. پرداخت آنلاین به‌زودی فعال می‌شود.",
           donateButton: "برای حمایت تماس بگیرید",
@@ -2137,8 +2137,8 @@
           supportTitle: "Помогите сети расти",
           supportLead: "OpenRung полагается на волонтёров для пропускной способности и на доноров, чтобы продолжать работу.",
           volunteerTitle: "Стать волонтёром",
-          volunteerBody: "Если у вас есть свободный доступ в интернет, вы можете запустить волонтёрский ретранслятор и открыть путь к нему для других. Волонтёры используют десктопное приложение командной строки. Внимание: в текущей версии волонтёры выступают прямыми выходными узлами, что несёт реальные юридические риски и риски для приватности — сначала ознакомьтесь с деталями.",
-          volunteerButton: "Связаться, чтобы стать волонтёром",
+          volunteerBody: "Если у вас есть свободный доступ в интернет, вы можете запустить волонтёрский ретранслятор и открыть путь к нему для других. Ретранслятор работает как Docker-контейнер на любом сервере с публичным IP — по инструкции установка занимает несколько минут. Внимание: в текущей версии волонтёры выступают прямыми выходными узлами, что несёт реальные юридические риски и риски для приватности — сначала ознакомьтесь с деталями.",
+          volunteerButton: "Запустить волонтёрский ретранслятор",
           donateTitle: "Поддержать",
           donateBody: "Ваша поддержка помогает OpenRung оставаться бесплатным и финансирует инфраструктуру, безопасность, инструменты для волонтёров и поддержку пользователей. Онлайн-пожертвования скоро появятся.",
           donateButton: "Связаться, чтобы поддержать",


### PR DESCRIPTION
## Summary
- The volunteer card on the landing page said "Contact us to volunteer" with a mailto link, even though the Docker-based volunteer relay guide ([deploy/volunteer/README.md](https://github.com/openrung/openrung/blob/main/deploy/volunteer/README.md)) is published and sufficient for technical users to spin up a relay.
- Point the button at the setup guide on GitHub instead, and refresh the card copy — relays run as a Docker container on any server with a public IP, not a "desktop command-line app". The legal/privacy risk warning is kept verbatim.
- Updated in all four languages (EN / ZH / FA / RU). The i18n mechanism only swaps textContent, so the href is set once on the anchor.

## Verification
- Served docs/ locally in the browser pane: button renders "Set up a volunteer relay" and cycling all four language switchers swaps the label/body while the href stays pinned to the GitHub guide; no console errors.
- Confirmed deploy/volunteer/README.md exists on origin/main (the link target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)