### PR TITLE
punch: add gomobile wrapper for the mobile NAT-punch client

### DIFF
--- a/internal/punch/session.go
+++ b/internal/punch/session.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"syscall"
 	"time"
 )
 
@@ -20,6 +21,14 @@ type Dialer struct {
 	Hub     HubClient
 	RelayID string
 	Logger  *slog.Logger
+	// Control, when non-nil, is invoked with the raw file descriptor of the punch
+	// UDP socket immediately after it is created and before any datagram is sent.
+	// It exists for platforms where the socket must be excused from the process's
+	// own tunnel — on Android the callback runs VpnService.protect(fd) so the
+	// reflector, hole-punch, and QUIC traffic on this one socket reaches the
+	// underlying network instead of looping back through the app's TUN. Desktop
+	// leaves it nil, so socket creation is byte-for-byte the previous behaviour.
+	Control func(fd uintptr)
 }
 
 // Establishment is a live punched path. The caller starts Bridge.Serve with a
@@ -55,6 +64,33 @@ func (d *Dialer) logger() *slog.Logger {
 	return slog.Default()
 }
 
+// listenPunchSocket opens the single udp4 socket that serves reflector discovery,
+// the hole punch, and QUIC. When d.Control is set it is applied to the raw fd at
+// creation (before any traffic) so callers can protect the socket from the
+// process's own tunnel. The returned conn is always a *net.UDPConn: ListenConfig
+// with network "udp4" yields one, which Gather/Attempt/LocalCandidates require,
+// and it is left unconnected so quic-go can WriteTo arbitrary addresses.
+func (d *Dialer) listenPunchSocket(ctx context.Context) (*net.UDPConn, error) {
+	if d.Control == nil {
+		return net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	}
+	lc := net.ListenConfig{
+		Control: func(_, _ string, c syscall.RawConn) error {
+			return c.Control(d.Control)
+		},
+	}
+	pc, err := lc.ListenPacket(ctx, "udp4", ":0")
+	if err != nil {
+		return nil, err
+	}
+	sock, ok := pc.(*net.UDPConn)
+	if !ok {
+		_ = pc.Close()
+		return nil, fmt.Errorf("punch: expected *net.UDPConn, got %T", pc)
+	}
+	return sock, nil
+}
+
 // Establish attempts the full client punch flow. On success it returns a live
 // Establishment (the caller must run Bridge.Serve) and an OK PunchResult. On any
 // failure it returns a non-nil error and a PunchResult whose Reason/NATClass are
@@ -70,7 +106,7 @@ func (d *Dialer) Establish(ctx context.Context) (*Establishment, PunchResult, er
 		return nil, res, err
 	}
 
