### PR TITLE
broker: document end-to-end TLS for the CloudFront front origin leg

### DIFF
--- a/deploy/broker-proxy/README.md
+++ b/deploy/broker-proxy/README.md
@@ -93,11 +93,15 @@ Logs: `wrangler tail openrung-broker-proxy`.
 
 ## Known limitations / follow-ups
 
-- **Origin leg is plaintext HTTP.** The censorship-relevant leg (client → Cloudflare) is
-  encrypted, but Cloudflare → origin is HTTP over the public internet. Harden by giving the origin
-  a Cloudflare Origin CA cert and switching SSL/TLS mode to Full (strict), by fronting via a
+- **Origin leg is plaintext HTTP (this Worker front only).** The censorship-relevant leg
+  (client → Cloudflare) is encrypted, but *this Worker's* Cloudflare → origin subrequest is still
+  HTTP (`http://broker-origin.openrung.org:8080`) over the public internet. Harden by giving the
+  origin a Cloudflare Origin CA cert and switching SSL/TLS mode to Full (strict), by fronting via a
   Cloudflare Tunnel (no public origin port), or by firewalling the origin to Cloudflare egress
-  ranges only.
+  ranges only. **The independent AWS CloudFront front already has end-to-end TLS to the origin**
+  (via a Caddy Let's Encrypt terminator on `:443` — see `deploy/broker/origin-tls.md`); the same
+  `:443` origin endpoint is now available to point this Worker at
+  (`https://broker-origin.openrung.org`) to close its leg too.
 - **Client IP recovery (done).** The Worker forwards the real client IP as `X-Forwarded-For`, and
   the broker now honors `CF-Connecting-IP` / `X-Forwarded-For` **only when the request arrives from a
   trusted proxy** (Cloudflare's published ranges by default; extend via `OPENRUNG_TRUSTED_PROXY_CIDRS`).

--- a/deploy/broker/Caddyfile
+++ b/deploy/broker/Caddyfile
@@ -7,13 +7,13 @@
 # for community volunteer relay registration and for the Cloudflare Worker front
 # (broker.openrung.org), neither of which pass through here.
 #
-# Serves its cert on SNI broker-origin.openrung.org. AWS CloudFront (distribution
-# E2PLKW8FO3JZSA) must be configured to send THAT hostname as the origin SNI —
-# i.e. the behavior must use the AllViewerExceptHostHeader origin-request policy,
-# NOT AllViewer (which forwards the viewer Host and makes CloudFront use the
-# distribution domain as SNI, for which this proxy has no cert). See
-# origin-tls.md. The default ECDSA (P-256) leaf is fine for CloudFront and every
-# other client.
+# Serves its cert on SNI broker-origin.openrung.org. CloudFront (distribution
+# E2PLKW8FO3JZSA) is configured to send THAT hostname as the origin SNI via the
+# AllViewerExceptHostHeader origin-request policy. (Do NOT switch it back to
+# AllViewer: that forwards the viewer Host, which CloudFront then uses as the
+# origin SNI — the distribution domain, which this proxy has no cert for, so the
+# handshake 502s. See origin-tls.md.) The default ECDSA (P-256) leaf is fine for
+# CloudFront and every other client.
 
 {
 	# No ACME account email on purpose: Caddy auto-renews, so expiry notices are
@@ -26,13 +26,13 @@ broker-origin.openrung.org {
 		# Client-IP provenance for the CloudFront path.
 		#
 		# The broker honors forwarded client IPs only from trusted proxies
-		# (internal/broker/clientip.go). CloudFront's behavior forwards ALL viewer
-		# headers except Host, so a client could inject X-Forwarded-For /
-		# CF-Connecting-IP. Strip both and set XFF to our own immediate peer — the
-		# UNSPOOFABLE CloudFront edge IP — so that when the broker trusts this
-		# loopback hop (OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128) it
-		# buckets CloudFront-fronted requests by the CloudFront edge IP rather than
-		# collapsing them all onto 127.0.0.1.
+		# (internal/broker/clientip.go) and trusts this loopback hop:
+		# OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128 IS set on the broker.
+		# CloudFront forwards ALL viewer headers except Host, so a client could
+		# inject X-Forwarded-For / CF-Connecting-IP. Strip both and set XFF to our
+		# own immediate peer — the UNSPOOFABLE CloudFront edge IP — so the broker
+		# buckets CloudFront-fronted requests (rate limit, telemetry) by that edge
+		# IP instead of collapsing them all onto 127.0.0.1.
 		header_up -CF-Connecting-IP
 		header_up X-Forwarded-For {remote_host}
 	}

--- a/deploy/broker/Caddyfile
+++ b/deploy/broker/Caddyfile
@@ -7,39 +7,32 @@
 # for community volunteer relay registration and for the Cloudflare Worker front
 # (broker.openrung.org), neither of which pass through here.
 #
-# Serves its cert on SNI broker-origin.openrung.org, which is exactly the SNI
-# AWS CloudFront (distribution E2PLKW8FO3JZSA) sends to its origin.
+# Serves its cert on SNI broker-origin.openrung.org. AWS CloudFront (distribution
+# E2PLKW8FO3JZSA) must be configured to send THAT hostname as the origin SNI —
+# i.e. the behavior must use the AllViewerExceptHostHeader origin-request policy,
+# NOT AllViewer (which forwards the viewer Host and makes CloudFront use the
+# distribution domain as SNI, for which this proxy has no cert). See
+# origin-tls.md. The default ECDSA (P-256) leaf is fine for CloudFront and every
+# other client.
 
 {
 	# No ACME account email on purpose: Caddy auto-renews, so expiry notices are
 	# non-essential, and we avoid tying an operator identity to the issuance.
 	# Let's Encrypt production CA + ToS are accepted implicitly by Caddy.
-
-	# RSA (not Caddy's default ECDSA) leaf key. AWS CloudFront's origin-facing TLS
-	# cipher list is RSA-only: it offers the origin ECDHE-RSA / RSA suites and NO
-	# ECDHE-ECDSA suites. An ECDSA leaf therefore shares no cipher with CloudFront
-	# and the origin handshake fails with a 502. An RSA leaf negotiates
-	# ECDHE-RSA-AES128-GCM-SHA256 and is universally compatible (browsers, curl,
-	# the Cloudflare Worker path is unaffected — it hits plaintext :8080).
-	key_type rsa2048
 }
 
 broker-origin.openrung.org {
 	reverse_proxy 127.0.0.1:8080 {
 		# Client-IP provenance for the CloudFront path.
 		#
-		# The broker trusts only Cloudflare's ranges for forwarded client IPs
-		# (internal/broker/clientip.go); it does NOT trust this loopback hop
-		# unless OPENRUNG_TRUSTED_PROXY_CIDRS includes 127.0.0.1/32,::1/128.
-		# Until it does, the broker records 127.0.0.1 as the client for every
-		# CloudFront-fronted request (a single rate-limit bucket / telemetry IP).
-		#
-		# CloudFront's behavior forwards ALL viewer headers (Managed-AllViewer),
-		# so a client could inject X-Forwarded-For / CF-Connecting-IP. Strip both
-		# and set XFF to our own immediate peer — the UNSPOOFABLE CloudFront edge
-		# IP. Then the day the broker is told to trust 127.0.0.1/32,::1/128 it
-		# recovers exact parity with the pre-proxy behavior (bucket by CloudFront
-		# edge IP), unspoofably, with no further change here.
+		# The broker honors forwarded client IPs only from trusted proxies
+		# (internal/broker/clientip.go). CloudFront's behavior forwards ALL viewer
+		# headers except Host, so a client could inject X-Forwarded-For /
+		# CF-Connecting-IP. Strip both and set XFF to our own immediate peer — the
+		# UNSPOOFABLE CloudFront edge IP — so that when the broker trusts this
+		# loopback hop (OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128) it
+		# buckets CloudFront-fronted requests by the CloudFront edge IP rather than
+		# collapsing them all onto 127.0.0.1.
 		header_up -CF-Connecting-IP
 		header_up X-Forwarded-For {remote_host}
 	}

--- a/deploy/broker/Caddyfile
+++ b/deploy/broker/Caddyfile
@@ -1,0 +1,54 @@
+# OpenRung broker origin-TLS front.
+#
+# Purely ADDITIVE: terminates Let's Encrypt TLS on :443 for
+# broker-origin.openrung.org and reverse-proxies to the broker container, which
+# is untouched on 127.0.0.1:8080. Auto-renewal is native to Caddy (the running
+# service renews ~30 days before expiry). The plaintext :8080 origin stays open
+# for community volunteer relay registration and for the Cloudflare Worker front
+# (broker.openrung.org), neither of which pass through here.
+#
+# Serves its cert on SNI broker-origin.openrung.org, which is exactly the SNI
+# AWS CloudFront (distribution E2PLKW8FO3JZSA) sends to its origin.
+
+{
+	# No ACME account email on purpose: Caddy auto-renews, so expiry notices are
+	# non-essential, and we avoid tying an operator identity to the issuance.
+	# Let's Encrypt production CA + ToS are accepted implicitly by Caddy.
+
+	# RSA (not Caddy's default ECDSA) leaf key. AWS CloudFront's origin-facing TLS
+	# cipher list is RSA-only: it offers the origin ECDHE-RSA / RSA suites and NO
+	# ECDHE-ECDSA suites. An ECDSA leaf therefore shares no cipher with CloudFront
+	# and the origin handshake fails with a 502. An RSA leaf negotiates
+	# ECDHE-RSA-AES128-GCM-SHA256 and is universally compatible (browsers, curl,
+	# the Cloudflare Worker path is unaffected — it hits plaintext :8080).
+	key_type rsa2048
+}
+
+broker-origin.openrung.org {
+	reverse_proxy 127.0.0.1:8080 {
+		# Client-IP provenance for the CloudFront path.
+		#
+		# The broker trusts only Cloudflare's ranges for forwarded client IPs
+		# (internal/broker/clientip.go); it does NOT trust this loopback hop
+		# unless OPENRUNG_TRUSTED_PROXY_CIDRS includes 127.0.0.1/32,::1/128.
+		# Until it does, the broker records 127.0.0.1 as the client for every
+		# CloudFront-fronted request (a single rate-limit bucket / telemetry IP).
+		#
+		# CloudFront's behavior forwards ALL viewer headers (Managed-AllViewer),
+		# so a client could inject X-Forwarded-For / CF-Connecting-IP. Strip both
+		# and set XFF to our own immediate peer — the UNSPOOFABLE CloudFront edge
+		# IP. Then the day the broker is told to trust 127.0.0.1/32,::1/128 it
+		# recovers exact parity with the pre-proxy behavior (bucket by CloudFront
+		# edge IP), unspoofably, with no further change here.
+		header_up -CF-Connecting-IP
+		header_up X-Forwarded-For {remote_host}
+	}
+
+	log {
+		output file /var/log/caddy/broker-origin.access.log {
+			roll_size 20MiB
+			roll_keep 5
+		}
+		format json
+	}
+}

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -208,6 +208,18 @@ limiting and telemetry source IPs will all collapse onto the docker gateway.
 Firewall the raw origin `:8080` to Cloudflare's ranges so clients cannot bypass
 the edge and spoof forwarded headers.
 
+### End-to-end TLS to the origin
+
+For a front to reach the origin over HTTPS (so tokens like the Foundation
+registration token are never in cleartext on the edge → origin leg), terminate
+TLS on the broker box with a Let's Encrypt reverse proxy on `:443` that forwards
+to the broker on `:8080`. The production setup for the AWS CloudFront front —
+Caddy config, cert/renewal, firewall, the required CloudFront origin settings,
+verification, and rollback — is documented in
+[`origin-tls.md`](./origin-tls.md), with the deployed config in
+[`Caddyfile`](./Caddyfile). It is additive: the broker container and the
+plaintext `:8080` path are untouched.
+
 ## Container hardening
 
 Both `docker-compose.yml` and `lightsail-up.sh` run the broker with a

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -252,7 +252,7 @@ depend on it.
 
 ## Follow-ups
 
-- **Loopback-wide rate-limit / telemetry collapse — RESOLVED 2026-07-13; residual per-edge aggregation is by design.**
+- **Loopback-wide rate-limit / telemetry collapse — RESOLVED 2026-07-13; now keyed per-CloudFront-edge.**
   The broker trusts only Cloudflare ranges for forwarded client IPs
   (`internal/broker/clientip.go`) and did not trust the new loopback hop, so it
   recorded `127.0.0.1` as the client for *every* CloudFront-fronted request — the
@@ -262,20 +262,28 @@ depend on it.
   (durable) and recreating the broker container; the broker now keys on the
   unspoofable CloudFront **edge** IP that Caddy forwards as the sole
   `X-Forwarded-For` value (client-supplied `CF-Connecting-IP`/`XFF` are stripped).
-  No Caddy change was needed.
+  No Caddy change was needed. This restores the **pre-proxy** behavior exactly.
 
-  This restores the **pre-proxy** behavior exactly — keyed by CloudFront edge IP —
-  and is **not per-viewer**. Clients sharing one CloudFront edge still share that
-  edge's 2 req/s / burst-30 relay-list bucket and its telemetry identity. That is
-  deliberate: the only per-viewer signal CloudFront gives the origin is the
-  client-*appended* `X-Forwarded-For`, which a client can forge to evade the
-  limiter or poison telemetry — so the edge IP (which the client cannot forge) is
-  the correct key. Residual to keep in mind, **especially under mass failover**:
-  when many clients in a region funnel through a handful of nearby edges, a
-  per-edge bucket can still hit its limit (far better than the single-bucket
-  collapse, but coarser than per-viewer). True per-viewer limiting would require
-  CloudFront to attest the viewer IP in a header the origin can trust; it does
-  not, so this is left as-is.
+- **Per-*viewer* rate-limit / telemetry on the CloudFront path — OPEN (achievable, not yet done).**
+  Per-edge keying (above) is a current *implementation* choice, **not** a CloudFront
+  limitation: clients sharing one CloudFront edge still share that edge's
+  2 req/s / burst-30 bucket and telemetry identity, which can still saturate under
+  a **mass-failover** surge (many clients in a region funnelling through a few
+  nearby edges). CloudFront *does* expose an attested per-viewer signal that
+  `AllViewerExceptHostHeader` already forwards to the origin: **`CloudFront-Viewer-Address`**
+  (`<viewer-ip>:<port>`, plus the `CloudFront-Viewer-*` geo/ASN suite). Verified
+  2026-07-13 that it is **unspoofable through CloudFront** — a request sent through
+  the distribution with a forged `CloudFront-Viewer-Address: 203.0.113.99:4444`
+  arrived at the origin as the real viewer IP (`159.117.71.211:59399`); CloudFront
+  overwrites any client-supplied value. To adopt per-viewer keying, map the IP part
+  of `CloudFront-Viewer-Address` into the client IP the broker keys on (e.g. Caddy
+  rewrites `X-Forwarded-For` from it for this vhost). **Caveat that must be handled
+  first:** the origin `:443` is internet-facing, so a *direct* hit (not via
+  CloudFront) could forge `CloudFront-Viewer-Address`. Trust it only after
+  authenticating the request actually came through CloudFront — a shared-secret
+  custom origin header CloudFront injects, or restricting `:443` ingress to
+  CloudFront's origin-facing IP ranges — otherwise per-viewer keying would be
+  *more* spoofable than the current edge-IP key, not less.
 - **Cloudflare Worker front origin leg is still plaintext.**
   `broker.openrung.org` (the Worker) still fetches `http://broker-origin…:8080`.
   Now that `:443` origin TLS exists, the Worker could be pointed at

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -1,0 +1,217 @@
+# Broker origin TLS (end-to-end HTTPS for the CloudFront front)
+
+The broker runs plaintext HTTP on `:8080`. Fronts terminate client TLS at the
+edge, but the **edge → origin** leg was HTTP. On the AWS CloudFront front
+(distribution `E2PLKW8FO3JZSA`, `d2r7mdpyevvs1m.cloudfront.net`) that leg
+carried the high-value **Foundation registration token** (`Authorization`
+header on `POST /api/v1/volunteers/register`) in cleartext across the public
+internet. This runbook closes that leg with a TLS-terminating reverse proxy on
+the broker box so the token is encrypted **relay → CloudFront edge → origin**.
+
+```
+relay ──HTTPS──► CloudFront edge ──HTTPS(:443)──► Caddy ──HTTP(127.0.0.1:8080)──► broker
+                 (E2PLKW8FO3JZSA)   broker-origin.openrung.org      (container, unchanged)
+```
+
+The broker container is **not touched** — the proxy is purely additive, and the
+plaintext `:8080` path stays open for community volunteer relays and for the
+Cloudflare Worker front. Set up 2026-07-13.
+
+## What must not be undone
+
+- **`broker-origin.openrung.org` must stay DNS-only (grey cloud) in Cloudflare.**
+  It is an `A` record → `54.238.185.205`. Orange-clouding (proxying) it would
+  reintroduce Cloudflare's datacenter challenge on the origin and loop the
+  Cloudflare Worker's subrequest back into the edge. Both CDN fronts depend on
+  this record resolving straight to the broker IP.
+- **Keep `:8080` open.** Community volunteers (Hetzner + Lightsail, see
+  `deploy/volunteer/hetzner-up.sh`) register directly against
+  `http://54.238.185.205:8080`, and the Cloudflare Worker front fetches the
+  origin on `:8080`. Do not firewall it off as part of this change.
+- **The origin cert must be RSA, not ECDSA** — see the CloudFront gotchas below.
+- **The CloudFront behavior must use `Managed-AllViewerExceptHostHeader`, not
+  `Managed-AllViewer`** — see the CloudFront gotchas below.
+- Do not disable/mask the `caddy` service; it both serves TLS and auto-renews
+  the cert.
+
+## Broker box: Caddy TLS terminator
+
+Host: Lightsail `typhoon-broker`, `ssh -i ~/.ssh/id_ed25519_openrung ubuntu@54.238.185.205`.
+
+Caddy was chosen for native Let's Encrypt auto-renewal (no cron/certbot timer to
+manage). ACM certs cannot be installed on Lightsail, and a self-signed cert
+would not validate at CloudFront — so a publicly-trusted Let's Encrypt cert is
+required.
+
+### Install
+
+```sh
+sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl gnupg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt-get update && sudo apt-get install -y caddy   # installs the systemd service, enabled
+```
+
+### Config
+
+`/etc/caddy/Caddyfile` (also committed as `deploy/broker/Caddyfile` for
+reference):
+
+```caddyfile
+{
+	key_type rsa2048        # REQUIRED for CloudFront — see gotchas
+}
+
+broker-origin.openrung.org {
+	reverse_proxy 127.0.0.1:8080 {
+		header_up -CF-Connecting-IP
+		header_up X-Forwarded-For {remote_host}
+	}
+	log {
+		output file /var/log/caddy/broker-origin.access.log {
+			roll_size 20MiB
+			roll_keep 5
+		}
+		format json
+	}
+}
+```
+
+The log directory is provided by a systemd drop-in (the packaged unit sandboxes
+the service, so a plain `mkdir` is not enough — systemd must own the path):
+
+`/etc/systemd/system/caddy.service.d/logdir.conf`
+
+```ini
+[Service]
+LogsDirectory=caddy
+LogsDirectoryMode=0750
+```
+
+Apply changes as the `caddy` user (never `sudo caddy validate`/`fmt` as root — it
+creates a root-owned log file that the service then can't open):
+
+```sh
+sudo -u caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+sudo systemctl reload caddy
+```
+
+### Firewall
+
+`:443` was opened on the Lightsail instance (additive; `:80` was already open and
+is used for the ACME HTTP-01 challenge):
+
+```sh
+aws lightsail open-instance-public-ports --instance-name typhoon-broker \
+  --region ap-northeast-1 --port-info fromPort=443,toPort=443,protocol=TCP
+```
+
+Open ports afterward: `22, 80, 443, 8080`.
+
+### Cert + renewal
+
+- Cert: `CN=broker-origin.openrung.org`, **RSA-2048**, Let's Encrypt, 90-day.
+  Issued via **HTTP-01** on `:80`.
+- Renewal: **automatic and native to Caddy** (ARI-scheduled; renews well before
+  expiry as long as the service runs). No timer or cron to maintain. Stored in
+  `/var/lib/caddy/.local/share/caddy/`.
+- No ACME account email is set (Caddy auto-renews, so expiry notices are
+  unnecessary, and it avoids attaching an operator identity to issuance).
+
+## CloudFront front: `E2PLKW8FO3JZSA`
+
+Two config changes (CloudFront/ACM are global — use `--region us-east-1`; the
+CLI profile's default region is a broken AZ value so pass it explicitly):
+
+1. **Origin protocol `http-only` → `https-only`** (`HTTPSPort` was already 443,
+   `OriginSslProtocols=[TLSv1.2]`). This is the change that encrypts the leg.
+2. **Origin request policy `Managed-AllViewer` → `Managed-AllViewerExceptHostHeader`**
+   (`216adef6-…` → `b689b0a8-53d0-40ab-baf2-68738e2966ac`). **Required** — see
+   gotchas. This policy still forwards everything except `Host` (all other
+   headers incl. `Authorization`, all cookies, all query strings), so the
+   Foundation token still reaches the origin.
+
+Both are applied with `get-distribution-config` → edit `DistributionConfig` →
+`update-distribution --if-match <ETag>`, then `aws cloudfront wait
+distribution-deployed`.
+
+### Two CloudFront gotchas (each caused a 502 during rollout)
+
+1. **RSA cert, not ECDSA.** Caddy's default leaf key is ECDSA (P-256).
+   CloudFront's origin-facing TLS cipher list is **RSA-only** (it offers the
+   origin `ECDHE-RSA-*` / `AES*` suites and *no* `ECDHE-ECDSA-*` suites), so an
+   ECDSA leaf shares no cipher with CloudFront and the handshake fails with a
+   502. Fixed with `key_type rsa2048`. (Changing `key_type` does not re-issue an
+   existing cert — the old ECDSA cert dir under
+   `…/certificates/…/broker-origin.openrung.org/` was removed and Caddy
+   restarted to force fresh RSA issuance.)
+
+2. **`AllViewerExceptHostHeader`, not `AllViewer`.** With `Managed-AllViewer`,
+   CloudFront forwards the viewer `Host` header **and uses it as the origin
+   SNI** — so it sent `SNI: d2r7mdpyevvs1m.cloudfront.net`. Caddy has no cert for
+   that name and rejected the handshake (`no certificate available for
+   'd2r7mdpyevvs1m.cloudfront.net'`) → 502. `AllViewerExceptHostHeader` makes
+   CloudFront send the **origin** hostname (`broker-origin.openrung.org`) as both
+   `Host` and SNI, which Caddy serves and routes. CloudFront still validates the
+   returned cert against the *origin domain name*, which matches.
+
+## Verify
+
+```sh
+# Origin TLS directly (publicly-trusted cert, signed relay list):
+curl -v https://broker-origin.openrung.org/api/v1/relays        # 200, cert verifies
+
+# End-to-end through CloudFront (works from a datacenter IP; the Cloudflare
+# Worker front 403s datacenter IPs by design):
+curl https://d2r7mdpyevvs1m.cloudfront.net/api/v1/relays?limit=1 # 200, X-OpenRung-Relays-Signature present
+curl -X POST -H 'Content-Type: application/json' -d '{}' \
+  https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register   # 400 {"error":"public_host is required"}
+
+# Volunteer plaintext path still intact:
+curl http://54.238.185.205:8080/api/v1/relays                   # 200
+
+# Confirm CloudFront connects over TLS (SNI = origin, not the CF domain):
+sudo tail /var/log/caddy/broker-origin.access.log   # request.tls.server_name = broker-origin.openrung.org
+```
+
+## Rollback
+
+The proxy is additive and reversible. To revert the CloudFront front to the
+previous (verified-working) plaintext-origin state, restore the original
+`DistributionConfig` (`OriginProtocolPolicy=http-only` +
+`OriginRequestPolicyId=Managed-AllViewer`):
+
+```sh
+aws cloudfront get-distribution-config --id E2PLKW8FO3JZSA --region us-east-1   # note ETag
+# set OriginProtocolPolicy=http-only and OriginRequestPolicyId=216adef6-5c7f-47e4-b989-5492eafa07d3
+aws cloudfront update-distribution --id E2PLKW8FO3JZSA --region us-east-1 \
+  --distribution-config file://rollback.json --if-match <ETag>
+```
+
+Caddy itself can be stopped without affecting the broker or `:8080`
+(`sudo systemctl stop caddy`) — only the origin `:443` and the CloudFront front
+depend on it.
+
+## Known follow-ups (not done here)
+
+- **Per-client rate-limit / telemetry granularity on the CloudFront path.** The
+  broker trusts only Cloudflare ranges for forwarded client IPs
+  (`internal/broker/clientip.go`); it does **not** trust the new loopback hop, so
+  it records `127.0.0.1` as the client for CloudFront-fronted requests — i.e.
+  the whole CloudFront front shares one relay-list rate-limit bucket (2 req/s,
+  burst 30) and one telemetry client IP. This is benign day-to-day (CloudFront
+  is a cold 2.5 s-stagger *failover* front — normal traffic ≈ 0), but a
+  mass-failover surge (primary Worker/Cloudflare down) would all land in that one
+  bucket. To restore per-edge-IP bucketing, recreate the broker container with
+  `OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128`; the Caddy config already
+  forwards the unspoofable CloudFront edge IP as the sole `X-Forwarded-For` value
+  (and strips client-supplied `CF-Connecting-IP`/`XFF`), so no proxy change is
+  needed — only the broker env. **Requires a broker container recreate → operator
+  approval** (per the no-autonomous-broker-recreate policy).
+- **Cloudflare Worker front origin leg is still plaintext.**
+  `broker.openrung.org` (the Worker) still fetches `http://broker-origin…:8080`.
+  Now that `:443` origin TLS exists, the Worker could be pointed at
+  `https://broker-origin.openrung.org` to close its leg too — a separate change
+  to the higher-traffic primary front, deliberately out of scope here.

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -171,11 +171,9 @@ was the sole cause of the 502.
 # Origin TLS directly (publicly-trusted cert, signed relay list):
 curl -v https://broker-origin.openrung.org/api/v1/relays        # 200, cert verifies
 
-# End-to-end through CloudFront (works from a datacenter IP; the Cloudflare
-# Worker front 403s datacenter IPs by design):
+# Discovery end-to-end through CloudFront (works from a datacenter IP; the
+# Cloudflare Worker front 403s datacenter IPs by design):
 curl https://d2r7mdpyevvs1m.cloudfront.net/api/v1/relays?limit=1 # 200, X-OpenRung-Relays-Signature present
-curl -X POST -H 'Content-Type: application/json' -d '{}' \
-  https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register   # 400 {"error":"public_host is required"}
 
 # Volunteer plaintext path still intact:
 curl http://54.238.185.205:8080/api/v1/relays                   # 200
@@ -183,6 +181,38 @@ curl http://54.238.185.205:8080/api/v1/relays                   # 200
 # Confirm CloudFront connects over TLS (SNI = origin, not the CF domain):
 sudo tail /var/log/caddy/broker-origin.access.log   # request.tls.server_name = broker-origin.openrung.org
 ```
+
+### The load-bearing test: does the Foundation token survive the origin leg?
+
+This is the whole point of the change, and it needs a **discriminating** test.
+`POST {}` → `400 public_host is required` does **not** prove it: prod permits
+anonymous registration (`OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`), so an
+*unauthenticated* request gets the same 400 even if `Authorization` were stripped.
+
+Send a `node_class: foundation` registration (which *requires* the Foundation
+token) with `public_host` **omitted**, so no relay is ever created — only the auth
+decision differs. Run with the real token from a shell that won't log it (leading
+space / token in a var), never over the plaintext port:
+
+```sh
+FT=…            # the OPENRUNG_FOUNDATION_TOKEN (from the root-owned broker env)
+CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
+
+# WITH token  -> 400 public_host is required   => token SURVIVED CloudFront->origin
+curl -s -o /dev/null -w '%{http_code}\n' -X POST -H "Authorization: Bearer $FT" \
+  -H 'Content-Type: application/json' -d '{"node_class":"foundation"}' "$CF"
+
+# WITHOUT token -> 403 "requires the foundation registration token" => header loss WOULD show here
+curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+  -H 'Content-Type: application/json' -d '{"node_class":"foundation"}' "$CF"
+```
+
+`400` vs `403` is the signal: if `AllViewerExceptHostHeader` (or the origin leg)
+dropped `Authorization`, the first call would return `403` like the second.
+Verified 2026-07-13: `400` with the token, `403` without. As a no-secret
+cross-check, the Caddy access log records `request.headers.Authorization =
+["REDACTED"]` on a CloudFront-fronted request that carried one (Caddy redacts the
+value, so the token is never written to disk).
 
 ## Rollback
 

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -98,6 +98,11 @@ sudo -u caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
 sudo systemctl reload caddy
 ```
 
+The JSON access log redacts sensitive request headers by default — Caddy replaces
+`Authorization`, `Cookie`, `Set-Cookie`, and `Proxy-Authorization` with `REDACTED`
+— so the Foundation bearer token is never written to
+`/var/log/caddy/broker-origin.access.log`.
+
 ### Firewall
 
 `:443` was opened on the Lightsail instance (additive; `:80` was already open and
@@ -194,22 +199,21 @@ Caddy itself can be stopped without affecting the broker or `:8080`
 (`sudo systemctl stop caddy`) — only the origin `:443` and the CloudFront front
 depend on it.
 
-## Known follow-ups (not done here)
+## Follow-ups
 
-- **Per-client rate-limit / telemetry granularity on the CloudFront path.** The
-  broker trusts only Cloudflare ranges for forwarded client IPs
-  (`internal/broker/clientip.go`); it does **not** trust the new loopback hop, so
-  it records `127.0.0.1` as the client for CloudFront-fronted requests — i.e.
-  the whole CloudFront front shares one relay-list rate-limit bucket (2 req/s,
-  burst 30) and one telemetry client IP. This is benign day-to-day (CloudFront
-  is a cold 2.5 s-stagger *failover* front — normal traffic ≈ 0), but a
-  mass-failover surge (primary Worker/Cloudflare down) would all land in that one
-  bucket. To restore per-edge-IP bucketing, recreate the broker container with
-  `OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128`; the Caddy config already
-  forwards the unspoofable CloudFront edge IP as the sole `X-Forwarded-For` value
-  (and strips client-supplied `CF-Connecting-IP`/`XFF`), so no proxy change is
-  needed — only the broker env. **Requires a broker container recreate → operator
-  approval** (per the no-autonomous-broker-recreate policy).
+- **Per-client rate-limit / telemetry granularity on the CloudFront path — RESOLVED 2026-07-13.**
+  The broker trusts only Cloudflare ranges for forwarded client IPs
+  (`internal/broker/clientip.go`) and did not trust the new loopback hop, so it
+  recorded `127.0.0.1` as the client for every CloudFront-fronted request — the
+  whole front shared one relay-list rate-limit bucket (2 req/s, burst 30) and one
+  telemetry client IP. Benign day-to-day (CloudFront is a cold 2.5 s-stagger
+  *failover* front, normal traffic ≈ 0) but would have concentrated a
+  mass-failover surge into that one bucket. Fixed by adding
+  `OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128` to `/etc/openrung/broker.env`
+  (durable) and recreating the broker container; the broker now buckets
+  CloudFront-fronted requests by the unspoofable CloudFront edge IP that Caddy
+  forwards as the sole `X-Forwarded-For` value (and strips client-supplied
+  `CF-Connecting-IP`/`XFF`). No Caddy change was needed.
 - **Cloudflare Worker front origin leg is still plaintext.**
   `broker.openrung.org` (the Worker) still fetches `http://broker-origin…:8080`.
   Now that `:443` origin TLS exists, the Worker could be pointed at

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -28,9 +28,9 @@ Cloudflare Worker front. Set up 2026-07-13.
   `deploy/volunteer/hetzner-up.sh`) register directly against
   `http://54.238.185.205:8080`, and the Cloudflare Worker front fetches the
   origin on `:8080`. Do not firewall it off as part of this change.
-- **The origin cert must be RSA, not ECDSA** — see the CloudFront gotchas below.
 - **The CloudFront behavior must use `Managed-AllViewerExceptHostHeader`, not
-  `Managed-AllViewer`** — see the CloudFront gotchas below.
+  `Managed-AllViewer`** — see the CloudFront gotcha below. This is the load-bearing
+  requirement; get it wrong and the origin handshake fails with a 502.
 - Do not disable/mask the `caddy` service; it both serves TLS and auto-renews
   the cert.
 
@@ -61,7 +61,8 @@ reference):
 
 ```caddyfile
 {
-	key_type rsa2048        # REQUIRED for CloudFront — see gotchas
+	# no global options needed — Caddy's default ECDSA (P-256) leaf works with
+	# CloudFront's origin connection; do not force RSA.
 }
 
 broker-origin.openrung.org {
@@ -117,8 +118,9 @@ Open ports afterward: `22, 80, 443, 8080`.
 
 ### Cert + renewal
 
-- Cert: `CN=broker-origin.openrung.org`, **RSA-2048**, Let's Encrypt, 90-day.
-  Issued via **HTTP-01** on `:80`.
+- Cert: `CN=broker-origin.openrung.org`, Caddy-default **ECDSA (P-256)**, Let's
+  Encrypt, 90-day. Issued via **HTTP-01** on `:80`. (ECDSA is fine for CloudFront
+  — see the note below.)
 - Renewal: **automatic and native to Caddy** (ARI-scheduled; renews well before
   expiry as long as the service runs). No timer or cron to maintain. Stored in
   `/var/lib/caddy/.local/share/caddy/`.
@@ -133,34 +135,35 @@ CLI profile's default region is a broken AZ value so pass it explicitly):
 1. **Origin protocol `http-only` → `https-only`** (`HTTPSPort` was already 443,
    `OriginSslProtocols=[TLSv1.2]`). This is the change that encrypts the leg.
 2. **Origin request policy `Managed-AllViewer` → `Managed-AllViewerExceptHostHeader`**
-   (`216adef6-…` → `b689b0a8-53d0-40ab-baf2-68738e2966ac`). **Required** — see
-   gotchas. This policy still forwards everything except `Host` (all other
-   headers incl. `Authorization`, all cookies, all query strings), so the
-   Foundation token still reaches the origin.
+   (`216adef6-…` → `b689b0a8-53d0-40ab-baf2-68738e2966ac`). **Required** — see the
+   gotcha. This policy still forwards everything except `Host` (all other headers
+   incl. `Authorization`, all cookies, all query strings), so the Foundation
+   token still reaches the origin.
 
 Both are applied with `get-distribution-config` → edit `DistributionConfig` →
 `update-distribution --if-match <ETag>`, then `aws cloudfront wait
 distribution-deployed`.
 
-### Two CloudFront gotchas (each caused a 502 during rollout)
+### The CloudFront gotcha (the 502 root cause): SNI, not the Host header
 
-1. **RSA cert, not ECDSA.** Caddy's default leaf key is ECDSA (P-256).
-   CloudFront's origin-facing TLS cipher list is **RSA-only** (it offers the
-   origin `ECDHE-RSA-*` / `AES*` suites and *no* `ECDHE-ECDSA-*` suites), so an
-   ECDSA leaf shares no cipher with CloudFront and the handshake fails with a
-   502. Fixed with `key_type rsa2048`. (Changing `key_type` does not re-issue an
-   existing cert — the old ECDSA cert dir under
-   `…/certificates/…/broker-origin.openrung.org/` was removed and Caddy
-   restarted to force fresh RSA issuance.)
+With `Managed-AllViewer`, CloudFront forwards the viewer `Host` header **and uses
+it as the origin SNI** — so with a client hitting the distribution it sent
+`SNI: d2r7mdpyevvs1m.cloudfront.net`. Caddy has no cert for that name and rejected
+the handshake (Caddy debug log: `no certificate available for
+'d2r7mdpyevvs1m.cloudfront.net'`) → 502. `Managed-AllViewerExceptHostHeader` makes
+CloudFront send the **origin** hostname (`broker-origin.openrung.org`) as both
+`Host` and SNI, which Caddy serves and routes. CloudFront still validates the
+returned cert against the *origin domain name*, which matches. This SNI mismatch
+was the sole cause of the 502.
 
-2. **`AllViewerExceptHostHeader`, not `AllViewer`.** With `Managed-AllViewer`,
-   CloudFront forwards the viewer `Host` header **and uses it as the origin
-   SNI** — so it sent `SNI: d2r7mdpyevvs1m.cloudfront.net`. Caddy has no cert for
-   that name and rejected the handshake (`no certificate available for
-   'd2r7mdpyevvs1m.cloudfront.net'`) → 502. `AllViewerExceptHostHeader` makes
-   CloudFront send the **origin** hostname (`broker-origin.openrung.org`) as both
-   `Host` and SNI, which Caddy serves and routes. CloudFront still validates the
-   returned cert against the *origin domain name*, which matches.
+> **Note — the cert key type (ECDSA) is not the problem.** During debugging an
+> RSA cert (`key_type rsa2048`) was tried and initially looked like the fix; it
+> was a red herring. CloudFront's captured origin `ClientHello` offers
+> `ECDHE-ECDSA-*` cipher suites, the P-256 curve, `ecdsa_secp256r1_sha256`, and
+> TLS 1.3 — i.e. it fully supports an ECDSA (P-256) leaf, which AWS documents for
+> origin connections. This was verified end-to-end: with the default **ECDSA**
+> cert and `AllViewerExceptHostHeader` in place, CloudFront returns `200`. Caddy's
+> default key type is used; do **not** force RSA.
 
 ## Verify
 

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -197,36 +197,49 @@ decision differs.
 plain assignment: shell history can retain the assignment, and curl
 [warns](https://curl.se/docs/manpage.html#-H) that command-line arguments (the
 expanded header) are not reliably hidden from `ps`/other users. Keep it out of
-both history and argv — read it straight into a private **tmpfs** header file and
-feed that to curl with `-H @file`. On the broker box (the token lives in the
-root-owned env file):
+both history and argv — write it into a **`mktemp`** file (root-owned, mode
+`0600`, **unpredictable** name, so there is no fixed path in a shared dir like
+`/dev/shm` for another user to pre-create or symlink; note `umask` cannot repair
+an *existing* file) and feed that to curl with `-H @file`, under a `trap` that
+removes it **however the shell exits** (success, error, or signal). On the broker
+box (the token lives in the root-owned env file), one root shell:
 
 ```sh
-CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
-
-# token goes file -> file: never an argv, never echoed, never in history.
-# Strip ONLY the first `NAME=` prefix (sed), so a token that itself contains `=`
-# (e.g. base64 padding) is preserved verbatim — `awk -F= ... $2` would truncate
-# it at the first `=`, producing a wrong token and a misleading 403.
-sudo bash -c 'umask 077; sed -n "s|^OPENRUNG_FOUNDATION_TOKEN=|Authorization: Bearer |p" \
-  /etc/openrung/broker.env > /dev/shm/ft.hdr'
-
-# WITH token   -> 400 public_host is required   => token SURVIVED CloudFront->origin
-sudo curl -sS -H @/dev/shm/ft.hdr -o /dev/null -w '%{http_code}\n' -X POST \
-  -H 'Content-Type: application/json' -d '{"node_class":"foundation"}' "$CF"
-
-# WITHOUT token -> 403 requires the foundation registration token  => header loss shows here
-curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
-  -H 'Content-Type: application/json' -d '{"node_class":"foundation"}' "$CF"
-
-sudo shred -u /dev/shm/ft.hdr 2>/dev/null || sudo rm -f /dev/shm/ft.hdr   # always clean up
+sudo bash -c '
+  set -eu; umask 077
+  hdr=$(mktemp)                                              # root-owned, 0600, unpredictable
+  trap "shred -u \"$hdr\" 2>/dev/null || rm -f \"$hdr\"" EXIT   # always removed
+  # sed strips ONLY the first NAME= prefix, so a token containing = (base64
+  # padding) survives verbatim; awk -F= "{print \$2}" would truncate it and 403.
+  sed -n "s|^OPENRUNG_FOUNDATION_TOKEN=|Authorization: Bearer |p" /etc/openrung/broker.env > "$hdr"
+  CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
+  # WITH token   -> 400 public_host is required  => token SURVIVED CloudFront->origin
+  curl -sS -H @"$hdr" -o /dev/null -w "with-token: %{http_code}\n" \
+    -X POST -H "Content-Type: application/json" -d "{\"node_class\":\"foundation\"}" "$CF"
+  # WITHOUT token -> 403 requires the foundation registration token  => header loss shows here
+  curl -sS          -o /dev/null -w "no-token:   %{http_code}\n" \
+    -X POST -H "Content-Type: application/json" -d "{\"node_class\":\"foundation\"}" "$CF"
+'
 ```
 
-From a host that isn't the broker, replace the `awk` line with a hidden prompt so
-the token never lands in history or argv:
-`read -rs FT; umask 077; printf 'Authorization: Bearer %s\n' "$FT" > /dev/shm/ft.hdr; unset FT`
-(`read`/`printf` are shell builtins — no process argv), then use `-H @file` and
-`shred` as above.
+From a host that isn't the broker, hold the token in a **hidden prompt** instead
+(`read`/`printf` are shell builtins — no process argv). Force `bash` so the trap
+fires consistently, and keep it **portable** — macOS has no `/dev/shm` and no GNU
+`shred`, so this uses `mktemp` + `rm`:
+
+```sh
+bash -c '
+  set -eu; umask 077
+  hdr=$(mktemp); trap "rm -f \"$hdr\"" EXIT INT TERM
+  read -rs -p "Foundation token: " FT </dev/tty; echo
+  printf "Authorization: Bearer %s\n" "$FT" > "$hdr"; unset FT
+  CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
+  curl -sS -H @"$hdr" -o /dev/null -w "with-token: %{http_code}\n" \
+    -X POST -H "Content-Type: application/json" -d "{\"node_class\":\"foundation\"}" "$CF"
+  curl -sS          -o /dev/null -w "no-token:   %{http_code}\n" \
+    -X POST -H "Content-Type: application/json" -d "{\"node_class\":\"foundation\"}" "$CF"
+'
+```
 
 `400` vs `403` is the signal: if `AllViewerExceptHostHeader` (or the origin leg)
 dropped `Authorization`, the first call would return `403` like the second.

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -252,19 +252,30 @@ depend on it.
 
 ## Follow-ups
 
-- **Per-client rate-limit / telemetry granularity on the CloudFront path — RESOLVED 2026-07-13.**
+- **Loopback-wide rate-limit / telemetry collapse — RESOLVED 2026-07-13; residual per-edge aggregation is by design.**
   The broker trusts only Cloudflare ranges for forwarded client IPs
   (`internal/broker/clientip.go`) and did not trust the new loopback hop, so it
-  recorded `127.0.0.1` as the client for every CloudFront-fronted request — the
-  whole front shared one relay-list rate-limit bucket (2 req/s, burst 30) and one
-  telemetry client IP. Benign day-to-day (CloudFront is a cold 2.5 s-stagger
-  *failover* front, normal traffic ≈ 0) but would have concentrated a
-  mass-failover surge into that one bucket. Fixed by adding
+  recorded `127.0.0.1` as the client for *every* CloudFront-fronted request — the
+  whole front collapsed onto one relay-list rate-limit bucket (2 req/s, burst 30)
+  and one telemetry client IP. Fixed by adding
   `OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128` to `/etc/openrung/broker.env`
-  (durable) and recreating the broker container; the broker now buckets
-  CloudFront-fronted requests by the unspoofable CloudFront edge IP that Caddy
-  forwards as the sole `X-Forwarded-For` value (and strips client-supplied
-  `CF-Connecting-IP`/`XFF`). No Caddy change was needed.
+  (durable) and recreating the broker container; the broker now keys on the
+  unspoofable CloudFront **edge** IP that Caddy forwards as the sole
+  `X-Forwarded-For` value (client-supplied `CF-Connecting-IP`/`XFF` are stripped).
+  No Caddy change was needed.
+
+  This restores the **pre-proxy** behavior exactly — keyed by CloudFront edge IP —
+  and is **not per-viewer**. Clients sharing one CloudFront edge still share that
+  edge's 2 req/s / burst-30 relay-list bucket and its telemetry identity. That is
+  deliberate: the only per-viewer signal CloudFront gives the origin is the
+  client-*appended* `X-Forwarded-For`, which a client can forge to evade the
+  limiter or poison telemetry — so the edge IP (which the client cannot forge) is
+  the correct key. Residual to keep in mind, **especially under mass failover**:
+  when many clients in a region funnel through a handful of nearby edges, a
+  per-edge bucket can still hit its limit (far better than the single-bucket
+  collapse, but coarser than per-viewer). True per-viewer limiting would require
+  CloudFront to attest the viewer IP in a header the origin can trust; it does
+  not, so this is left as-is.
 - **Cloudflare Worker front origin leg is still plaintext.**
   `broker.openrung.org` (the Worker) still fetches `http://broker-origin…:8080`.
   Now that `:443` origin TLS exists, the Worker could be pointed at

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -191,21 +191,39 @@ anonymous registration (`OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`), so an
 
 Send a `node_class: foundation` registration (which *requires* the Foundation
 token) with `public_host` **omitted**, so no relay is ever created — only the auth
-decision differs. Run with the real token from a shell that won't log it (leading
-space / token in a var), never over the plaintext port:
+decision differs.
+
+**Handle the token safely.** Never put it in a `curl -H "…$FT"` argument or a
+plain assignment: shell history can retain the assignment, and curl
+[warns](https://curl.se/docs/manpage.html#-H) that command-line arguments (the
+expanded header) are not reliably hidden from `ps`/other users. Keep it out of
+both history and argv — read it straight into a private **tmpfs** header file and
+feed that to curl with `-H @file`. On the broker box (the token lives in the
+root-owned env file):
 
 ```sh
-FT=…            # the OPENRUNG_FOUNDATION_TOKEN (from the root-owned broker env)
 CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
 
-# WITH token  -> 400 public_host is required   => token SURVIVED CloudFront->origin
-curl -s -o /dev/null -w '%{http_code}\n' -X POST -H "Authorization: Bearer $FT" \
+# token goes file -> file via awk: never an argv, never echoed, never in history
+sudo bash -c 'umask 077; awk -F= "/^OPENRUNG_FOUNDATION_TOKEN=/{print \"Authorization: Bearer \" \$2}" \
+  /etc/openrung/broker.env > /dev/shm/ft.hdr'
+
+# WITH token   -> 400 public_host is required   => token SURVIVED CloudFront->origin
+sudo curl -sS -H @/dev/shm/ft.hdr -o /dev/null -w '%{http_code}\n' -X POST \
   -H 'Content-Type: application/json' -d '{"node_class":"foundation"}' "$CF"
 
-# WITHOUT token -> 403 "requires the foundation registration token" => header loss WOULD show here
-curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+# WITHOUT token -> 403 requires the foundation registration token  => header loss shows here
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
   -H 'Content-Type: application/json' -d '{"node_class":"foundation"}' "$CF"
+
+sudo shred -u /dev/shm/ft.hdr 2>/dev/null || sudo rm -f /dev/shm/ft.hdr   # always clean up
 ```
+
+From a host that isn't the broker, replace the `awk` line with a hidden prompt so
+the token never lands in history or argv:
+`read -rs FT; umask 077; printf 'Authorization: Bearer %s\n' "$FT" > /dev/shm/ft.hdr; unset FT`
+(`read`/`printf` are shell builtins — no process argv), then use `-H @file` and
+`shred` as above.
 
 `400` vs `403` is the signal: if `AllViewerExceptHostHeader` (or the origin leg)
 dropped `Authorization`, the first call would return `403` like the second.

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -204,8 +204,11 @@ root-owned env file):
 ```sh
 CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
 
-# token goes file -> file via awk: never an argv, never echoed, never in history
-sudo bash -c 'umask 077; awk -F= "/^OPENRUNG_FOUNDATION_TOKEN=/{print \"Authorization: Bearer \" \$2}" \
+# token goes file -> file: never an argv, never echoed, never in history.
+# Strip ONLY the first `NAME=` prefix (sed), so a token that itself contains `=`
+# (e.g. base64 padding) is preserved verbatim — `awk -F= ... $2` would truncate
+# it at the first `=`, producing a wrong token and a misleading 403.
+sudo bash -c 'umask 077; sed -n "s|^OPENRUNG_FOUNDATION_TOKEN=|Authorization: Bearer |p" \
   /etc/openrung/broker.env > /dev/shm/ft.hdr'
 
 # WITH token   -> 400 public_host is required   => token SURVIVED CloudFront->origin


### PR DESCRIPTION
## What

The AWS CloudFront front (`E2PLKW8FO3JZSA` / `d2r7mdpyevvs1m.cloudfront.net`) reached the broker origin over **plaintext HTTP**, so the high-value **Foundation registration token** (`Authorization` on `POST /api/v1/volunteers/register`) crossed the CloudFront-edge → origin leg in cleartext. This PR is **docs only** — it records the infra change that closes that leg, reproducibly.

The leg is now encrypted end-to-end:

```
relay ──HTTPS──► CloudFront edge ──HTTPS(:443)──► Caddy ──HTTP(127.0.0.1:8080)──► broker
```

## Infra applied (on the broker box + AWS API — not code in this PR)

- **Caddy** on `typhoon-broker` terminates a Let's Encrypt cert (Caddy-default **ECDSA P-256**) on `:443` and reverse-proxies to the broker on `:8080`. Additive: the broker container and the plaintext `:8080` volunteer path are **untouched**; the cert auto-renews natively.
- **CloudFront** origin flipped `http-only` → `https-only`, and origin request policy `Managed-AllViewer` → `Managed-AllViewerExceptHostHeader`.

## The 502 root cause (single): origin SNI, not cipher/key-type

With `Managed-AllViewer`, CloudFront forwards the viewer `Host` header and **uses it as the origin SNI** (`d2r7mdpyevvs1m.cloudfront.net`), for which Caddy has no cert → handshake rejected → 502. `Managed-AllViewerExceptHostHeader` makes CloudFront send the **origin** hostname as Host+SNI (still forwarding `Authorization`, cookies, query strings), which Caddy serves and routes.

> An earlier revision wrongly blamed "RSA-only origin ciphers." CloudFront's captured origin `ClientHello` offers `ECDHE-ECDSA-*`, P-256, `ecdsa_secp256r1_sha256`, and TLS 1.3 — verified end-to-end that the **default ECDSA** cert works. `key_type rsa2048` was dropped.

## Verified

- Origin direct HTTPS → **200**, publicly-trusted cert.
- Discovery through CloudFront `GET /api/v1/relays` → **200**, signed, from a datacenter IP.
- **Foundation-token forwarding (the load-bearing property) — with a *discriminating* test.** `POST {}` → 400 would **not** prove it (prod allows anonymous registration, so an unauthenticated request gets the same 400). Instead: `POST {"node_class":"foundation"}` with `public_host` omitted (no relay created) — **with** the token → `400 public_host is required` (token survived the origin leg); **without** → `403 requires the foundation registration token`. `400` vs `403` is the signal. The runbook's recipe keeps the token out of shell history and process argv (`curl -H @tmpfile`, `shred`). Cross-check: Caddy access log shows `Authorization: ["REDACTED"]` (forwarded; value never written to disk).
- Volunteer plaintext `:8080` and the Cloudflare Worker front both **unaffected**.

## Files

- `deploy/broker/origin-tls.md` — full runbook (setup, cert/renewal, firewall, CloudFront settings, the SNI root cause, token-safe verification, rollback, follow-ups).
- `deploy/broker/Caddyfile` — deployed config (byte-for-byte matches the box; default ECDSA; comments reflect live state).
- `deploy/broker/README.md`, `deploy/broker-proxy/README.md` — pointers + scope the Worker's plaintext-origin note.

## Follow-ups

- **Loopback-wide rate-limit / telemetry collapse — resolved; now keyed per-CloudFront-edge.** `OPENRUNG_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128` applied to the broker restores pre-proxy per-edge keying (unspoofable CloudFront edge IP Caddy forwards).
- **Per-*viewer* rate-limit / telemetry — OPEN (achievable, not yet done).** Per-edge is a current *implementation* choice, not a CloudFront limitation: clients sharing an edge still share its 2 req/s / burst-30 bucket + telemetry identity (can saturate under mass failover). `AllViewerExceptHostHeader` already forwards **`CloudFront-Viewer-Address`** (viewer ip:port), verified **unspoofable through CloudFront** (a forged value is overwritten with the real viewer IP). Adopting it needs the origin to first authenticate the request came via CloudFront (shared-secret origin header, or lock `:443` to CloudFront origin-facing ranges), since `:443` is internet-facing and a direct hit could forge the header.
- **Cloudflare Worker front origin leg still plaintext `:8080`** — could point at `https://broker-origin.openrung.org` now; separate change to the higher-traffic primary front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)