### PR TITLE
deploy: reconcile + document the container-hardening posture across the three provisioning scripts

### DIFF
--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -208,6 +208,35 @@ limiting and telemetry source IPs will all collapse onto the docker gateway.
 Firewall the raw origin `:8080` to Cloudflare's ranges so clients cannot bypass
 the edge and spoof forwarded headers.
 
+## Container hardening
+
+Both `docker-compose.yml` and `lightsail-up.sh` run the broker with a
+least-privilege container posture (verified 2026-07-13 by running the published
+image under the full flag set — it starts, serves `/healthz`, and enforces the
+read-only rootfs):
+
+- `--cap-drop ALL` — the broker binds `:8080` (≥ 1024) and never changes user or
+  mounts, so it needs no Linux capabilities.
+- `--security-opt no-new-privileges` — nothing in the image escalates via setuid
+  or file capabilities. (Unlike the volunteer relay, which must **not** set this:
+  it binds 443 through a `cap_net_bind_service` file capability that
+  `no-new-privileges` would disable.)
+- `--read-only` root filesystem with `--tmpfs /tmp` — the only writable paths are
+  `/tmp` and the telemetry named volume (`jsonl` mode appends there; `postgres`
+  mode writes nothing to disk).
+
+These flags take effect **only** for a container created by the script or compose
+file. A broker recreated by hand — for example a manual `docker run` that adds an
+extra `-e` override — does not inherit them unless the flags are re-typed. Verify
+a running container and recreate it (with the full flag set and `--env-file`) if
+it has drifted:
+
+```sh
+docker inspect openrung-broker \
+  --format '{{.HostConfig.ReadonlyRootfs}} {{.HostConfig.CapDrop}} {{.HostConfig.SecurityOpt}}'
+# want: true [ALL] [no-new-privileges]
+```
+
 ## Configuration
 
 | Variable                             | Required | Default                             | Purpose                                                        |

--- a/deploy/broker/lightsail-up.sh
+++ b/deploy/broker/lightsail-up.sh
@@ -93,8 +93,36 @@ GEOIP_ENV=""; [ -n "$GEOIP_ENDPOINT" ] && GEOIP_ENV="OPENRUNG_GEOIP_ENDPOINT=${G
 # Launch script: install Docker, write the env file, pull the public image, and
 # run the broker. Host networking so the broker sees real peer IPs (its
 # trusted-proxy client-IP logic needs them); a named volume persists telemetry
-# across restarts; the rootfs is otherwise read-only. The image points
-# OPENRUNG_TELEMETRY_FILE at the volume, so no telemetry path is set here.
+# across restarts.
+#
+# Container hardening — verified 2026-07-13 by running the published image
+# (ghcr.io/openrung/openrung-broker) under the full flag set below: it starts
+# clean and serves /healthz, the rootfs is enforced read-only (a write outside
+# the volume/tmpfs fails EROFS), and the jsonl telemetry file is created on the
+# volume. The flags on the `docker run` line:
+#   --cap-drop ALL                    the broker binds :8080 (>=1024) and never
+#                                     changes user or mounts, so it needs zero
+#                                     Linux capabilities.
+#   --security-opt no-new-privileges  nothing in the image escalates via setuid
+#                                     or file capabilities, so this is safe here.
+#                                     (The volunteer relay must NOT set this — it
+#                                     binds 443 through a file capability, which
+#                                     no-new-privileges disables. See its script.)
+#   --read-only --tmpfs /tmp          read-only rootfs; the only writable paths
+#                                     the broker needs are /tmp (Go temp) and the
+#                                     named volume below. In jsonl mode it appends
+#                                     telemetry + compaction temp files to the
+#                                     volume; in postgres mode it writes nothing
+#                                     to disk. The image points
+#                                     OPENRUNG_TELEMETRY_FILE at the volume, so no
+#                                     telemetry path is set here.
+#
+# These flags take effect ONLY for a container this script (or the compose file)
+# creates. A broker recreated by hand — e.g. a manual `docker run` that bolts on
+# an extra `-e` override — does NOT inherit them unless they are re-typed. Keep
+# the full flag set on any recreate and confirm with:
+#   docker inspect openrung-broker \
+#     --format '{{.HostConfig.ReadonlyRootfs}} {{.HostConfig.CapDrop}} {{.HostConfig.SecurityOpt}}'
 read -r -d '' USERDATA <<EOF || true
 #!/bin/sh
 # NOTE: Lightsail prepends its own #!/bin/sh preamble, so this runs under dash.

--- a/deploy/volunteer/hetzner-up.sh
+++ b/deploy/volunteer/hetzner-up.sh
@@ -76,6 +76,25 @@ hcloud firewall add-rule "$FIREWALL_NAME" --direction in --protocol icmp        
 # Cloud-init user-data: install Docker, pull the public image, run the relay. The
 # public IP is not known until the server exists, so the box self-discovers it
 # from Hetzner's metadata service at boot and bakes it into OPENRUNG_PUBLIC_HOST.
