### PR TITLE
tunnel: fix flaky TestHubReregistersWhenBrokerForgetsRelay

### DIFF
--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -29,6 +29,11 @@ type fakeRegistrar struct {
 	relayIDs []string
 	// failHeartbeatOnce is returned by the next Heartbeat call, then cleared.
 	failHeartbeatOnce error
+	// releaseHeartbeat, when non-nil, holds the Heartbeat call that returns
+	// failHeartbeatOnce until the channel is closed. This lets a test observe the
+	// pre-re-registration registry state deterministically instead of racing the
+	// re-registration that the not-found error triggers.
+	releaseHeartbeat chan struct{}
 }
 
 func (f *fakeRegistrar) Register(_ context.Context, req relay.RegisterRequest) (RelayRegistration, error) {
@@ -47,16 +52,28 @@ func (f *fakeRegistrar) Register(_ context.Context, req relay.RegisterRequest) (
 	return RelayRegistration{RelayID: id, PublicHost: req.PublicHost, PublicPort: req.PublicPort, ExpiresAt: time.Now().Add(time.Minute)}, nil
 }
 
-func (f *fakeRegistrar) Heartbeat(_ context.Context, _ string) error {
+func (f *fakeRegistrar) Heartbeat(ctx context.Context, _ string) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.heartbeats++
-	if f.failHeartbeatOnce != nil {
-		err := f.failHeartbeatOnce
-		f.failHeartbeatOnce = nil
-		return err
+	err := f.failHeartbeatOnce
+	if err == nil {
+		f.mu.Unlock()
+		return nil
 	}
-	return nil
+	f.failHeartbeatOnce = nil
+	gate := f.releaseHeartbeat
+	f.mu.Unlock()
+	// Hold the not-found response until the test releases the gate, so the
+	// assertion on the initial relay entry cannot race the re-registration this
+	// error triggers. Honor ctx so a failed test tears the goroutine down.
+	if gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return err
 }
 
 func (f *fakeRegistrar) stats() (registers, heartbeats int, lastReq relay.RegisterRequest) {
@@ -247,6 +264,7 @@ func TestHubReregistersWhenBrokerForgetsRelay(t *testing.T) {
 	registrar := &fakeRegistrar{
 		relayIDs:          []string{"relay_old", "relay_new"},
 		failHeartbeatOnce: fmt.Errorf("broker /api/v1/volunteers/relay_old/heartbeat: %w", ErrRelayNotFound),
+		releaseHeartbeat:  make(chan struct{}),
 	}
 	hub, controlAddr, _ := startTestHub(t, registrar, "secret")
 
@@ -287,11 +305,15 @@ func TestHubReregistersWhenBrokerForgetsRelay(t *testing.T) {
 	if ack.RelayID != "relay_old" {
 		t.Fatalf("relay_id = %q, want relay_old", ack.RelayID)
 	}
-	if hub.lookupTunnel("relay_old") == nil {
+	// The hub publishes the tunnel to its registry after sending the ack, so wait
+	// for the initial relay_old entry rather than reading it instantaneously. The
+	// gated heartbeat below guarantees re-registration has not yet removed it.
+	if !eventually(2*time.Second, func() bool { return hub.lookupTunnel("relay_old") != nil }) {
 		t.Fatal("registry missing initial relay_old entry")
 	}
 
-	// The first heartbeat returns not-found; the hub must re-register.
+	// Now let the first heartbeat return not-found; the hub must re-register.
+	close(registrar.releaseHeartbeat)
 	if !eventually(3*time.Second, func() bool {
 		registers, _, _ := registrar.stats()
 		return registers == 2


### PR DESCRIPTION
## Problem

`TestHubReregistersWhenBrokerForgetsRelay` intermittently failed with `registry missing initial relay_old entry` (server_test.go:291) and passed on re-run. Reproduced on 375f454 (a green-CI commit) with `go test -race -count=3 -run TestHubReregistersWhenBrokerForgetsRelay ./internal/tunnel/`.

## Root cause (test timing assumption, not a production bug)

The assertion `hub.lookupTunnel("relay_old") != nil` was an **instantaneous, non-retried** read of the hub registry taken the moment the client's `OnRegistered` callback fired. It raced two independent events:

1. **Publish-after-ack.** `handleControl` writes `HelloAck` — unblocking the client and the test — at `server.go:146`, but only calls `addTunnel("relay_old", …)` later at `server.go:176` (the ack must go out as a raw frame before yamux takes over the conn, and `addTunnel` needs the yamux-backed tunnel). So the test could look before the entry was ever inserted.
2. **Re-registration deleting it.** The heartbeat ticks every 25 ms; the first fails with `ErrRelayNotFound`, and `reregister` does `removeTunnel("relay_old")` + `addTunnel("relay_new")`. If the test goroutine was starved > 25 ms after the ack (easy under `-race`), `relay_old` was already gone.

A bare `eventually` wrapper fixes (1) but not (2) — if re-registration wins, `relay_old` never reappears.

## Fix

Test-only change (`internal/tunnel/server_test.go`):

- Added a `releaseHeartbeat` gate to `fakeRegistrar`. The heartbeat that returns the not-found error blocks on that channel until the test closes it — releasing the mutex first so `stats()` can't deadlock, and honoring `ctx` so a failed test doesn't leak the goroutine.
- The test now waits via `eventually` for `relay_old` to appear (closes race 1), then closes the gate to *let* re-registration proceed (closes race 2). Re-registration provably cannot remove `relay_old` until after the test has observed it.

The production hub is unchanged.

## Verification

| Scenario | Result |
|---|---|
| `-race -count=10` × 150 runs | **0 failures** |
| `GOMAXPROCS=4 count=15/25` saturation, ~1300+ runs | **0** "registry missing" failures |
| full `internal/tunnel` package, `-race -count=3` | `ok` |
| original binary, same load | reproduced ~1 in 300 |

### Note (out of scope)
Under deliberately pathological `GOMAXPROCS=4 × count=25` saturation, a *separate, pre-existing* flake appears — `timed out waiting for tunnel establishment` (the 3 s ack-wait), which the original binary hits at the same rate and which does not occur under the specified `-race -count=10`. Left alone here to keep this change scoped to the registry race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)