-	sock, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	sock, err := d.listenPunchSocket(ctx)
 	if err != nil {
 		res.Reason = "socket"
 		return nil, res, err

--- a/internal/punch/session_control_test.go
+++ b/internal/punch/session_control_test.go
@@ -1,0 +1,74 @@
+package punch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDialerControlProtectsSocket verifies that a non-nil Dialer.Control is
+// invoked exactly once, with a live file descriptor, when the punch socket is
+// created — the seam Android uses to VpnService.protect() the socket. The punch
+// itself is expected to fail (the fake hub only answers /config and 404s the
+// punch request), which is fine: the socket is opened, and thus Control is fired,
+// before the request that fails.
+func TestDialerControlProtectsSocket(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case PathPunchConfig:
+			// One unreachable reflector so Gather (on the just-protected socket)
+			// returns quickly; Establish then fails at the unhandled punch request.
+			writeJSON(t, w, PunchConfig{ReflectorAddrs: []string{"127.0.0.1:1"}, ALPN: ALPN, TTLMillis: 500})
+		default:
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer hub.Close()
+
+	var gotFD uintptr
+	calls := 0
+	dialer := &Dialer{
+		Hub:     HubClient{BaseURL: hub.URL},
+		RelayID: "relay_test",
+		Logger:  discardLogger(),
+		Control: func(fd uintptr) {
+			calls++
+			gotFD = fd
+		},
+	}
+
+	_, _, err := dialer.Establish(context.Background())
+	if err == nil {
+		t.Fatal("expected Establish to fail with an unreachable reflector")
+	}
+	if calls != 1 {
+		t.Fatalf("Control called %d times, want exactly 1", calls)
+	}
+	if gotFD == 0 {
+		t.Fatalf("Control got fd 0, want a live descriptor")
+	}
+}
+
+// TestDialerNilControlOpensUDPConn confirms the desktop path (nil Control) still
+// yields a working *net.UDPConn from listenPunchSocket.
+func TestDialerNilControlOpensUDPConn(t *testing.T) {
+	dialer := &Dialer{Logger: discardLogger()}
+	sock, err := dialer.listenPunchSocket(context.Background())
+	if err != nil {
+		t.Fatalf("listenPunchSocket: %v", err)
+	}
+	defer sock.Close()
+	if sock.LocalAddr() == nil {
+		t.Fatal("socket has no local address")
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}

--- a/mobile/orpunch/orpunch.go
+++ b/mobile/orpunch/orpunch.go
@@ -1,0 +1,202 @@
+// Package orpunch is the gomobile-facing wrapper around the OpenRung NAT
+// hole-punch client (internal/punch). It is bound into the mobile app's
+// sing-box/libbox AAR so Android (and later iOS) can reach a CGNAT volunteer
+// directly, bypassing the relay hub's data path, exactly like the desktop
+// client's cmd/client maybePunch flow.
+//
+// gomobile only marshals a restricted set of types across the JNI boundary, so
+// every exported symbol here uses String/int/bool/interface only. The rich Go
+// types (*net.UDPConn, *quic.Conn, punch.Establishment, context.Context) never
+// cross the boundary — they are owned entirely inside Session.
+//
+// A hole punch that does not succeed is NOT reported as an error: Dial returns a
+// Session with OK()==false carrying a structured Reason/NATClass for telemetry,
+// and the caller silently falls back to the relay hub endpoint. Dial returns a
+// non-nil error only for programmer misuse (nil protector, empty config).
+package orpunch
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"time"
+
+	"openrung/internal/punch"
+)
+
+// hubHTTPTimeout bounds each hub coordination request. Mirrors the default
+// punch.HubClient timeout so the mobile wrapper behaves like the desktop client.
+const hubHTTPTimeout = 10 * time.Second
+
+// SocketProtector is implemented on the platform side (Kotlin/Swift). Protect is
+// invoked with the punch UDP socket's raw file descriptor at creation, before any
+// datagram is sent, so the platform can excuse it from the app's own VPN tunnel.
+// On Android the implementation calls VpnService.protect(fd), the same seam
+// libbox already uses for its outbound sockets.
+type SocketProtector interface {
+	Protect(fd int)
+}
+
+// Config carries the punch coordination parameters from the platform. It is a
+// gomobile-safe struct: only String/bool fields, so gomobile generates a plain
+// Java class with a constructor and getters/setters.
+type Config struct {
+	// HubBaseURL is the hub punch coordinator base URL — the relay descriptor's
+	// punch_endpoint, or a derived http://<publicHost>:9444 when it is empty.
+	HubBaseURL string
+	// RelayID is the broker relay id of the punch-capable volunteer.
+	RelayID string
+	// Insecure skips TLS verification of the hub HTTP coordination endpoint only
+	// (for a volunteer-run hub with a self-signed cert). The punched QUIC data
+	// path still pins the volunteer's per-session certificate by fingerprint and
+	// the tunnel itself is VLESS+REALITY, so a hub MITM can at worst force a
+	// fallback to the relay path, never read or redirect traffic.
+	Insecure bool
+}
+
+// Session is an opaque handle to a punch attempt. On success (OK()==true) it owns
+// the live punched path and the loopback bridge goroutine; the caller points
+// sing-box at BridgeHost():BridgePort() and adds PeerIP() to
+// route_exclude_address. Close() tears everything down and is always safe to call,
+// including after a failed attempt.
+type Session struct {
+	ok        bool
+	reason    string
+	natClass  string
+	rttMillis int64
+	sessionID string
+
+	est    *punch.Establishment
+	cancel context.CancelFunc
+}
+
+// OK reports whether the punch succeeded and BridgeHost/BridgePort/PeerIP are
+// valid. When false, the caller falls back to the relay hub endpoint.
+func (s *Session) OK() bool { return s.ok }
+
+// Reason is the failure reason for telemetry when OK()==false ("" on success).
+// One of: config, socket, nonce, discovery, request, declined:<hubError>, token,
+// punch, quic, bridge.
+func (s *Session) Reason() string { return s.reason }
+
+// NATClass is the client's locally-derived NAT mapping class: eim, symmetric, or
+// unknown. Advisory; the hub's reflector-observed class is authoritative.
+func (s *Session) NATClass() string { return s.natClass }
+
+// RTTMillis is the end-to-end punch establishment time in milliseconds (0 unless
+// OK()).
+func (s *Session) RTTMillis() int64 { return s.rttMillis }
+
+// SessionID is the hub-assigned punch session id (empty until the hub replies).
+func (s *Session) SessionID() string { return s.sessionID }
+
+// BridgeHost is the loopback host sing-box should dial in place of the relay
+// ("127.0.0.1" when OK()).
+func (s *Session) BridgeHost() string {
+	if s.est == nil {
+		return ""
+	}
+	return s.est.BridgeHost
+}
+
+// BridgePort is the loopback TCP port sing-box should dial (0 unless OK()).
+func (s *Session) BridgePort() int {
+	if s.est == nil {
+		return 0
+	}
+	return s.est.BridgePort
+}
+
+// PeerIP is the volunteer's reflexive UDP IP on the punched path. It MUST be
+// added to the sing-box TUN's route_exclude_address so the QUIC datagrams the
+// punch socket exchanges are not captured by auto_route/strict_route.
+func (s *Session) PeerIP() string {
+	if s.est == nil {
+		return ""
+	}
+	return s.est.PeerIP
+}
+
+// Close cancels the bridge context and releases the punched QUIC connection and
+// UDP socket. Safe to call multiple times and on a failed Session.
+func (s *Session) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+	if s.est != nil {
+		err := s.est.Close()
+		s.est = nil
+		return err
+	}
+	return nil
+}
+
+// Dial runs the full client punch flow — hub config fetch, reflector discovery,
+// punch request, UDP hole punch, QUIC dial, loopback bridge — and, on success,
+// starts serving the bridge on an internal goroutine bound to the Session's
+// context. The blocking work (hub HTTP up to ~10s, punch TTL ~6s, QUIC handshake
+// ~5s) runs synchronously in the caller's thread, so the platform must call Dial
+// off the main/UI thread.
+func Dial(cfg *Config, protector SocketProtector) (*Session, error) {
+	if cfg == nil {
+		return nil, errors.New("orpunch: nil config")
+	}
+	if cfg.HubBaseURL == "" || cfg.RelayID == "" {
+		return nil, errors.New("orpunch: config requires HubBaseURL and RelayID")
+	}
+	if protector == nil {
+		return nil, errors.New("orpunch: nil protector")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dialer := &punch.Dialer{
+		Hub:     punch.HubClient{BaseURL: cfg.HubBaseURL, HTTPClient: hubHTTPClient(cfg.Insecure)},
+		RelayID: cfg.RelayID,
+		Control: func(fd uintptr) { protector.Protect(int(fd)) },
+	}
+
+	est, res, err := dialer.Establish(ctx)
+	if err != nil {
+		cancel()
+		return &Session{
+			ok:        false,
+			reason:    res.Reason,
+			natClass:  res.NATClass,
+			sessionID: res.SessionID,
+		}, nil
+	}
+
+	// The bridge must outlive Establish: sing-box dials the loopback listener for
+	// the whole tunnel lifetime. It stops when the Session is Closed (ctx cancel)
+	// or the underlying QUIC connection drops.
+	go func() { _ = est.Bridge.Serve(ctx) }()
+
+	return &Session{
+		ok:        true,
+		reason:    res.Reason,
+		natClass:  res.NATClass,
+		rttMillis: res.RTTMillis,
+		sessionID: res.SessionID,
+		est:       est,
+		cancel:    cancel,
+	}, nil
+}
+
+// hubHTTPClient returns the HTTP client for the hub coordination API. With
+// insecure set it skips TLS verification for a self-signed hub cert; nil uses
+// punch.HubClient's bounded default. This weakens only the coordination channel —
+// the data path is independently secured (see Config.Insecure).
+func hubHTTPClient(insecure bool) *http.Client {
+	if !insecure {
+		return &http.Client{Timeout: hubHTTPTimeout}
+	}
+	return &http.Client{
+		Timeout: hubHTTPTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // self-signed hub cert; data path is independently secured
+		},
+	}
+}