+#
+# Container hardening — identical posture to the Lightsail volunteer helper, and
+# the exact posture the production fleet runs (confirmed read-only via
+# `docker inspect` on a live Hetzner relay 2026-07-13: ReadonlyRootfs=true,
+# CapDrop=[ALL], CapAdd=[NET_BIND_SERVICE], while serving 443). The flags on the
+# `docker run` line:
+#   --cap-drop ALL --cap-add NET_BIND_SERVICE
+#       Drop every capability, re-add only the one needed to bind the privileged
+#       public port (443). The binary carries a cap_net_bind_service file
+#       capability (setcap in the Dockerfile); NET_BIND_SERVICE keeps it in the
+#       container's bounding set so the non-root `openrung` user can use it.
+#   (deliberately NO --security-opt no-new-privileges)
+#       no-new-privileges makes the kernel ignore file capabilities on exec,
+#       which would break the 443 bind. Do NOT add it here. To harden with
+#       no-new-privileges instead, serve a port >= 1024 and drop NET_BIND_SERVICE.
+#   --read-only --tmpfs /tmp
+#       Read-only rootfs; the only writable path the relay needs is the generated
+#       xray config under /tmp. Xray logs to stdout (loglevel warning, no log
+#       files), so nothing else is written.
 USERDATA_FILE="$(mktemp)"
 trap 'rm -f "$USERDATA_FILE"' EXIT
 cat >"$USERDATA_FILE" <<EOF

--- a/deploy/volunteer/lightsail-up.sh
+++ b/deploy/volunteer/lightsail-up.sh
@@ -45,6 +45,24 @@ STATIC_IP="$(aws lightsail get-static-ip --static-ip-name "$IPNAME" --region "$R
 
 # Launch script: install Docker, pull the public image, run the relay. The IP is
 # known up front (static IP), so OPENRUNG_PUBLIC_HOST and OPENRUNG_LABEL are baked in.
+#
+# Container hardening — this is the exact posture the production Lightsail and
+# Hetzner fleets run (confirmed read-only via `docker inspect` on 2026-07-13:
+# ReadonlyRootfs=true, CapDrop=[ALL], CapAdd=[NET_BIND_SERVICE], while serving
+# 443). The flags on the `docker run` line:
+#   --cap-drop ALL --cap-add NET_BIND_SERVICE
+#       Drop every capability, re-add only the one needed to bind the privileged
+#       public port (443). The binary carries a cap_net_bind_service file
+#       capability (setcap in the Dockerfile); NET_BIND_SERVICE keeps it in the
+#       container's bounding set so the non-root `openrung` user can use it.
+#   (deliberately NO --security-opt no-new-privileges)
+#       no-new-privileges makes the kernel ignore file capabilities on exec,
+#       which would break the 443 bind. Do NOT add it here. To harden with
+#       no-new-privileges instead, serve a port >= 1024 and drop NET_BIND_SERVICE.
+#   --read-only --tmpfs /tmp
+#       Read-only rootfs; the only writable path the relay needs is the generated
+#       xray config under /tmp. Xray logs to stdout (loglevel warning, no log
+#       files), so nothing else is written.
 read -r -d '' USERDATA <<EOF || true
 #!/bin/sh
 # NOTE: Lightsail prepends its own #!/bin/sh preamble, so this runs under dash.


### PR DESCRIPTION
## Summary

The three provisioning scripts prescribe a Docker container-hardening posture, but
(a) the live **broker** had drifted completely off it and (b) only the volunteer
compose/README explained *why* the flags are what they are, so the up.sh scripts
were a step away from being "helpfully" broken. This PR reconciles the three
scripts to one **correct, verified, consistently-documented** posture.

**No `docker run` flag is changed** — the flag sets are already correct and are now
verified. The change is comments + one README section. This is the
`If the hardening works: keep it` branch of the task, taken on evidence.

## What each script prescribes (unchanged)

| Script | cap-drop | cap-add | no-new-privileges | read-only | tmpfs | volume |
|---|---|---|---|---|---|---|
| `broker/lightsail-up.sh` | ALL | — | ✅ | ✅ | /tmp | `openrung-broker-state:/var/lib/openrung` |
| `volunteer/lightsail-up.sh` | ALL | NET_BIND_SERVICE | ❌ | ✅ | /tmp | — |
| `volunteer/hetzner-up.sh` | ALL | NET_BIND_SERVICE | ❌ | ✅ | /tmp | — |

The broker/volunteer differences are **principled, not accidental**:
- The broker binds `:8080` (≥1024) as non-root and needs **no** capabilities, so it
  can and does add `no-new-privileges`.
