### PR TITLE
deploy(broker): keep anonymous-registration opt-in in the env file, not a docker -e flag

### DIFF
--- a/deploy/broker/.env.example
+++ b/deploy/broker/.env.example
@@ -10,9 +10,17 @@
 # the relay directory that clients route their VPN traffic through.
 #
 # The broker refuses to start without a token, so this template opts into an
-# open, unauthenticated broker (anyone can register a relay). To require auth
-# instead, set OPENRUNG_VOLUNTEER_TOKEN below — a token supersedes the anonymous
-# flag, which then becomes a no-op — and remove or comment out the anonymous line.
+# open, unauthenticated broker (anyone can register a relay). This is a
+# deliberate choice: OpenRung's public network intentionally runs open so any
+# volunteer can contribute a relay without a shared secret. To require auth
+# instead (e.g. a private deployment), set OPENRUNG_VOLUNTEER_TOKEN below — a
+# token supersedes the anonymous flag, which then becomes a no-op — and remove
+# or comment out the anonymous line.
+#
+# Keep this line HERE, in the env file loaded via --env-file, not as an ad-hoc
+# `docker run -e OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`. The broker fails
+# closed at startup, so a redeploy that forgets an inline -e flag crash-loops;
+# in the env file the opt-in travels with every recreate.
 OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true
 #OPENRUNG_VOLUNTEER_TOKEN=
 

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -64,10 +64,18 @@ through. You must either:
   and volunteers), **or**
 - explicitly opt into an open, unauthenticated broker with
   `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true` (the `.env.example` default).
+  OpenRung's public network intentionally runs open so any volunteer can
+  contribute a relay without a shared secret.
 
 A token, when set, takes precedence and enforces auth; the anonymous flag then
 becomes a no-op. Generate a token with `openssl rand -hex 32`. Send it only over
 TLS — see Cloudflare below.
+
+Keep whichever auth line you choose **in the env file** (`.env` / the
+`--env-file` broker.env), never as an ad-hoc `docker run -e
+OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`. Because the broker fails closed at
+startup, a redeploy that forgets an inline `-e` flag crash-loops; keeping the
+opt-in in the env file means it travels with every `--env-file` recreate.
 
 Separately, `OPENRUNG_FOUNDATION_TOKEN` (optional) authorizes registrations
 that claim `node_class: foundation`, marking relays the foundation operates

--- a/deploy/broker/lightsail-up.sh
+++ b/deploy/broker/lightsail-up.sh
@@ -72,8 +72,12 @@ aws lightsail allocate-static-ip --static-ip-name "$IPNAME" --region "$REGION" >
 STATIC_IP="$(aws lightsail get-static-ip --static-ip-name "$IPNAME" --region "$REGION" --query 'staticIp.ipAddress' --output text)"
 
 # Auth: the broker fails closed without a registration token, so when none is
-# provided we explicitly opt into an open, unauthenticated broker — set
-# OPENRUNG_VOLUNTEER_TOKEN to require auth (a token supersedes the anonymous flag).
+# provided we explicitly opt into an open, unauthenticated broker — OpenRung's
+# public network intentionally runs open so any volunteer can contribute a relay.
+# Set OPENRUNG_VOLUNTEER_TOKEN to require auth (a token supersedes the anonymous
+# flag). Either way the choice is written into broker.env below and applied via
+# --env-file, never an ad-hoc `docker run -e` (a redeploy that forgets it would
+# crash-loop the fail-closed broker).
 TOKEN_ENV=""
 ANON_ENV=""
 if [ -n "$TOKEN" ]; then


### PR DESCRIPTION
## What

Documentation/comment hardening in the broker deploy path so the open-broker opt-in (`OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`) is unambiguously sourced from the env file (`--env-file`), never an ad-hoc `docker run -e` flag.

No logic or Go changes — the repo's deploy path (`.env.example`, `docker-compose.yml`, `lightsail-up.sh`) already used the env file. This locks in that shape and explains why.

## Why

The broker **fails closed** at startup (`cmd/broker/main.go` refuses to run without either `OPENRUNG_VOLUNTEER_TOKEN` or `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true`). A hand-redeploy that forgets an inline `-e` flag therefore crash-loops. Keeping the opt-in in the env file means it travels with every `--env-file` recreate, removing that footgun. The comments now also record that OpenRung's public network intentionally runs open (any volunteer can contribute a relay without a shared secret).

## Changes

- `deploy/broker/.env.example` — expand the auth comment: deliberate open-broker opt-in, and keep the line in the env file (not inline `-e`).
- `deploy/broker/README.md` — same rationale in the fail-closed auth section + an explicit "keep the auth line in the env file, never `docker run -e`" note.
- `deploy/broker/lightsail-up.sh` — comment-only clarification that the choice is written into `broker.env` and applied via `--env-file`.

## Verification

- `go build ./...` — OK (no Go changed).
- `bash -n deploy/broker/lightsail-up.sh` — OK.
- Live prod broker (`typhoon-broker`) `/etc/openrung/broker.env` verified via SSH to already contain the line; the running container carries a redundant duplicate from a leftover `-e` — safe to drop on the next recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)