--- a/mobile/orpunch/orpunch_test.go
+++ b/mobile/orpunch/orpunch_test.go
@@ -1,0 +1,248 @@
+package orpunch_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"openrung/internal/punch"
+	"openrung/mobile/orpunch"
+)
+
+// fakeHub stands up a punch coordinator faithful to internal/tunnel/punch.go but
+// with the volunteer running in-process: /request mints the session token, drives
+// the real punch.RespondToDirective (which punches back and serves QUIC bridged
+// to a loopback echo), and returns its ack. It lets orpunch.Dial exercise the
+// entire real client punch path against the real server code over loopback.
+type fakeHub struct {
+	secret    []byte
+	reflector *punch.Reflector
+	echoHost  string
+	echoPort  int
+	ctx       context.Context
+	relayID   string
+}
+
+func (h *fakeHub) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(punch.PathPunchConfig, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, punch.PunchConfig{
+			ReflectorAddrs: h.reflector.Addrs(),
+			ALPN:           punch.ALPN,
+			TTLMillis:      2000,
+		})
+	})
+	mux.HandleFunc(punch.PathPunchRequest, func(w http.ResponseWriter, r *http.Request) {
+		var req punch.PunchRequest
+		if err := json.NewDecoder(io.LimitReader(r.Body, 16<<10)).Decode(&req); err != nil {
+			writeJSON(w, punch.PunchResponse{OK: false, Error: "invalid request"})
+			return
+		}
+
+		// Classify the client from the hub's own reflector observations, exactly
+		// as the real coordinator does — the client's Gather must have populated
+		// them by now.
+		var clientReflexive []punch.Endpoint
+		clientClass := punch.ClassUnknown
+		if key, err := punch.NonceKey(req.ClientNonce); err == nil {
+			if class, reflexive, ok := h.reflector.Classify(key); ok {
+				clientClass = class
+				clientReflexive = punch.SanitizePeers(reflexive)
+			}
+		}
+
+		sessionID := "sess-" + strconv.FormatInt(int64(len(req.ClientNonce)), 10)
+		token := punch.EncodeToken(punch.ComputeToken(h.secret, sessionID, req.RelayID, req.ClientNonce))
+
+		dir := punch.PunchDirective{
+			SessionID:       sessionID,
+			RelayID:         req.RelayID,
+			ClientReflexive: clientReflexive,
+			ClientLocal:     punch.SanitizePeers(req.ClientLocal),
+			ClientClass:     clientClass,
+			PunchToken:      token,
+			ReflectorAddrs:  h.reflector.Addrs(),
+			TTLMillis:       2000,
+			QUICALPN:        punch.ALPN,
+			ProtoVersion:    punch.ProtoVersion,
+		}
+
+		// The volunteer's punch/bridge goroutine must outlive this request, so use
+		// the test context, not r.Context().
+		ack := punch.RespondToDirective(h.ctx, dir, h.echoHost, h.echoPort, discard())
+		if !ack.OK {
+			writeJSON(w, punch.PunchResponse{OK: false, Error: "volunteer declined: " + ack.Error})
+			return
+		}
+		writeJSON(w, punch.PunchResponse{
+			OK:                 true,
+			SessionID:          sessionID,
+			VolunteerReflexive: ack.VolunteerReflexive,
+			VolunteerLocal:     ack.VolunteerLocal,
+			VolunteerClass:     ack.VolunteerClass,
+			PunchToken:         token,
+			CertFingerprint:    ack.CertFingerprint,
+			TTLMillis:          2000,
+		})
+	})
+	return mux
+}
+
+func TestDialEndToEndOverLoopback(t *testing.T) {
+	echoHost, echoPort := startEchoServer(t)
+
+	reflector, err := punch.NewReflector([]string{"127.0.0.1:0"}, discard())
+	if err != nil {
+		t.Fatalf("reflector: %v", err)
+	}
+	defer reflector.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hub := httptest.NewServer((&fakeHub{
+		secret:    []byte("test-hub-session-secret-32-bytes!"),
+		reflector: reflector,
+		echoHost:  echoHost,
+		echoPort:  echoPort,
+		ctx:       ctx,
+		relayID:   "relay_loopback",
+	}).handler())
+	defer hub.Close()
+
+	var protectCalls int32
+	protector := protectorFunc(func(fd int) {
+		if fd <= 0 {
+			t.Errorf("protector got non-positive fd %d", fd)
+		}
+		atomic.AddInt32(&protectCalls, 1)
+	})
+
+	session, err := orpunch.Dial(&orpunch.Config{HubBaseURL: hub.URL, RelayID: "relay_loopback"}, protector)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer session.Close()
+
+	if !session.OK() {
+		t.Fatalf("punch did not succeed: reason=%q nat=%q", session.Reason(), session.NATClass())
+	}
+	if got := atomic.LoadInt32(&protectCalls); got != 1 {
+		t.Fatalf("Protect called %d times, want 1", got)
+	}
+	if session.BridgeHost() != "127.0.0.1" || session.BridgePort() <= 0 {
+		t.Fatalf("bad bridge endpoint %s:%d", session.BridgeHost(), session.BridgePort())
+	}
+	if net.ParseIP(session.PeerIP()) == nil {
+		t.Fatalf("PeerIP %q is not an IP", session.PeerIP())
+	}
+
+	// Bytes must flow client -> loopback bridge -> QUIC -> volunteer bridge -> echo.
+	if err := echoRoundTrip(session.BridgeHost(), session.BridgePort(), "hello-through-punch"); err != nil {
+		t.Fatalf("echo over punched path: %v", err)
+	}
+	if err := echoRoundTrip(session.BridgeHost(), session.BridgePort(), "second-stream"); err != nil {
+		t.Fatalf("second stream over punched path: %v", err)
+	}
+}
+
+func TestDialFallsBackWhenHubDeclines(t *testing.T) {
+	// A hub whose /request always declines: Dial must return a non-OK Session with
+	// a structured reason, NOT an error, so the caller falls back to the relay.
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == punch.PathPunchConfig {
+			writeJSON(w, punch.PunchConfig{ReflectorAddrs: []string{"127.0.0.1:1"}, ALPN: punch.ALPN, TTLMillis: 500})
+			return
+		}
+		writeJSON(w, punch.PunchResponse{OK: false, Error: "no volunteer"})
+	}))
+	defer hub.Close()
+
+	session, err := orpunch.Dial(&orpunch.Config{HubBaseURL: hub.URL, RelayID: "relay_x"}, protectorFunc(func(int) {}))
+	if err != nil {
+		t.Fatalf("Dial returned error (should be a non-OK Session): %v", err)
+	}
+	defer session.Close()
+	if session.OK() {
+		t.Fatal("expected punch to fail against a declining hub")
+	}
+	if session.Reason() == "" {
+		t.Fatal("expected a non-empty failure reason for telemetry")
+	}
+}
+
+func TestDialRejectsBadConfig(t *testing.T) {
+	if _, err := orpunch.Dial(nil, protectorFunc(func(int) {})); err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if _, err := orpunch.Dial(&orpunch.Config{RelayID: "r"}, protectorFunc(func(int) {})); err == nil {
+		t.Fatal("expected error for empty HubBaseURL")
+	}
+	if _, err := orpunch.Dial(&orpunch.Config{HubBaseURL: "http://x", RelayID: "r"}, nil); err == nil {
+		t.Fatal("expected error for nil protector")
+	}
+}
+
+// --- helpers ---
+
+type protectorFunc func(fd int)
+
+func (f protectorFunc) Protect(fd int) { f(fd) }
+
+func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func startEchoServer(t *testing.T) (string, int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(c)
+		}
+	}()
+	addr := ln.Addr().(*net.TCPAddr)
+	return "127.0.0.1", addr.Port
+}
+
+func echoRoundTrip(host string, port int, msg string) error {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), 2*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	if _, err := conn.Write([]byte(msg)); err != nil {
+		return err
+	}
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return err
+	}
+	if string(buf) != msg {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}