- The volunteer binds **443** as non-root via a `cap_net_bind_service` **file
  capability** (`setcap` in the Dockerfile). `no-new-privileges` makes the kernel
  ignore file capabilities on `exec`, so adding it would break the bind. Hence
  `--cap-add NET_BIND_SERVICE` **and no** `no-new-privileges`.

## Root cause of the drift

The broker script has prescribed the full hardening since its **first commit**
(`5da96f1`, 2026-07-07) — it was never "added but not yet shipped." The live prod
broker simply was **never deployed by this script**. `docker inspect` on
`typhoon-broker` shows the fingerprint of a hand-typed `docker run`: host net +
volume + `--env-file` **plus a duplicated inline** `-e OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`
and the postgres/foundation env — none of which the base script emits inline. That
manual command carried the functional flags forward but **dropped the four
hardening flags**.

The volunteers, which **are** deployed by their scripts (cloud-init runs the
script's exact `docker run`), run the full hardening in prod — live proof the
posture works and that the drift is operational, not a broken flag.

## Evidence

**Prod broker** (`typhoon-broker`, image `sha-d2f2f46`), read-only inspect:
```
ReadonlyRootfs=false  SecurityOpt=[]  CapDrop=[]  CapAdd=[]  Tmpfs=map[]
NetworkMode=host  Binds=[openrung-broker-state:/var/lib/openrung]  User=openrung
env: OPENRUNG_{RELAY,TELEMETRY}_STORE=postgres, ANONYMOUS_REGISTRATION=true (x2)
```
→ zero hardening flags in effect.

**Prod volunteers** (Lightsail `proud-falcon`, Hetzner `eager-raven`), read-only inspect:
```
ReadonlyRootfs=true  CapDrop=[ALL]  CapAdd=[CAP_NET_BIND_SERVICE]
Tmpfs=map[/tmp:]  SecurityOpt=[]  User=openrung  — serving 443
```
→ full prescribed hardening, working.

**Broker hardening works** — ran the exact prod image locally under the full flag
set (`--cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp` +
the named volume, default jsonl store):
- container `Running=true`, `/healthz` → `200 {"ok":true,...}`
- read-only rootfs enforced: write to a rootfs path → `Read-only file system` (EROFS);
  writes to `/var/lib/openrung` (volume) and `/tmp` (tmpfs) succeed
- jsonl telemetry file created on the volume at startup; `POST /api/v1/telemetry/events` → `202`

**Why read-only is safe for every writable path:**
- broker: `/tmp` (Go temp) + the named volume (jsonl append + `os.CreateTemp` compaction
  files live in the same dir on the volume; postgres mode writes nothing to disk).
- volunteer: only the generated xray config under `/tmp` (`-config-out` defaults to
  `os.TempDir()`); the generated xray config sets `log.loglevel=warning` with **no**
  log-file paths, so xray logs to stdout — nothing else is written.

## Changes

- `deploy/broker/lightsail-up.sh` — expand the pre-`docker run` comment to document
  the full posture, each writable path, and a **drift caveat**: these flags apply
  only to script/compose-created containers; a hand-recreated broker won't inherit
  them — verify with `docker inspect`.
- `deploy/volunteer/{lightsail,hetzner}-up.sh` — add parallel, evidence-backed
  hardening comments, including the **"do NOT add `no-new-privileges`"** guard (the
  scripts previously had none; only the compose/README did).
- `deploy/broker/README.md` — new **Container hardening** section mirroring the
  above, with the drift caveat and the inspect command.

## Follow-up (separate, needs your approval — NOT in this PR)

The live broker is unhardened. To close the drift, recreate it **on the box** with
the hardened flags, preserving the current prod env (postgres stores, foundation
token in the env file, the anonymous-registration override), e.g.:

```sh
# on typhoon-broker (54.238.185.205)
sudo docker rm -f openrung-broker
sudo docker run -d --name openrung-broker --restart unless-stopped \
  --network host --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp \
  -v openrung-broker-state:/var/lib/openrung \
  --env-file /etc/openrung/broker.env \
  -e OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true \
  ghcr.io/openrung/openrung-broker:sha-d2f2f46
```
This is a brief control-plane blip (the broker carries no user traffic; clients use
cached/signed relay lists across it). Confirm afterward:
`docker inspect openrung-broker --format '{{.HostConfig.ReadonlyRootfs}} {{.HostConfig.CapDrop}} {{.HostConfig.SecurityOpt}}'` → `true [ALL] [no-new-privileges]`,
then `curl -s localhost:8080/healthz`.

## Out of scope (noted, not touched)

`deploy/relayhub/lightsail-up.sh` also prescribes `--cap-drop ALL --read-only --tmpfs /tmp`
(non-privileged ports, non-root, certs `:ro`). Like the broker, it could safely add
`--security-opt no-new-privileges`; left for a separate change to keep this PR to the
three scripts in scope.