### PR DESCRIPTION
## What & why

The OpenRung **mobile** app adds NAT hole punching by reusing this repo's `internal/punch` client — the same code and `quic-go/quic-go v0.60.0` the desktop ships — bound into the app's sing-box/libbox AAR via **gomobile**. That makes the punched data path interoperate with the volunteer/hub byte-for-byte, instead of a separate Kotlin/Swift QUIC reimplementation that would have to track this code forever.

This PR is the small server/shared-code side of that: a thin gomobile-safe wrapper plus the one hook the mobile side needs. **Desktop behavior is unchanged.** (The Android integration + build wiring is a separate PR in `openrung/openrung-mobile-app`.)

## Changes

- **`mobile/orpunch/`** (new) — a gomobile-bindable wrapper over `internal/punch`. Every exported symbol crosses JNI as `String`/`int`/`bool`/`interface` only (`Config`, `Session`, `SocketProtector`, `Dial`); the rich Go types (`*net.UDPConn`, `*quic.Conn`, `Establishment`, `context`) stay owned inside the wrapper. A punch that doesn't succeed is reported as `Session.OK()==false` with a structured `reason`/`natClass` (not an `error`), so the caller falls back to the hub cleanly; `error` is reserved for programmer misuse. `Dial` serves the loopback bridge on a context that `Session.Close()` cancels.
- **`internal/punch/session.go`** — `Dialer` gains an optional `Control func(fd uintptr)` hook, applied to the punch UDP socket at creation via `net.ListenConfig`. Mobile uses it to `VpnService.protect()` the socket so the reflector / hole-punch / QUIC traffic escapes the app's own TUN. **`nil` on desktop → socket creation is byte-for-byte the previous `net.ListenUDP`.**

## Tests
- `mobile/orpunch/orpunch_test.go` — an end-to-end loopback punch driving `orpunch.Dial` against the real volunteer side (`RespondToDirective` + `ListenQUIC` + `VolunteerBridge`), asserting `OK()`, the bridge endpoint/`PeerIP`, live echo round-trips, and that the `SocketProtector` fires once with a live fd; plus the fallback-not-error and misuse-error contracts.
- `internal/punch/session_control_test.go` — `Control` fires exactly once with a nonzero fd; the `nil`-Control desktop path still yields a working `*net.UDPConn`.

## Reviewer notes
- `mobile/orpunch` lives inside this module (so it can import the internal `internal/punch`); it is only compiled when explicitly targeted (the mobile AAR build), so it adds nothing to desktop/server binaries.
- The mobile build wires this in via a go.mod `replace` to a local checkout of this branch and appends `openrung/mobile/orpunch` to sing-box's `build_libbox` bind (details in the companion mobile PR). No changes to this repo's own build.
- `go build ./...`, `go vet`, `gofmt`, and `go test ./internal/punch/... ./mobile/...` all pass; `cmd/client` and the `desktop/` module still build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)