### PR TITLE
Use relay as the generic runtime terminology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Optional shared token required by the broker for volunteer registration.
+# Optional shared token required by the broker for volunteer-class registration.
 OPENRUNG_VOLUNTEER_TOKEN=change-me
 
 # Optional shared relay-state backend for safer broker restarts and multiple

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -9,7 +9,7 @@ name: uptime
 #
 # Front 403s are expected from this vantage: the Cloudflare edge serves
 # 403 to datacenter IPs on this zone (verified on the first real-runner
-# run, 2026-07-10) — the same behavior that forces volunteers to register
+# run, 2026-07-10) — the same behavior that forces volunteer-run relays to register
 # against the origin. A front 403 therefore says nothing about real-client
 # availability and is downgraded to a warning; every other front failure
 # (5xx, timeout, staleness) still fails the job. If a WAF exception for

--- a/.github/workflows/volunteer-image.yml
+++ b/.github/workflows/volunteer-image.yml
@@ -1,6 +1,7 @@
 name: volunteer-image
 
-# Build and publish the volunteer relay image to GHCR.
+# Build and publish the relay runtime image to GHCR. The workflow and image keep
+# their legacy volunteer names until the artifact-alias migration.
 # Multi-arch (amd64 + arm64) so it runs on x86 and Graviton/ARM VPSes.
 
 on:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test fmt broker volunteer relayhub client docker-build docker-keygen docker-run relayhub-docker-build broker-docker-build
+.PHONY: test fmt broker relay volunteer relayhub client docker-build docker-keygen docker-run relayhub-docker-build broker-docker-build
 
 VOLUNTEER_IMAGE ?= openrung-volunteer:latest
 RELAYHUB_IMAGE ?= openrung-relayhub:latest
@@ -14,7 +14,7 @@ test:
 broker:
 	OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true go run ./cmd/broker -addr :8080
 
-volunteer:
+relay:
 	go run ./cmd/volunteer \
 		-broker http://localhost:8080 \
 		-public-host 127.0.0.1 \
@@ -24,6 +24,9 @@ volunteer:
 		-reality-public-key dev-public-key \
 		-short-id 5f7a8d9c01ab23cd \
 		-skip-xray-run
+
+# Legacy local-development alias; the executable path is migrated separately.
+volunteer: relay
 
 relayhub:
 	OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true go run ./cmd/relayhub \
@@ -35,7 +38,7 @@ relayhub:
 client:
 	go run ./cmd/client check -broker http://localhost:8080
 
-# Build the volunteer relay image (run from the repo root).
+# Build the relay runtime image (legacy target/image names retained for compatibility).
 docker-build:
 	docker build -f deploy/volunteer/Dockerfile -t $(VOLUNTEER_IMAGE) .
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 **Reach the open internet.**
 
-OpenRung is a volunteer-powered relay network that helps people living behind
-internet censorship reach blocked websites and apps — through relays run by
-everyday volunteers in unrestricted regions.
+OpenRung is a relay network that helps people living behind internet censorship
+reach blocked websites and apps through Foundation-operated and volunteer-run
+relays in unrestricted regions.
 
 [![Website](https://img.shields.io/badge/website-openrung.org-1d8a4f)](https://openrung.org)
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue)](LICENSE)
@@ -26,27 +26,27 @@ everyday volunteers in unrestricted regions.
 
 ## How it works
 
-OpenRung connects censored users with everyday volunteers, similar in spirit to
-Tor's [Snowflake](https://snowflake.torproject.org/):
+OpenRung connects censored users with relays in unrestricted regions, similar in
+spirit to Tor's [Snowflake](https://snowflake.torproject.org/):
 
 - **Clients** (the mobile app and a desktop CLI) route device traffic through a
-  VPN tunnel to a volunteer relay.
-- **Volunteers** run a small command-line app that relays that traffic to the
-  open internet.
+  VPN tunnel to a relay.
+- **Relay operators** — the OpenRung Foundation and community volunteers — run
+  a small command-line app that relays that traffic to the open internet.
 - **The broker** is a control plane only: it matches clients with healthy
   relays and never proxies user traffic.
 
 ```mermaid
 flowchart LR
     client["📱 Client app<br/>(VPN mode)"]
-    volunteer["🙋 Volunteer relay"]
+    relay["🔁 Relay"]
     broker["🧭 Broker<br/>(control plane)"]
     web["🌐 Open internet"]
 
     client -. "relay discovery" .-> broker
-    volunteer -. "register + heartbeats" .-> broker
-    client == "VLESS + REALITY + Vision" ==> volunteer
-    volunteer ==> web
+    relay -. "register + heartbeats" .-> broker
+    client == "VLESS + REALITY + Vision" ==> relay
+    relay ==> web
 ```
 
 Relay transport uses [Xray-core](https://github.com/XTLS/Xray-core)'s
@@ -59,27 +59,28 @@ clients are steered toward relays that actually work.
 
 - 🙌 **Simple volunteering** — one CLI plus an Xray binary; IPv6-first with
   IPv4 and dual-stack options.
-- 🕳️ **Works behind CGNAT** — volunteers with no inbound port can join through
-  a reverse-tunnel relay hub.
+- 🕳️ **Works behind CGNAT** — volunteer-run relays with no inbound port can join
+  through a reverse-tunnel relay hub.
 - 📱 **Full-device mobile client** — the OpenRung app routes all device
   traffic in VPN mode (developed in a separate React Native repository).
 - 🧭 **Privacy-aware control plane** — the broker matchmakes but never carries
   user traffic.
 - 🗄️ **Production-friendly broker** — optional shared PostgreSQL state for safe
   restarts and load-balanced deployments.
-- 📊 **Operational visibility** — colored per-connection logs for volunteers
-  and an opt-in, token-protected telemetry dashboard for operators.
+- 📊 **Operational visibility** — colored per-connection logs for relay
+  operators and an opt-in, token-protected telemetry dashboard.
 
 ## Quick start
 
-You need Go 1.25+, and volunteers also need an
+You need Go 1.25+, and relay operators also need an
 [Xray-core](https://github.com/XTLS/Xray-core) binary that supports
 `xray x25519` and `xray run -config`.
 
 ### Start the broker
 
 The broker fails closed: it refuses to start unless you either set a shared
-registration token (`OPENRUNG_VOLUNTEER_TOKEN`, matched by hubs/volunteers) or
+registration token (`OPENRUNG_VOLUNTEER_TOKEN`, matched by hubs and
+volunteer-run relays) or
 explicitly opt into an open, unauthenticated broker. Running open lets anyone
 register a relay into the directory, so only do it on a trusted/private network.
 It also requires `OPENRUNG_RELAY_SIGNING_KEY` — standard base64 of the 32-byte
@@ -120,7 +121,7 @@ When the variable is unset, the dashboard and its data API return 404. In
 production, serve the broker over HTTPS so the administrator session cookie is
 protected in transit.
 
-### Run a volunteer relay
+### Run a relay
 
 ```sh
 go run ./cmd/volunteer \
@@ -132,16 +133,16 @@ go run ./cmd/volunteer \
 
 Useful to know:
 
-- The volunteer listens on IPv6 (`::`) by default and advertises the first
+- The relay listens on IPv6 (`::`) by default and advertises the first
   global IPv6 address it finds. Pass `-public-host` (and `-listen-host` if
   needed) to use a DNS name, an IPv4 address, or a specific IPv6 address, or
   `-listen-host dual` to listen on both stacks in one process.
 - A global IPv6 address still needs inbound firewall/router rules that allow
-  clients to reach the volunteer port.
+  clients to reach the relay port.
 - Client connection events print in color by default — green on open, red on
   close, with client IP, duration, and byte counts. Pass
   `-connection-log=false` to let Xray bind the public port directly.
-- The broker currently advertises one `public_host` per volunteer. For both
+- The broker currently advertises one `public_host` per relay. For both
   IPv4 and IPv6 discovery, advertise a DNS name with A and AAAA records, or
   run separate registrations.
 
@@ -153,10 +154,10 @@ Useful to know:
 > as entry relays in front of dedicated exit servers is on the
 > [roadmap](#roadmap).
 
-### Volunteers behind CGNAT
+### Volunteer-run relays behind CGNAT
 
-Volunteers with no inbound port (carrier-grade NAT) can join through a relay
-hub. Run the hub on a publicly reachable host where bandwidth is cheap:
+Volunteer-run relays with no inbound port (carrier-grade NAT) can join through
+a relay hub. Run the hub on a publicly reachable host where bandwidth is cheap:
 
 ```sh
 go run ./cmd/relayhub \
@@ -165,15 +166,15 @@ go run ./cmd/relayhub \
   -port-range 20000-20100
 ```
 
-Then run the volunteer in tunnel mode — it binds Xray to loopback and dials the
-hub instead of exposing a port (no `-public-host` needed):
+Then run the relay in tunnel mode — it binds Xray to loopback and dials the hub
+instead of exposing a port (no `-public-host` needed):
 
 ```sh
 go run ./cmd/volunteer -tunnel -hub hub.example.com:9443 -xray /path/to/xray
 ```
 
-All traffic for a CGNAT volunteer transits the hub, so keep the relay path
-opt-in (public-IP volunteers should stay in direct mode) and run hubs off
+All traffic for a CGNAT relay transits the hub, so keep the relay path opt-in
+(public-IP relays should stay in direct mode) and run hubs off
 metered cloud egress. See [`deploy/relayhub/README.md`](deploy/relayhub/README.md)
 for cost details and TLS setup.
 
@@ -195,8 +196,9 @@ retired from this one.
 
 ```text
 cmd/broker/          Broker HTTP API (control plane).
-cmd/volunteer/       Volunteer CLI for Xray-backed relay registration.
-cmd/relayhub/        Relay hub for CGNAT volunteers (reverse-tunnel data plane).
+cmd/volunteer/       Relay CLI for Xray-backed registration (legacy path name).
+cmd/relayhub/        Relay hub for CGNAT volunteer-run relays
+                     (reverse-tunnel data plane).
 cmd/client/          Desktop CLI client.
 internal/broker/     Broker store and HTTP handlers.
 internal/client/     Client engine, relay selection, and sing-box config.
@@ -204,12 +206,12 @@ internal/clienttelemetry/  Client metrics reporting to the broker.
 internal/punch/      NAT hole-punch QUIC layer (session, transport, bridges) over punchcore.
 internal/relay/      Shared relay descriptor models.
 internal/relayhub/   Relay hub configuration.
-internal/tunnel/     Reverse-tunnel transport (hub + volunteer client, yamux).
-internal/volunteer/  Xray config generation helpers.
+internal/tunnel/     Reverse-tunnel transport (hub + relay client, yamux).
+internal/volunteer/  Relay Xray config helpers (legacy package name).
 punchcore/           Shared NAT hole-punch protocol core (nested Go module
                      github.com/openrung/openrung/punchcore) consumed by the
                      servers, the desktop client, and the mobile app's binding.
-deploy/              Broker proxy, relay hub, and volunteer deployment assets.
+deploy/              Broker proxy, relay hub, and relay deployment assets.
 docs/                Architecture, API, client, and operations docs + website.
 ```
 
@@ -225,12 +227,13 @@ docs/                Architecture, API, client, and operations docs + website.
 
 ## Roadmap
 
-- **Dedicated exit servers** — let volunteers choose to act as entry relays
-  instead of direct exits.
+- **Dedicated exit servers** — let volunteer operators choose to act as entry
+  relays instead of direct exits.
 - **Abuse and rate controls** — exit policies, rate limits, and abuse
   reporting ahead of a broad public rollout.
-- **NAT hole punching** — direct client↔volunteer paths without a hub in the
-  middle (core protocol in the `punchcore` module,
+- **NAT hole punching** — direct client↔relay paths for volunteer-run relays
+  behind CGNAT, without a hub in the middle (core protocol in the `punchcore`
+  module,
   `github.com/openrung/openrung/punchcore`; shipped in the desktop and Android
   clients, iOS still planned).
 - **Dual-stack relay discovery** — multiple public endpoints per relay.
@@ -267,7 +270,7 @@ The mobile app (maintained in its own repository) statically links
 combined app — and the project as a whole — is GPL-3.0-or-later. The relay
 transport's VLESS + REALITY + Vision support comes
 from [Xray-core](https://github.com/XTLS/Xray-core) (MPL-2.0), which the
-volunteer runs as a separate process.
+relay runs as a separate process.
 
 Third-party components bundled or linked into distributed artifacts (Docker
 images, server binaries), and the attribution and source-offer

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -89,7 +89,7 @@ recipients of the MPL-2.0 terms and where to obtain the source.
 ### yamux
 
 - **Component:** `github.com/hashicorp/yamux` v0.1.2 (reverse-tunnel transport;
-  statically linked into the volunteer, relayhub, and broker binaries).
+  statically linked into the relay runtime and relayhub binaries).
 - **License:** MPL-2.0.
 - **Source:** https://github.com/hashicorp/yamux/tree/v0.1.2
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -24,7 +24,7 @@ func main() {
 
 func run() error {
 	addr := flag.String("addr", envDefault("OPENRUNG_ADDR", ":8080"), "HTTP listen address")
-	leaseTTL := flag.Duration("lease-ttl", 3*time.Minute, "volunteer relay lease TTL")
+	leaseTTL := flag.Duration("lease-ttl", 3*time.Minute, "relay lease TTL")
 	telemetryFile := flag.String("telemetry-file", envDefault("OPENRUNG_TELEMETRY_FILE", "openrung-telemetry.jsonl"), "append-only client telemetry JSONL file (its directory must be writable)")
 	telemetryStore := flag.String("telemetry-store", envDefault("OPENRUNG_TELEMETRY_STORE", "jsonl"), "telemetry storage backend: jsonl or postgres")
 	telemetryDatabaseURL := flag.String("telemetry-database-url", envDefault("OPENRUNG_TELEMETRY_DATABASE_URL", os.Getenv("OPENRUNG_RELAY_DATABASE_URL")), "PostgreSQL database URL for telemetry (defaults to the relay database URL)")
@@ -50,11 +50,11 @@ func run() error {
 
 	// The foundation token authorizes node_class=foundation registrations. It
 	// must not equal the (shared, widely distributed) volunteer token, or every
-	// volunteer could label its relay as foundation-operated and clients would
-	// trust the signed lie.
+	// volunteer-token holder could label a relay as foundation-operated and
+	// clients would trust the signed lie.
 	foundationToken := os.Getenv("OPENRUNG_FOUNDATION_TOKEN")
 	if foundationToken != "" && foundationToken == registrationToken {
-		return errors.New("OPENRUNG_FOUNDATION_TOKEN must differ from OPENRUNG_VOLUNTEER_TOKEN: a shared value would let any volunteer register as a foundation relay")
+		return errors.New("OPENRUNG_FOUNDATION_TOKEN must differ from OPENRUNG_VOLUNTEER_TOKEN: a shared value would let any holder of the volunteer token register a foundation relay")
 	}
 
 	// Fail closed on the signing key too: a missing or malformed seed must
@@ -82,7 +82,7 @@ func run() error {
 	cfg := broker.Config{
 		RegistrationToken: registrationToken,
 		FoundationToken:   foundationToken,
-		VolunteerLeaseTTL: *leaseTTL,
+		RelayLeaseTTL:     *leaseTTL,
 		TelemetrySink:     telemetrySink,
 		DashboardToken:    os.Getenv("OPENRUNG_DASHBOARD_TOKEN"),
 		// Cloudflare's published ranges are trusted by default; add more (e.g. an upstream LB) here.
@@ -250,7 +250,7 @@ func maintainBroker(store broker.RelayStore, telemetry broker.TelemetryReader, i
 			continue
 		}
 		for _, desc := range expired {
-			slog.Info("volunteer expired", "relay_id", desc.ID, "last_heartbeat_at", desc.LastHeartbeatAt)
+			slog.Info("relay expired", "relay_id", desc.ID, "last_heartbeat_at", desc.LastHeartbeatAt)
 		}
 		pruneTelemetryPartitions(telemetry, now)
 		if !logStatus {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -383,7 +383,7 @@ func punchBaseURL(override string, selected relay.Descriptor) string {
 // punchHTTPClient returns the HTTP client for the hub punch API. With insecure
 // set it skips TLS verification, for a hub serving a self-signed cert on its
 // HTTPS punch endpoint. The punched QUIC path is unaffected (it pins the
-// volunteer's per-session cert by fingerprint regardless).
+// relay's per-session cert by fingerprint regardless).
 func punchHTTPClient(insecure bool) *http.Client {
 	if !insecure {
 		return nil // punchcore.HubClient uses its default client

--- a/cmd/relayhub/main.go
+++ b/cmd/relayhub/main.go
@@ -34,11 +34,11 @@ func run() error {
 		return err
 	}
 
-	// Fail closed: an empty token disables volunteer authentication, so any node
-	// could register as a relay through this hub. Require a token unless the
+	// Fail closed: an empty token disables relay authentication, so any caller
+	// could register a relay through this hub. Require a token unless the
 	// operator explicitly opts into an open hub.
 	if cfg.Token == "" && !envTrue("OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS") {
-		return errors.New("OPENRUNG_VOLUNTEER_TOKEN is empty: refusing to start an open hub where any node can register as a relay. Set OPENRUNG_VOLUNTEER_TOKEN, or set OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true to run open intentionally")
+		return errors.New("OPENRUNG_VOLUNTEER_TOKEN is empty: refusing to start an open hub where any caller can register a relay. Set OPENRUNG_VOLUNTEER_TOKEN, or set OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true to run open intentionally")
 	}
 
 	alloc, err := tunnel.NewPortAllocator(cfg.PortRangeStart, cfg.PortRangeEnd)
@@ -69,7 +69,7 @@ func run() error {
 		mux := http.NewServeMux()
 
 		// The reachability prober is always available on the HTTP API so
-		// volunteers can auto-detect direct vs tunnel even when punch is off.
+		// relays can auto-detect direct vs tunnel even when punch is off.
 		tunnel.NewReachabilityProber(cfg.Token, slog.Default()).Register(mux)
 
 		if cfg.PunchEnabled() {
@@ -152,12 +152,12 @@ func run() error {
 }
 
 func parseConfig() (relayhub.Config, error) {
-	controlAddr := flag.String("control-addr", envDefault("OPENRUNG_HUB_CONTROL_ADDR", ":9443"), "control listener address volunteers dial")
+	controlAddr := flag.String("control-addr", envDefault("OPENRUNG_HUB_CONTROL_ADDR", ":9443"), "control listener address dialed by volunteer-run relays")
 	publicHost := flag.String("public-host", os.Getenv("OPENRUNG_HUB_PUBLIC_HOST"), "public hostname or IP advertised to clients")
 	publicBindHost := flag.String("public-bind-host", os.Getenv("OPENRUNG_HUB_PUBLIC_BIND_HOST"), "interface the per-tunnel public listeners bind to; empty means all interfaces")
 	portRange := flag.String("port-range", envDefault("OPENRUNG_HUB_PORT_RANGE", "20000-20100"), "public TCP port range as start-end")
 	brokerURL := flag.String("broker", envDefault("OPENRUNG_BROKER_URL", "http://localhost:8080"), "broker base URL")
-	token := flag.String("token", os.Getenv("OPENRUNG_VOLUNTEER_TOKEN"), "shared volunteer/broker bearer token")
+	token := flag.String("token", os.Getenv("OPENRUNG_VOLUNTEER_TOKEN"), "shared volunteer-class relay/broker bearer token")
 	tlsCert := flag.String("tls-cert", os.Getenv("OPENRUNG_HUB_TLS_CERT"), "TLS certificate file for the control channel")
 	tlsKey := flag.String("tls-key", os.Getenv("OPENRUNG_HUB_TLS_KEY"), "TLS key file for the control channel")
 	heartbeat := flag.Duration("heartbeat-interval", envDurationDefault("OPENRUNG_HUB_HEARTBEAT_INTERVAL", 30*time.Second), "broker heartbeat interval for live relays")

--- a/cmd/volunteer/main.go
+++ b/cmd/volunteer/main.go
@@ -27,14 +27,14 @@ const version = "dev"
 func main() {
 	var cfg cliConfig
 	flag.StringVar(&cfg.BrokerURL, "broker", "http://localhost:8080", "broker base URL")
-	flag.StringVar(&cfg.RegistrationToken, "registration-token", os.Getenv("OPENRUNG_VOLUNTEER_TOKEN"), "volunteer registration token")
+	flag.StringVar(&cfg.RegistrationToken, "registration-token", os.Getenv("OPENRUNG_VOLUNTEER_TOKEN"), "volunteer-class relay registration token")
 	flag.StringVar(&cfg.Label, "label", os.Getenv("OPENRUNG_LABEL"), "human-readable relay label shown in the broker; a random adjective-noun is generated when empty")
 	flag.StringVar(&cfg.NodeClass, "node-class", os.Getenv("OPENRUNG_NODE_CLASS"), "relay operator class: volunteer (default) or foundation. For a foundation relay prefer -foundation-token, which sets this and forces direct mode / https automatically; a bare -node-class=foundation still needs direct mode, the foundation token as the bearer, and an https broker")
-	flag.StringVar(&cfg.FoundationToken, "foundation-token", os.Getenv("OPENRUNG_FOUNDATION_TOKEN"), "foundation registration token; presenting it runs this relay as a foundation node — it forces foundation class, direct mode, an https broker, and redirect refusal, so no separate -node-class is needed")
+	flag.StringVar(&cfg.FoundationToken, "foundation-token", os.Getenv("OPENRUNG_FOUNDATION_TOKEN"), "foundation registration token; presenting it runs this as a foundation relay — it forces foundation class, direct mode, an https broker, and redirect refusal, so no separate -node-class is needed")
 	flag.StringVar(&cfg.XrayPath, "xray", "xray", "path to xray binary")
 	flag.StringVar(&cfg.ListenHost, "listen-host", "::", "local listen host; with connection logging, :: listens on both IPv6 and IPv4 through the observer")
 	flag.IntVar(&cfg.ListenPort, "listen-port", 443, "local listen port")
-	flag.StringVar(&cfg.PublicHost, "public-host", "", "public hostname or IP clients can reach; defaults to this machine's first global IPv6 address")
+	flag.StringVar(&cfg.PublicHost, "public-host", "", "public hostname or IP clients can reach; defaults to the relay host's first global IPv6 address")
 	flag.IntVar(&cfg.PublicPort, "public-port", 443, "public port clients can reach")
 	flag.StringVar(&cfg.ServerName, "server-name", "www.cloudflare.com", "Reality server name")
 	flag.StringVar(&cfg.RealityDest, "reality-dest", "www.cloudflare.com:443", "Reality dest")
@@ -61,16 +61,16 @@ func main() {
 	cfg.Mode = normalizeMode(cfg.Mode, cfg.TunnelMode, cfg.HubAddr)
 
 	if err := cfg.ApplyDefaults(); err != nil {
-		slog.Error("invalid volunteer config", "error", err)
+		slog.Error("invalid relay config", "error", err)
 		os.Exit(2)
 	}
 	if err := cfg.Validate(); err != nil {
-		slog.Error("invalid volunteer config", "error", err)
+		slog.Error("invalid relay config", "error", err)
 		os.Exit(2)
 	}
 
 	if err := run(cfg); err != nil {
-		slog.Error("volunteer stopped", "error", err)
+		slog.Error("relay stopped", "error", err)
 		os.Exit(1)
 	}
 }
@@ -454,7 +454,7 @@ func run(cfg cliConfig) error {
 
 // runTunnelMode binds Xray to a loopback port and serves client traffic through
 // a reverse tunnel to the relay hub. The hub registers the relay with the broker
-// on the volunteer's behalf, so the volunteer never exposes a public port and
+// on the relay's behalf, so the relay never exposes a public port and
 // never calls the broker directly.
 func runTunnelMode(parent context.Context, cfg cliConfig) error {
 	ctx, cancel := context.WithCancel(parent)
@@ -517,8 +517,8 @@ func runTunnelMode(parent context.Context, cfg cliConfig) error {
 			MaxSessions:      cfg.MaxSessions,
 			MaxMbps:          cfg.MaxMbps,
 			Label:            cfg.Label,
-			VolunteerVersion: version,
-			// A current volunteer always understands the stream-type discriminator;
+			RelayVersion:     version,
+			// A current relay always understands the stream-type discriminator;
 			// PunchCapable additionally asks the hub to advertise a direct path.
 			StreamTyping: true,
 			PunchCapable: cfg.Punch,
@@ -680,7 +680,7 @@ func register(ctx context.Context, cfg cliConfig, prepared preparedRuntime) (rel
 		ExitMode:         relay.ExitModeDirect,
 		MaxSessions:      cfg.MaxSessions,
 		MaxMbps:          cfg.MaxMbps,
-		VolunteerVersion: version,
+		RelayVersion:     version,
 		Label:            cfg.Label,
 		NodeClass:        cfg.NodeClass,
 	}
@@ -690,9 +690,9 @@ func register(ctx context.Context, cfg cliConfig, prepared preparedRuntime) (rel
 	}
 	// A broker that predates node_class drops the field and answers 201 with
 	// no class attested; without this check the relay would silently serve
-	// mislabeled as a volunteer.
+	// mislabeled as a volunteer-class relay.
 	if req.NodeClass == relay.NodeClassFoundation && desc.NodeClass != relay.NodeClassFoundation {
-		return relay.Descriptor{}, fmt.Errorf("broker attested node_class %q instead of %q: the broker likely predates node_class support; upgrade it, or drop -node-class to serve as a volunteer", desc.NodeClass, relay.NodeClassFoundation)
+		return relay.Descriptor{}, fmt.Errorf("broker attested node_class %q instead of %q: the broker likely predates node_class support; upgrade it, or drop -node-class to serve as a volunteer-class relay", desc.NodeClass, relay.NodeClassFoundation)
 	}
 	return desc, nil
 }

--- a/cmd/volunteer/main_test.go
+++ b/cmd/volunteer/main_test.go
@@ -170,7 +170,7 @@ func jsonResponse(status int, body string) *http.Response {
 
 // A broker that predates node_class silently drops the field and returns a
 // descriptor without it; a foundation relay must refuse to serve mislabeled
-// rather than silently run as a volunteer.
+// rather than silently run as a volunteer-class relay.
 func TestRegisterRejectsUnattestedFoundationClass(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return jsonResponse(http.StatusCreated, `{"id":"relay_new","public_host":"relay.example","public_port":443}`), nil

--- a/deploy/broker/.env.example
+++ b/deploy/broker/.env.example
@@ -6,8 +6,9 @@
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------
-# Shared bearer token volunteers/hubs must present to register a relay. It gates
-# the relay directory that clients route their VPN traffic through.
+# Shared bearer token that volunteer-class relays and hubs must present to
+# register. It gates the relay directory that clients route their VPN traffic
+# through.
 #
 # The broker refuses to start without a token, so this template opts into an
 # open, unauthenticated broker (anyone can register a relay). This is a

--- a/deploy/broker/Caddyfile
+++ b/deploy/broker/Caddyfile
@@ -4,7 +4,7 @@
 # broker-origin.openrung.org and reverse-proxies to the broker container, which
 # is untouched on 127.0.0.1:8080. Auto-renewal is native to Caddy (the running
 # service renews ~30 days before expiry). The plaintext :8080 origin stays open
-# for community volunteer relay registration and for the Cloudflare Worker front
+# for volunteer-run relay registration and for the Cloudflare Worker front
 # (broker.openrung.org), neither of which pass through here.
 #
 # Serves its cert on SNI broker-origin.openrung.org. CloudFront (distribution

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -3,7 +3,7 @@
 The broker is the **control plane**: it matches clients with healthy relays and
 records operational telemetry. It never carries user traffic and never holds any
 Reality key — it only serves the relay directory (`GET /api/v1/relays`), accepts
-volunteer registrations/heartbeats, ingests client telemetry, and (optionally)
+relay registrations/heartbeats, ingests client telemetry, and (optionally)
 serves a protected telemetry dashboard.
 
 Because its traffic is tiny (control-plane only), the broker can run anywhere —
@@ -18,8 +18,8 @@ docker compose up -d --build
 docker compose logs -f
 ```
 
-The broker listens on `:8080` (host networking). Point hubs and volunteers at it
-with `OPENRUNG_BROKER_URL`, and check it:
+The broker listens on `:8080` (host networking). Point hubs and relay runtimes
+at it with `OPENRUNG_BROKER_URL`, and check it:
 
 ```sh
 curl http://localhost:8080/healthz
@@ -45,7 +45,7 @@ With no `OPENRUNG_VOLUNTEER_TOKEN` set it runs open (anonymous registration); se
 one to require auth. Optional overrides: `OPENRUNG_REGION`, `OPENRUNG_BUNDLE`,
 `OPENRUNG_DASHBOARD_TOKEN`, `OPENRUNG_RELAY_STORE` / `OPENRUNG_RELAY_DATABASE_URL`,
 `OPENRUNG_GEOIP_ENDPOINT`. The script prints the health URL and the
-`OPENRUNG_BROKER_URL=http://<ip>:8080` to point hubs and volunteers at. Front the
+`OPENRUNG_BROKER_URL=http://<ip>:8080` to point hubs and relay runtimes at. Front the
 origin with Cloudflare for TLS (below) and set the client apps' HTTPS broker URL
 to the Cloudflare hostname.
 
@@ -61,7 +61,7 @@ anyone can register a relay into the directory clients route their VPN traffic
 through. You must either:
 
 - set `OPENRUNG_VOLUNTEER_TOKEN` to a long random string (shared with your hubs
-  and volunteers), **or**
+  and volunteer-run relays), **or**
 - explicitly opt into an open, unauthenticated broker with
   `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true` (the `.env.example` default).
   OpenRung's public network intentionally runs open so any volunteer can
@@ -103,9 +103,9 @@ not reload a changed env file). `lightsail-up.sh` intentionally rejects
 > **Rolling back past `node_class`:** a broker image that predates the
 > `node_class` column does not guard registrations or heartbeats, so it can
 > overwrite a foundation relay's `host:port` row — replacing its id, keys, and
-> endpoint with an attacker's or volunteer's — while leaving `node_class`
-> stuck at `'foundation'`. An upgraded broker would then sign that forged
-> descriptor as Foundation.
+> endpoint with one controlled by an attacker or volunteer-run relay — while
+> leaving `node_class` stuck at `'foundation'`. An upgraded broker would then
+> sign that forged descriptor as Foundation.
 >
 > **Never run pre-`node_class` and `node_class`-aware broker binaries against
 > the same database while any foundation row exists** — a mixed-version fleet
@@ -238,7 +238,7 @@ read-only rootfs):
 - `--cap-drop ALL` — the broker binds `:8080` (≥ 1024) and never changes user or
   mounts, so it needs no Linux capabilities.
 - `--security-opt no-new-privileges` — nothing in the image escalates via setuid
-  or file capabilities. (Unlike the volunteer relay, which must **not** set this:
+  or file capabilities. (Unlike the relay runtime, which must **not** set this:
   it binds 443 through a `cap_net_bind_service` file capability that
   `no-new-privileges` would disable.)
 - `--read-only` root filesystem with `--tmpfs /tmp` — the only writable paths are
@@ -261,7 +261,7 @@ docker inspect openrung-broker \
 
 | Variable                             | Required | Default                             | Purpose                                                        |
 | ------------------------------------ | -------- | ----------------------------------- | -------------------------------------------------------------- |
-| `OPENRUNG_VOLUNTEER_TOKEN`           | yes\*    | —                                   | Shared registration token (must match hubs/volunteers)         |
+| `OPENRUNG_VOLUNTEER_TOKEN`           | yes\*    | —                                   | Shared registration token (must match hubs/relay runtimes)     |
 | `OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION` | yes\* | —                                   | Set `true` to run open when no token is set (\*one of these)   |
 | `OPENRUNG_FOUNDATION_TOKEN`          | no       | —                                   | Privileged token for `node_class=foundation` registrations; must differ from the volunteer token |
 | `OPENRUNG_RELAY_SIGNING_KEY`         | yes      | —                                   | Std-base64 32-byte Ed25519 seed; signs every relay-list response |

--- a/deploy/broker/lightsail-up.sh
+++ b/deploy/broker/lightsail-up.sh
@@ -5,7 +5,7 @@
 #   deploy/broker/lightsail-up.sh [name]
 #
 # The broker is the control-plane HTTP API: it serves the relay directory to
-# clients, accepts volunteer/hub registrations and heartbeats, and ingests client
+# clients, accepts relay/hub registrations and heartbeats, and ingests client
 # telemetry. It carries NO user traffic. This stands one up on a micro_3_0
 # instance (1 GB RAM / 2 vCPU), gives it a static IP, pulls the prebuilt image
 # from GHCR, runs it with host networking + a persistent telemetry volume, and
@@ -67,7 +67,7 @@ IPNAME="${NAME}-ip"
 echo "Provisioning Lightsail broker '${NAME}' in ${REGION} (${BUNDLE}, ${BLUEPRINT})"
 
 # Static IP (free while attached; gives the broker a stable public host to point
-# hubs/volunteers and the Cloudflare origin at).
+# hubs/relay runtimes and the Cloudflare origin at).
 aws lightsail allocate-static-ip --static-ip-name "$IPNAME" --region "$REGION" >/dev/null 2>&1 || true
 STATIC_IP="$(aws lightsail get-static-ip --static-ip-name "$IPNAME" --region "$REGION" --query 'staticIp.ipAddress' --output text)"
 
@@ -109,7 +109,7 @@ GEOIP_ENV=""; [ -n "$GEOIP_ENDPOINT" ] && GEOIP_ENV="OPENRUNG_GEOIP_ENDPOINT=${G
 #                                     Linux capabilities.
 #   --security-opt no-new-privileges  nothing in the image escalates via setuid
 #                                     or file capabilities, so this is safe here.
-#                                     (The volunteer relay must NOT set this — it
+#                                     (The relay runtime must NOT set this — it
 #                                     binds 443 through a file capability, which
 #                                     no-new-privileges disables. See its script.)
 #   --read-only --tmpfs /tmp          read-only rootfs; the only writable paths
@@ -219,7 +219,7 @@ if [ -n "$DASHBOARD_TOKEN" ]; then
   echo "  Dashboard: http://${STATIC_IP}:${PORT}/admin/telemetry"
 fi
 echo
-echo "Point hubs and volunteers at it with:"
+echo "Point hubs and relay runtimes at it with:"
 echo "  OPENRUNG_BROKER_URL=http://${STATIC_IP}:${PORT}"
 echo
 echo "Front it with Cloudflare for TLS, and set the client apps' HTTPS broker URL"

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -14,7 +14,7 @@ relay ──HTTPS──► CloudFront edge ──HTTPS(:443)──► Caddy ─�
 ```
 
 The broker container is **not touched** — the proxy is purely additive, and the
-plaintext `:8080` path stays open for community volunteer relays and for the
+plaintext `:8080` path stays open for volunteer-run relays and for the
 Cloudflare Worker front. Set up 2026-07-13.
 
 ## What must not be undone
@@ -24,7 +24,7 @@ Cloudflare Worker front. Set up 2026-07-13.
   reintroduce Cloudflare's datacenter challenge on the origin and loop the
   Cloudflare Worker's subrequest back into the edge. Both CDN fronts depend on
   this record resolving straight to the broker IP.
-- **Keep `:8080` open.** Community volunteers (Hetzner + Lightsail, see
+- **Keep `:8080` open.** Volunteer-run relays (Hetzner + Lightsail, see
   `deploy/volunteer/hetzner-up.sh`) register directly against
   `http://54.238.185.205:8080`, and the Cloudflare Worker front fetches the
   origin on `:8080`. Do not firewall it off as part of this change.
@@ -175,7 +175,7 @@ curl -v https://broker-origin.openrung.org/api/v1/relays        # 200, cert veri
 # Cloudflare Worker front 403s datacenter IPs by design):
 curl https://d2r7mdpyevvs1m.cloudfront.net/api/v1/relays?limit=1 # 200, X-OpenRung-Relays-Signature present
 
-# Volunteer plaintext path still intact:
+# Volunteer-class relay plaintext path still intact:
 curl http://54.238.185.205:8080/api/v1/relays                   # 200
 
 # Confirm CloudFront connects over TLS (SNI = origin, not the CF domain):

--- a/deploy/relayhub/.env.example
+++ b/deploy/relayhub/.env.example
@@ -15,9 +15,9 @@ OPENRUNG_BROKER_URL=https://broker.example.com
 # ---------------------------------------------------------------------------
 # Control channel + ports (optional)
 # ---------------------------------------------------------------------------
-# Address volunteers dial to establish a tunnel (default :9443).
+# Address that volunteer-run relays dial to establish a tunnel (default :9443).
 #OPENRUNG_HUB_CONTROL_ADDR=:9443
-# Public TCP port range allocated to tunneled relays, one port per volunteer.
+# Public TCP port range allocated to tunneled relays, one port per relay.
 #OPENRUNG_HUB_PORT_RANGE=20000-20100
 # Interface the per-tunnel public listeners bind to (default all interfaces).
 #OPENRUNG_HUB_PUBLIC_BIND_HOST=
@@ -25,8 +25,9 @@ OPENRUNG_BROKER_URL=https://broker.example.com
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------
-# Shared bearer token: volunteers must present it to open a tunnel, and the hub
-# uses it for its broker registration calls. Must match the broker's token.
+# Shared bearer token: volunteer-run relays must present it to open a tunnel,
+# and the hub uses it for its broker registration calls. Must match the broker's
+# token.
 #
 # The hub refuses to start without a token, so this template opts into an open,
 # unauthenticated hub (no token configured). To require auth instead, set
@@ -51,16 +52,17 @@ OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true
 #OPENRUNG_HUB_HEARTBEAT_INTERVAL=30s
 
 # ---------------------------------------------------------------------------
-# Hub HTTP API (optional) — enables volunteer reachability auto-detection and,
+# Hub HTTP API (optional) — enables relay reachability auto-detection and,
 # with reflectors, NAT hole punching. Set OPENRUNG_HUB_HTTP_ADDR to turn it on.
-# Open its TCP port in the firewall and do NOT front it with a proxy (the
-# volunteer's real source IP must be observable). See README.md.
+# Open its TCP port in the firewall and do NOT front it with a proxy: the hub
+# must observe the relay connection's public source IP directly. See README.md.
 # ---------------------------------------------------------------------------
 #OPENRUNG_HUB_HTTP_ADDR=:9444
 #
-# NAT hole punching (optional): lets clients reach CGNAT volunteers directly,
-# bypassing the hub data path. Enabled only when HTTP_ADDR is set AND reflectors
-# are configured. Also open the reflector UDP port(s) in your firewall.
+# NAT hole punching (optional): lets clients reach CGNAT volunteer-run relays
+# directly, bypassing the hub data path. Enabled only when HTTP_ADDR is set AND
+# reflectors are configured. Also open the reflector UDP port(s) in your
+# firewall.
 #
 # REFLECTOR_ADDRS is the BIND list (addresses on the host NIC). On AWS the public
 # IP is 1:1-NAT'd and NOT on the NIC, so bind the private IP or a wildcard and set

--- a/deploy/relayhub/Dockerfile
+++ b/deploy/relayhub/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 #
 # OpenRung relay hub — the publicly reachable component that terminates reverse
-# tunnels from CGNAT volunteers and forwards client traffic to them. Unlike the
-# volunteer image it bundles no Xray (it only copies opaque bytes). Build from
-# the repository ROOT so the Go sources are in the build context:
+# tunnels from CGNAT volunteer-run relays and forwards client traffic to them.
+# Unlike the relay runtime image it bundles no Xray (it only copies opaque
+# bytes). Build from the repository ROOT so the Go sources are in the build
+# context:
 #
 #   docker build -f deploy/relayhub/Dockerfile -t openrung-relayhub .
 #

--- a/deploy/relayhub/README.md
+++ b/deploy/relayhub/README.md
@@ -1,11 +1,11 @@
 # OpenRung Relay Hub
 
-The relay hub is the publicly reachable component that lets volunteers behind
-**CGNAT** (carrier-grade NAT, no inbound port) join the network. A CGNAT
-volunteer dials the hub outbound over a single TLS connection; the hub allocates
-a public TCP port, registers the relay with the broker on the volunteer's
+The relay hub is the publicly reachable component that lets volunteer-run
+relays behind **CGNAT** (carrier-grade NAT, no inbound port) join the network. A
+CGNAT relay dials the hub outbound over a single TLS connection; the hub
+allocates a public TCP port, registers the relay with the broker on the relay's
 behalf, and forwards inbound client connections through the tunnel to the
-volunteer's local Xray. Clients reach `hub_public_host:allocated_port` exactly
+relay's local Xray. Clients reach `hub_public_host:allocated_port` exactly
 as they would any direct relay — no client changes.
 
 The hub copies **opaque bytes** only. It never holds the Reality private key, so
@@ -13,26 +13,28 @@ it cannot decrypt the end-to-end VLESS Reality traffic flowing through it.
 
 ## ⚠️ Run this where bandwidth is cheap — NOT on AWS egress
 
-For a CGNAT volunteer, **all** of its client traffic transits the hub in both
-directions (this is intrinsic to CGNAT — there is no direct path). The hub is
-therefore a pure bandwidth mover, and egress pricing dominates its cost:
+Without a successful NAT punch, **all** client traffic for a CGNAT relay
+transits the hub in both directions. The hub is therefore a pure bandwidth
+mover on the tunnel/fallback path, and egress pricing dominates its cost:
 
-| Sustained per volunteer | Monthly transfer | AWS egress (~$0.09/GB) | Unmetered host |
-| ----------------------- | ---------------- | ---------------------- | -------------- |
-| 20 Mbps                 | ~6.3 TB          | **~$575 / mo**         | ~$0            |
+| Sustained per relay | Monthly transfer | AWS egress (~$0.09/GB) | Unmetered host |
+| ------------------- | ---------------- | ---------------------- | -------------- |
+| 20 Mbps             | ~6.3 TB          | **~$575 / mo**         | ~$0            |
 
 Run relay hubs on **unmetered or cheap-bandwidth providers** (Hetzner — ~20 TB
 included then ~€1/TB, OVH, Fly, bare metal). Keep the broker (tiny control-plane
-traffic) wherever you like. Scale horizontally and place hubs near volunteers to
+traffic) wherever you like. Scale horizontally and place hubs near relays to
 spread load.
 
 > The MVP does **not** enforce per-relay or per-hub bandwidth caps. Size the
 > `OPENRUNG_HUB_PORT_RANGE` to the number of concurrent tunnels you intend to
 > host, and run on infrastructure whose bandwidth cost you control.
 
-Only point volunteers at a hub when they genuinely cannot expose a port. Hosts
-with a public IP — including public IPv6, which most residential ISPs provide —
-should run the volunteer in its default **direct** mode and never touch the hub.
+Only use the hub's tunnel data path when a volunteer-run relay cannot expose a
+port. Relays in `-mode auto` may still contact the hub to probe reachability; a
+successful callback selects **direct** mode, so client traffic bypasses the hub.
+Operators who already know the relay is publicly reachable can select
+**direct** mode explicitly.
 
 ## Quick start
 
@@ -43,7 +45,7 @@ docker compose up -d --build
 docker compose logs -f
 ```
 
-Then start a CGNAT volunteer pointing at this hub (see
+Then start a CGNAT volunteer-run relay pointing at this hub (see
 `deploy/volunteer/.env.example`):
 
 ```sh
@@ -68,7 +70,7 @@ hub image published to GHCR and made **public** (see note below).
 This allocates a static IP, generates a self-signed TLS cert for that IP, installs Docker, pulls
 `ghcr.io/openrung/openrung-relayhub:main`, runs the hub (host networking, certs mounted read-only),
 and opens the control port (9443) plus the tunnel port range (20000-20100) in the firewall. It
-prints the exact env to point a CGNAT volunteer at the hub:
+prints the exact env to point a CGNAT relay at the hub:
 
 ```sh
 OPENRUNG_TUNNEL=true OPENRUNG_HUB_ADDR=<static-ip>:9443 OPENRUNG_HUB_INSECURE=true
@@ -108,9 +110,9 @@ hourly — run it where that is acceptable, or fall back to Lightsail single-IP 
 The control channel carries the shared auth token, so TLS is strongly
 recommended. Provide a certificate and key via `OPENRUNG_HUB_TLS_CERT` /
 `OPENRUNG_HUB_TLS_KEY` (mounted read-only into the container). With a real CA
-certificate, volunteers verify it with their system roots out of the box. For a
-self-signed cert during testing, volunteers can set `OPENRUNG_HUB_INSECURE=true`
-to skip verification.
+certificate, relay runtimes verify it with their system roots out of the box.
+For a self-signed cert during testing, relay runtimes can set
+`OPENRUNG_HUB_INSECURE=true` to skip verification.
 
 Without a cert/key the hub logs a warning and runs the control channel in
 plaintext (local development only).
@@ -124,7 +126,7 @@ flags — run `relayhub -h`). See `.env.example` for the full list. The essentia
 | ----------------------------- | -------- | -------------- | -------------------------------------------------- |
 | `OPENRUNG_HUB_PUBLIC_HOST`    | yes      | —              | Host advertised to clients for tunneled relays     |
 | `OPENRUNG_BROKER_URL`         | yes      | —              | Broker the hub registers relays with               |
-| `OPENRUNG_HUB_CONTROL_ADDR`   | no       | `:9443`        | Address volunteers dial                            |
+| `OPENRUNG_HUB_CONTROL_ADDR`   | no       | `:9443`        | Address dialed by volunteer-run relays              |
 | `OPENRUNG_HUB_PORT_RANGE`     | no       | `20000-20100`  | Public ports allocated to tunnels (one each)       |
 | `OPENRUNG_VOLUNTEER_TOKEN`    | yes\*    | —              | Shared auth token (must match the broker). Required: the hub refuses to start without it unless `OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true` |
 | `OPENRUNG_HUB_TLS_CERT/KEY`   | no       | —              | TLS for the control channel                        |
@@ -138,20 +140,22 @@ Open the control port and the entire public port range in your firewall.
 ## Hub HTTP API: reachability probe + auto-detect
 
 Set `OPENRUNG_HUB_HTTP_ADDR` (e.g. `:9444`) to enable the hub's HTTP API. Even
-without punch, this powers **volunteer auto-detection**: a volunteer started with
-`-mode auto` (the default when it has a `-hub`) opens its listener and asks the
-hub to dial it back at its observed public IP. If the callback succeeds the
-volunteer registers **directly**; if not (CGNAT / firewalled) it falls back to
+without punch, this powers **reachability auto-detection for volunteer-run
+relays**: a relay started with `-mode auto` (the default when it has a `-hub`)
+opens its listener and asks the hub to dial it back at its observed public IP.
+If the callback succeeds the relay registers **directly**; if not (CGNAT /
+firewalled) it falls back to
 **tunnel** mode automatically — no manual `-tunnel` guesswork. The prober only
 ever dials the caller's own source IP (never a caller-chosen host), so it is not
 an SSRF vector; it requires the shared token and is rate-limited. Open the HTTP
-API's TCP port in the firewall, and do **not** put it behind a proxy (the
-observed source IP must be the volunteer's real IP).
+API's TCP port in the firewall, and do **not** put it behind a proxy: the hub
+must observe the relay connection's public source IP directly.
 
 ## NAT hole punching (optional, cuts hub egress)
 
-When enabled, the hub coordinates a **direct** client ↔ CGNAT-volunteer path so
-the bytes bypass the hub entirely (it only signals). See
+When enabled, the hub coordinates a **direct** path between the client and a
+CGNAT volunteer-run relay, so the bytes bypass the hub entirely (it only
+signals). See
 [`docs/architecture.md`](../../docs/architecture.md) for the full design. Punching
 is **off** unless both `OPENRUNG_HUB_HTTP_ADDR` and `OPENRUNG_HUB_REFLECTOR_ADDRS`
 are set.
@@ -183,6 +187,6 @@ are set.
 - **Exposure.** The punch coordinator HTTP endpoint is direct-internet (not
   Cloudflare-fronted) and carries its own per-source-IP + per-relay rate limiting;
   the reflector enforces a request-size floor so it can never amplify traffic.
-- **Volunteers** offer punching by default (`-punch`, tunnel mode). A volunteer on
-  a public IP or global IPv6 should keep using direct/registration mode instead —
-  punching only helps genuinely NAT'd volunteers.
+- **Volunteer-run relays** offer punching by default (`-punch`, tunnel mode). A
+  relay on a public IP or global IPv6 should keep using direct/registration mode
+  instead — punching only helps genuinely NAT'd relays.

--- a/deploy/relayhub/ec2-up.sh
+++ b/deploy/relayhub/ec2-up.sh
@@ -184,7 +184,7 @@ docker run -d --name openrung-relayhub --restart unless-stopped \
 TMPL
 
 # Without a token the hub fails closed, so when none is provided we explicitly
-# opt into anonymous volunteers (open, unauthenticated hub) instead — set
+# allow anonymous relay connections (open, unauthenticated hub) instead — set
 # OPENRUNG_VOLUNTEER_TOKEN to require auth.
 TOKEN_ENV=""
 ANON_ENV=""

--- a/deploy/relayhub/lightsail-up.sh
+++ b/deploy/relayhub/lightsail-up.sh
@@ -5,8 +5,8 @@
 #   deploy/relayhub/lightsail-up.sh [name]
 #
 # The relay hub is the public component that terminates reverse tunnels from
-# CGNAT volunteers and forwards client traffic to them. This stands one up on a
-# micro_3_0 instance (1 GB RAM / 2 vCPU / 40 GB / 2 TB transfer), gives it a
+# CGNAT volunteer-run relays and forwards client traffic to them. This stands
+# one up on a micro_3_0 instance (1 GB RAM / 2 vCPU / 40 GB / 2 TB transfer), gives it a
 # static IP, generates a self-signed TLS cert for the control channel (with the
 # static IP in the cert SAN), pulls the prebuilt image from GHCR, and opens the
 # control port plus the public tunnel port range in the firewall.
@@ -27,7 +27,8 @@ IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relayhub:main}"
 BROKER_URL="${OPENRUNG_BROKER_URL:-http://54.238.185.205:8080}"
 CONTROL_PORT="${OPENRUNG_HUB_CONTROL_PORT:-9443}"
 PORT_RANGE="${OPENRUNG_HUB_PORT_RANGE:-20000-20100}"
-# HTTP API port for the reachability prober (enables volunteer -mode auto).
+# HTTP API port for the reachability prober (enables the relay runtime's
+# `-mode auto`).
 # Served over TLS with the same self-signed control cert. Set to empty to disable.
 HTTP_PORT="${OPENRUNG_HUB_HTTP_PORT:-9444}"
 TOKEN="${OPENRUNG_VOLUNTEER_TOKEN:-}"
@@ -55,7 +56,7 @@ STATIC_IP="$(aws lightsail get-static-ip --static-ip-name "$IPNAME" --region "$R
 
 # Optional bearer token (must match the broker). Included in the env file only
 # when set so a blank line is harmless. Without a token the hub fails closed, so
-# when none is provided we explicitly opt into anonymous volunteers (open,
+# when none is provided we explicitly allow anonymous relay connections (open,
 # unauthenticated hub) instead — set OPENRUNG_VOLUNTEER_TOKEN to require auth.
 TOKEN_ENV=""
 ANON_ENV=""
@@ -86,7 +87,8 @@ systemctl enable --now docker
 
 # Self-signed TLS for the control channel, valid for the static IP. The cert is
 # world-readable so the container's non-root user can read it (the box is
-# single-purpose). Volunteers connect with OPENRUNG_HUB_INSECURE=true.
+# single-purpose). Volunteer-run relays connect with
+# OPENRUNG_HUB_INSECURE=true.
 mkdir -p /etc/openrung/certs
 openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \\
   -keyout /etc/openrung/certs/hub.key \\
@@ -167,6 +169,6 @@ if [ -n "$HTTP_PORT" ]; then
 fi
 echo "It registers tunneled relays with ${BROKER_URL} after boot (~2-3 min)."
 echo
-echo "Point a CGNAT volunteer at it with:"
+echo "Point a CGNAT volunteer-run relay at it with:"
 echo "  OPENRUNG_TUNNEL=true OPENRUNG_HUB_ADDR=${STATIC_IP}:${CONTROL_PORT} OPENRUNG_HUB_INSECURE=true"
 echo "OPENRUNG_HUB name=${NAME} ip=${STATIC_IP} control_port=${CONTROL_PORT}"

--- a/deploy/volunteer/.env.example
+++ b/deploy/volunteer/.env.example
@@ -1,4 +1,4 @@
-# OpenRung volunteer relay configuration.
+# OpenRung relay runtime configuration.
 # Copy to .env and fill in. Only the two values under "Required" are mandatory.
 
 # ---------------------------------------------------------------------------
@@ -16,7 +16,7 @@ OPENRUNG_PUBLIC_HOST=2001:db8::1234
 # CGNAT reverse-tunnel mode (optional)
 # ---------------------------------------------------------------------------
 # Set OPENRUNG_MODE=tunnel if THIS relay is behind CGNAT (no inbound port). The
-# volunteer then dials a relay hub instead of exposing a public port: the hub
+# relay then dials a relay hub instead of exposing a public port: the hub
 # allocates a public port and registers the relay with the broker on its behalf.
 # In tunnel mode OPENRUNG_BROKER_URL and OPENRUNG_PUBLIC_HOST above are NOT used
 # (only OPENRUNG_HUB_ADDR is required), and the container needs no inbound port
@@ -62,7 +62,7 @@ OPENRUNG_PUBLIC_HOST=2001:db8::1234
 # OPENRUNG_NODE_CLASS or OPENRUNG_MODE — the token forces both. The value is the
 # same secret configured as OPENRUNG_FOUNDATION_TOKEN on the broker. A
 # Foundation-operated hub still registers community exits tunneled through it as
-# volunteers.
+# `node_class=volunteer`.
 #
 # Keep the populated env file root-owned and mode 0600. Transfer the token only
 # after boot over an authenticated channel; never place it in cloud-init/

--- a/deploy/volunteer/Dockerfile
+++ b/deploy/volunteer/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 #
-# OpenRung volunteer relay — a self-contained image bundling the volunteer
-# binary and a pinned Xray-core. Build from the repository ROOT so the Go
+# OpenRung relay runtime — a self-contained image bundling the legacy-named
+# legacy-named `volunteer` binary and a pinned Xray-core. Build from the repository
+# ROOT so the Go
 # sources are in the build context:
 #
 #   docker build -f deploy/volunteer/Dockerfile -t openrung-volunteer .
@@ -40,7 +41,7 @@ RUN set -eux; \
     unzip -o /tmp/xray.zip LICENSE README.md -d /xray-licenses; \
     chmod +x /xray/xray
 
-# --- Stage 2: build the volunteer binary (cross-compiled, no cgo) ---
+# --- Stage 2: build the relay binary (legacy output name; cross-compiled, no cgo) ---
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -71,7 +72,7 @@ COPY --from=build /out/volunteer /usr/local/bin/volunteer
 COPY deploy/volunteer/entrypoint.sh /usr/local/bin/entrypoint.sh
 # Third-party attribution + GPL/MPL source offers travel with the distributed image.
 COPY THIRD_PARTY_NOTICES.md /usr/local/share/openrung/THIRD_PARTY_NOTICES.md
-# Let the (non-root) volunteer bind the privileged public port (443). Pairs with
+# Let the non-root relay process bind the privileged public port (443). Pairs with
 # `cap_add: NET_BIND_SERVICE` at runtime. NOTE: file capabilities are ignored
 # under no-new-privileges, so do not enable that flag for this image (or switch
 # to a public port >= 1024 and run with zero capabilities instead).

--- a/deploy/volunteer/README.md
+++ b/deploy/volunteer/README.md
@@ -1,9 +1,10 @@
-# OpenRung volunteer relay — Docker deployment
+# OpenRung relay — Docker deployment
 
-A self-contained image for running an OpenRung volunteer relay on a cloud VPS
-(AWS EC2, DigitalOcean, Hetzner, Linode, …). The image bundles the `volunteer`
-binary and a pinned [Xray-core](https://github.com/XTLS/Xray-core); it is
-configured entirely through environment variables.
+A self-contained image for running an OpenRung relay on a cloud VPS (AWS EC2,
+DigitalOcean, Hetzner, Linode, …). The same runtime serves Foundation-operated
+and volunteer-run relays. The image bundles the legacy-named `volunteer` binary
+and a pinned [Xray-core](https://github.com/XTLS/Xray-core); it is configured
+entirely through environment variables.
 
 ## TL;DR
 
@@ -57,14 +58,14 @@ also set `OPENRUNG_NODE_CLASS` or `OPENRUNG_MODE`:
   downgrade.
 - Never put the token in cloud-init/user-data, provider metadata, inline
   `docker -e` arguments, or traced shell commands. The bundled Lightsail and
-  Hetzner bootstrap helpers intentionally provision anonymous volunteers only
-  and reject registration tokens; provision the host first, transfer the env
-  file over an authenticated channel, and recreate the container with
-  `--env-file`.
+  Hetzner bootstrap helpers intentionally provision anonymous volunteer-class
+  relays only and reject registration tokens; provision the host first,
+  transfer the env file over an authenticated channel, and recreate the
+  container with `--env-file`.
 
 `node_class` describes the operator of the exit relay, not the infrastructure it
-traverses. A Foundation-operated relay hub therefore does not make the community
-volunteers tunneled through it Foundation-operated.
+traverses. A Foundation-operated relay hub therefore does not make the
+volunteer-run relays tunneled through it Foundation-operated.
 
 ### Stable relay identity (recommended)
 
@@ -139,8 +140,8 @@ docker compose restart            # restart the relay
 docker compose down               # stop and remove
 ```
 
-Shutdown is graceful: `docker stop` sends SIGTERM, the volunteer stops xray and
-the connection observer and exits cleanly.
+Shutdown is graceful: `docker stop` sends SIGTERM, the relay runtime stops xray
+and the connection observer and exits cleanly.
 
 ## Updating Xray-core
 

--- a/deploy/volunteer/docker-compose.yml
+++ b/deploy/volunteer/docker-compose.yml
@@ -1,4 +1,4 @@
-# OpenRung volunteer relay.
+# OpenRung relay runtime (legacy service/image names retained for compatibility).
 #
 #   cp .env.example .env      # then edit .env (set OPENRUNG_BROKER_URL + OPENRUNG_PUBLIC_HOST)
 #   docker compose up -d --build

--- a/deploy/volunteer/entrypoint.sh
+++ b/deploy/volunteer/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Translate OPENRUNG_* environment variables into volunteer CLI flags, then exec
-# the binary so it receives SIGTERM directly for a clean shutdown.
+# Translate OPENRUNG_* environment variables into relay CLI flags, then exec the
+# legacy-named binary so it receives SIGTERM directly for a clean shutdown.
 set -eu
 
 # Resolve the connection mode the same way the binary's normalizeMode does:

--- a/deploy/volunteer/hetzner-up.sh
+++ b/deploy/volunteer/hetzner-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Provision an OpenRung volunteer relay on Hetzner Cloud.
+# Provision an OpenRung volunteer-run relay on Hetzner Cloud.
 #
 #   deploy/volunteer/hetzner-up.sh [name]
 #
@@ -29,7 +29,7 @@ OS_IMAGE="${OPENRUNG_OS_IMAGE:-ubuntu-24.04}"
 IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-volunteer:main}"  # multi-arch: pulls arm64 on CAX
 # Register against the broker ORIGIN, not the Cloudflare front (broker.openrung.org).
 # That hostname is a Worker front for *client* discovery; its edge serves a Managed
-# Challenge to datacenter IP ranges (incl. Hetzner), which a volunteer's HTTP client
+# Challenge to datacenter IP ranges (incl. Hetzner), which a relay's HTTP client
 # cannot solve (403). The origin is plaintext HTTP and takes registrations directly,
 # exactly like the Lightsail fleet (see lightsail-up.sh).
 BROKER_URL="${OPENRUNG_BROKER_URL:-http://54.238.185.205:8080}"
@@ -37,7 +37,7 @@ SSH_KEY_NAME="${OPENRUNG_SSH_KEY_NAME:-openrung}"
 FIREWALL_NAME="${OPENRUNG_FIREWALL_NAME:-openrung-volunteer}"
 
 if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_FOUNDATION_TOKEN+x}" = x ]; then
-  echo "error: this helper provisions anonymous volunteers only; OPENRUNG_VOLUNTEER_TOKEN / OPENRUNG_FOUNDATION_TOKEN must be unset because Hetzner retains cloud-init user-data. A Foundation relay also needs a TLS broker, which this plaintext-origin helper does not use — install its credential post-boot over an authenticated channel instead." >&2
+  echo "error: this helper provisions anonymous volunteer-class relays only; OPENRUNG_VOLUNTEER_TOKEN / OPENRUNG_FOUNDATION_TOKEN must be unset because Hetzner retains cloud-init user-data. A Foundation relay also needs a TLS broker, which this plaintext-origin helper does not use — install its credential post-boot over an authenticated channel instead." >&2
   exit 2
 fi
 
@@ -77,7 +77,7 @@ hcloud firewall add-rule "$FIREWALL_NAME" --direction in --protocol icmp        
 # public IP is not known until the server exists, so the box self-discovers it
 # from Hetzner's metadata service at boot and bakes it into OPENRUNG_PUBLIC_HOST.
 #
-# Container hardening — identical posture to the Lightsail volunteer helper, and
+# Container hardening — identical posture to the Lightsail relay helper, and
 # the exact posture the production fleet runs (confirmed read-only via
 # `docker inspect` on a live Hetzner relay 2026-07-13: ReadonlyRootfs=true,
 # CapDrop=[ALL], CapAdd=[NET_BIND_SERVICE], while serving 443). The flags on the

--- a/deploy/volunteer/lightsail-up.sh
+++ b/deploy/volunteer/lightsail-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Provision an OpenRung volunteer relay on AWS Lightsail.
+# Provision an OpenRung volunteer-run relay on AWS Lightsail.
 #
 #   deploy/volunteer/lightsail-up.sh [name]
 #

--- a/desktop-volunteer/main.go
+++ b/desktop-volunteer/main.go
@@ -57,7 +57,7 @@ func main() {
 			opts := wailsruntime.MessageDialogOptions{
 				Type:          wailsruntime.QuestionDialog,
 				Title:         "Stop volunteering?",
-				Message:       "Quitting stops your relay, and people connected through it will be moved to other volunteers. Quit anyway?",
+				Message:       "Quitting stops your relay, and people connected through it will be moved to other relays. Quit anyway?",
 				Buttons:       []string{"Quit", "Keep running"},
 				DefaultButton: "Keep running",
 				CancelButton:  "Keep running",

--- a/desktop-volunteer/volunteerservice/service.go
+++ b/desktop-volunteer/volunteerservice/service.go
@@ -280,7 +280,7 @@ func (s *Service) Start() error {
 	s.mu.Unlock()
 	_ = eng.UpdateConfig(cfg)
 
-	s.appendLog("starting volunteer relay…")
+	s.appendLog("starting relay…")
 	if err := eng.Start(); err != nil {
 		s.appendLog("start failed: " + err.Error())
 		return err
@@ -299,7 +299,7 @@ func (s *Service) Stop() error {
 	}
 	go func() {
 		eng.Stop()
-		s.appendLog("volunteer relay stopped")
+		s.appendLog("relay stopped")
 		s.emitCurrent()
 	}()
 	s.emitCurrent()

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -88,7 +88,7 @@ export default function App() {
                     <span className="or-wordmark">OpenRung</span>
                     <span className="or-cursor">▍</span>
                   </div>
-                  <span className="or-tagline">volunteer relay network</span>
+                  <span className="or-tagline">relay network</span>
                 </div>
                 <div className="or-header-right">
                   <div className={`or-map-chip ${state.directoryStatus === 'failed' ? 'is-failed' : ''}`}>

--- a/desktop/frontend/src/core/model/countryGeo.ts
+++ b/desktop/frontend/src/core/model/countryGeo.ts
@@ -4,7 +4,7 @@
  * the static SVG fallback map used when WebGL is unavailable.
  *
  * Curated ISO-3166 alpha-2 -> centroid table used to place exit-node markers on the map without a
- * per-host geocoding round trip. Asia-Pacific is covered densely (the volunteer network's focus);
+ * per-host geocoding round trip. Asia-Pacific is covered densely (the relay network's focus);
  * common VPN-exit countries elsewhere are included so a stray relay still lands somewhere sensible.
  *
  * Coordinates are approximate country centroids (latitude, longitude in degrees).

--- a/desktop/frontend/src/core/model/exitNode.ts
+++ b/desktop/frontend/src/core/model/exitNode.ts
@@ -3,14 +3,14 @@
  * Pure TypeScript, shared as-is with the mobile app.
  */
 
-/** One volunteer relay inside an [ExitNodeRegion]: just what the picker UI needs. */
+/** One relay inside an [ExitNodeRegion]: just what the picker UI needs. */
 export interface ExitNodeRelay {
   id: string; // broker relay id — what connect-to-this-relay targets
-  label: string | null; // volunteer-chosen name (e.g. "silly-lemur"); null on older brokers
+  label: string | null; // friendly name (operator-supplied or generated); null on older brokers
 }
 
 /**
- * One located exit spot on the exit-node map. Volunteer relays are grouped by the broker-served
+ * One located exit spot on the exit-node map. Relays are grouped by the broker-served
  * exit location (country + city), so a single marker may stand for several nodes (`nodeCount`,
  * with the individual relays listed in `relays` for the list view's per-relay picker).
  * Coordinates come straight from the broker and are city-level accurate at best — the map must

--- a/desktop/frontend/src/core/model/relay.ts
+++ b/desktop/frontend/src/core/model/relay.ts
@@ -16,7 +16,7 @@ export const RelayConstants = {
 
 export interface RelayDescriptor {
   id: string;
-  label?: string; // volunteer-chosen relay name (e.g. "silly-lemur"); absent on older brokers
+  label?: string; // friendly relay name (operator-supplied or generated); absent on older brokers
   public_host: string;
   public_port: number;
   protocol: string;
@@ -28,6 +28,7 @@ export interface RelayDescriptor {
   exit_mode: string;
   max_sessions: number;
   max_mbps: number;
+  // Legacy broker wire name; this reports the software version for every relay class.
   volunteer_version: string;
   registered_at: string; // ISO instant
   last_heartbeat_at: string;

--- a/desktop/frontend/src/screens/AboutScreen.tsx
+++ b/desktop/frontend/src/screens/AboutScreen.tsx
@@ -8,8 +8,8 @@ import { openExternal } from '../native/openExternal';
 
 const HOW_STEPS = [
   {
-    title: 'Volunteers share bandwidth',
-    body: 'People everywhere run small relay nodes on their own connections and register them with the network.',
+    title: 'Relay operators provide capacity',
+    body: 'The OpenRung Foundation and community volunteers run relays and register them with the network.',
   },
   {
     title: 'The broker finds your relay',
@@ -35,11 +35,11 @@ export function AboutScreen({ onOpenLicenses }: Props) {
           <span className="or-about-wordmark">OpenRung</span>
           <span className="or-about-version">v{APP_VERSION}</span>
         </div>
-        <span className="or-tagline">volunteer relay network</span>
+        <span className="or-tagline">relay network</span>
         <p className="or-about-mission">
-          OpenRung routes your traffic through relays run by volunteers around the world, keeping the
-          open internet reachable when networks are filtered. No accounts, no ads, no tracking — just
-          people sharing bandwidth.
+          OpenRung routes your traffic through relays around the world, keeping the open internet
+          reachable when networks are filtered. No account is required and there are no ads. During
+          early testing, OpenRung collects diagnostic connection metadata to improve reliability.
         </p>
       </div>
 

--- a/desktop/vpnservice/connect_helpers.go
+++ b/desktop/vpnservice/connect_helpers.go
@@ -162,7 +162,7 @@ func writeTempConfig(data []byte) (string, error) {
 }
 
 // geoLabel is the user-facing relay label: "City, Country", else country, else
-// the volunteer's chosen label. It never returns a raw IP (contract §3).
+// the relay's friendly label. It never returns a raw IP (contract §3).
 func geoLabel(r relay.Descriptor) string {
 	city := strings.TrimSpace(r.City)
 	country := strings.TrimSpace(r.Country)

--- a/desktop/vpnservice/livepunch_test.go
+++ b/desktop/vpnservice/livepunch_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestLivePunchCGNAT drives the real maybePunch path against the live broker and
-// the cgnat-test volunteer's hub. Skipped by default (it needs network and a
+// the cgnat-test relay's hub. Skipped by default (it needs network and a
 // punchable NAT on both ends); run explicitly:
 //
 //	OPENRUNG_LIVE_PUNCH=1 go test ./vpnservice/ -run TestLivePunchCGNAT -v

--- a/desktop/vpnservice/punch.go
+++ b/desktop/vpnservice/punch.go
@@ -19,7 +19,7 @@ import (
 // not advertise a punch_endpoint (its public host is then the hub).
 const defaultPunchPort = "9444"
 
-// maybePunch attempts a direct NAT-punched path to a punch-capable volunteer,
+// maybePunch attempts a direct NAT-punched path to a punch-capable relay,
 // bypassing the relay hub's data plane. On success it returns a live
 // Establishment whose loopback bridge sing-box dials in place of the hub; the
 // caller must run Bridge.Serve and Close it on teardown. On any failure (not
@@ -62,9 +62,9 @@ func punchBaseURL(selected relay.Descriptor) string {
 
 // punchHTTPClient returns the HTTP client for the hub punch coordination API.
 // With insecure set it skips TLS verification, for a hub serving a self-signed
-// cert on its HTTPS punch endpoint (volunteer-run hubs on bare IPs cannot get a
+// cert on its HTTPS punch endpoint (relay hubs on bare IPs cannot get a
 // CA cert). This weakens ONLY the hub coordination channel: the punched QUIC
-// data path still pins the volunteer's per-session cert by fingerprint, and the
+// data path still pins the relay's per-session cert by fingerprint, and the
 // tunnel itself is VLESS+REALITY keyed by broker-delivered credentials, so a hub
 // MITM can at worst force a fallback to the relay path, never read or redirect
 // the tunnel.

--- a/desktop/vpnservice/service.go
+++ b/desktop/vpnservice/service.go
@@ -153,9 +153,9 @@ type Service struct {
 	SingBoxPath string
 
 	// PunchEnabled attempts a direct NAT-punched path to punch-capable
-	// volunteers before falling back to the relay hub's data plane.
+	// relays before falling back to the relay hub's data plane.
 	// PunchInsecure skips TLS verification of the hub's self-signed punch
-	// coordination endpoint (volunteer hubs on bare IPs cannot get a CA cert);
+	// coordination endpoint (relay hubs on bare IPs cannot get a CA cert);
 	// see punchHTTPClient for why that stays safe.
 	PunchEnabled  bool
 	PunchInsecure bool
@@ -536,7 +536,7 @@ func (s *Service) candidatesFor(resp relay.ListResponse, targetCountry, targetRe
 		}
 		s.appendLog(fmt.Sprintf("connecting to relay %s", name))
 	case strings.TrimSpace(targetCountry) != "":
-		s.appendLog(fmt.Sprintf("connecting to a volunteer in %s", strings.ToUpper(strings.TrimSpace(targetCountry))))
+		s.appendLog(fmt.Sprintf("connecting to a relay in %s", strings.ToUpper(strings.TrimSpace(targetCountry))))
 	}
 	return cands, "", nil
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,7 +100,7 @@ The JSONL sink updates the dashboard's in-memory records immediately, flushes
 buffered JSONL output every five seconds, syncs it to durable storage every 30
 seconds, and performs a final flush and sync during graceful broker shutdown.
 
-The Settings screen offers a manual volunteer speed test. It downloads from the
+The Settings screen offers a manual relay speed test. It downloads from the
 configured broker, avoiding a dependency on external DNS while the VPN is
 active. It performs a 1 MB warm-up followed by a measured 10 MB download through
 the active tunnel and emits `speed_test_completed` with the active `relay_id`
@@ -174,7 +174,7 @@ top-ISP rankings counted by unique session.
 The session `source_ip` prefers the broker-observed pre-tunnel `client_seen`
 address, then the client's pre-tunnel `client_ip` attribute. The source address
 of later telemetry uploads is used only as a fallback because connected uploads
-can reach the broker through a volunteer relay.
+can reach the broker through a relay.
 
 Dashboard totals include active clients and active sessions. Active-session
 breakdowns are available by relay, country, city, ISP, and operating system.
@@ -202,13 +202,16 @@ When the broker uses PostgreSQL relay state, `/healthz` also verifies database
 connectivity. If relay state is unavailable, it returns `503` with an error
 payload so a load balancer can stop routing to that broker instance.
 
-## Register Volunteer
+## Register Relay
 
 ```http
 POST /api/v1/volunteers/register
 Authorization: Bearer <registration-token>
 Content-Type: application/json
 ```
+
+The `/api/v1/volunteers/register` path is a legacy compatibility name. It
+registers both `volunteer`-class and `foundation`-class relays.
 
 Request:
 
@@ -231,9 +234,13 @@ Request:
 }
 ```
 
+`volunteer_version` is a frozen legacy wire name retained for compatibility. It
+reports the relay runtime version for both `volunteer`-class and
+`foundation`-class relays.
+
 `transport` is optional and defaults to `direct`. The relay hub registers CGNAT
-volunteers with `transport: "tunnel"` and a `public_host`/`public_port` pointing
-at the hub; clients treat both the same.
+volunteer-run relays with `transport: "tunnel"` and a
+`public_host`/`public_port` pointing at the hub; clients treat both the same.
 
 `node_class` records who operates the relay: `volunteer` (the default when
 omitted) for community-run hardware, or `foundation` for relays the OpenRung
@@ -242,15 +249,15 @@ claim is only accepted when the request presents the broker's
 `OPENRUNG_FOUNDATION_TOKEN` as its bearer token; any other credential claiming
 `foundation` is rejected with `403` (fail loudly, never silently downgrade).
 The foundation token bounds the claimable class without forcing it — its holder
-may still register `volunteer` relays, but routine volunteer and hub traffic
-should use the volunteer token so the privileged bearer stays out of the hub
-path. On the shipped volunteer, presenting the foundation token
-(`OPENRUNG_FOUNDATION_TOKEN`) is self-contained: it **forces** direct mode,
+may still register `volunteer` relays, but routine volunteer-class relay and hub
+traffic should use the volunteer token so the privileged bearer stays out of
+the hub path. On the shipped relay executable (`cmd/volunteer`), presenting
+`OPENRUNG_FOUNDATION_TOKEN` is self-contained: it **forces** direct mode,
 overriding any `auto`/`tunnel` setting, so operators do not configure the mode
 themselves and the bearer never reaches a hub probe. (The hub path would receive
 the registration bearer, and the shipped hub always registers the tunneled exit
 operator as `volunteer`, so a Foundation-operated hub does not elevate the
-community volunteers behind it.) The class is served back inside the signed
+volunteer-run relays behind it.) The class is served back inside the signed
 relay-list body, so clients receive it with the same Ed25519 authenticity as
 every other descriptor field.
 
@@ -261,26 +268,26 @@ foundation relay's directory entry: a registration at a
 with `403` unless it is itself a foundation-class registration (which requires
 the token). Without this, an anonymous registrant could otherwise seize a
 foundation relay's row — new id, its own keys, downgraded class — and force
-the real node into a re-registration race. A foundation operator re-registers
+the real relay into a re-registration race. A foundation operator re-registers
 (refreshes) its own endpoint normally with the token. The same rule guards
 heartbeats: extending a `foundation` relay's lease requires the foundation
 token, so an orphaned foundation row expires from the origin store within one
 lease TTL.
 
 Foundation registrations must be sent over TLS: the foundation token is
-high-value, and the volunteer client refuses to transmit it over a cleartext
+high-value, and the relay client refuses to transmit it over a cleartext
 `http://` broker URL (loopback excepted for local testing). It also refuses all
 broker redirects in Foundation mode, preventing an HTTPS request from following
-a downgrade. The plaintext broker origin used by community volunteers —
+a downgrade. The plaintext broker origin used by volunteer-run relays —
 reachable because Cloudflare challenges datacenter IPs on the TLS front — is
 therefore volunteer-only.
 
-For tunnel registrations the hub also sends `exit_host`: the volunteer's public
-source IP as observed on its control connection, i.e. where tunneled traffic
-actually exits. The broker uses it only to geolocate the relay and never
-exposes it through any public endpoint, so a CGNAT volunteer's real IP stays
-private. `exit_host` is rejected for direct transport, where `public_host`
-already is the exit.
+For tunnel registrations the hub also sends `exit_host`: the volunteer-run
+relay's public source IP as observed on its control connection, i.e. where
+tunneled traffic actually exits. The broker uses it only to geolocate the relay
+and never exposes it through any public endpoint, so the relay host's observed
+exit IP stays private. `exit_host` is rejected for direct transport, where
+`public_host` already is the exit.
 
 Response:
 
@@ -312,7 +319,8 @@ Response:
 ```
 
 `city`, `country`, and `country_code` are resolved by the broker (never taken
-from the volunteer request) so clients can show where a relay's traffic
+from the relay's registration request) so clients can show where a relay's
+traffic
 physically exits: from `exit_host` for tunnel relays and from `public_host`
 for direct relays. The lookup is best-effort: when it has not succeeded yet
 the fields are omitted, and the broker retries on heartbeats until it
@@ -428,7 +436,7 @@ Response:
 }
 ```
 
-`node_class` (`volunteer` or `foundation`, see Register Volunteer) is
+`node_class` (`volunteer` or `foundation`, see Register Relay) is
 broker-attested and covered by the list signature. Clients written before the
 field existed ignore it; clients that read it must treat a missing value as
 `volunteer` and must not relax any signature or transport verification for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,13 @@
 
 ## Goals
 
-OpenRung provides temporary volunteer relays in unrestricted regions so clients behind internet censorship can reach blocked public websites and apps.
+OpenRung provides temporary relays in unrestricted regions so clients behind
+internet censorship can reach blocked public websites and apps. Relays may be
+Foundation-operated or run by community volunteers.
 
 The current version optimizes for learning:
 
-- Require each volunteer to expose a public reachable TCP port.
+- Require each direct-mode relay to expose a publicly reachable TCP port.
 - Use Xray-core for VLESS + Reality + Vision transport.
 - Keep the broker out of the data path.
 - Let the mobile client route all device traffic through a VPN tunnel.
@@ -26,28 +28,43 @@ The broker does not:
 
 The broker does:
 
-- Accept volunteer registration.
-- Track volunteer heartbeats.
-- Expire stale volunteers.
+- Accept relay registration.
+- Track relay heartbeats.
+- Expire stale relays.
 - Return a small ranked candidate set to clients using recent relay load, success, latency, and speed-test signals.
 - Optionally persist relay state in PostgreSQL so multiple broker instances can share one relay view behind a load balancer.
 - Keep experimental relay/session/metric fields in JSONB columns until they are stable enough to promote into indexed columns.
 
-### Volunteer CLI
+### Relay CLI
 
-The volunteer CLI runs on desktop systems. In the current version it starts an Xray-core inbound listener and registers the relay with the broker. It defaults to an IPv6 listener and auto-advertises the first global IPv6 address it can find unless the operator supplies `-public-host`. With connection logging enabled, `-listen-host dual` opens both IPv6 and IPv4 public listeners and forwards both to one loopback Xray listener. The CLI also wraps Xray with a local TCP observer by default so it can print client connect and disconnect events without changing the broker descriptor.
+The relay CLI (currently `cmd/volunteer`) runs on desktop systems. It starts an
+Xray-core inbound listener and registers the relay with the broker. It defaults
+to an IPv6 listener and auto-advertises the first global IPv6 address it can
+find unless the operator supplies `-public-host`. With connection logging
+enabled, `-listen-host dual` opens both IPv6 and IPv4 public listeners and
+forwards both to one loopback Xray listener. The CLI also wraps Xray with a
+local TCP observer by default so it can print client connect and disconnect
+events without changing the broker descriptor.
+
+The same executable serves both operator classes. Community-run relays register
+as `node_class: "volunteer"`; relays presenting the Foundation credential
+register as `node_class: "foundation"`. The broker attests this provenance in
+the signed relay directory. It is not a quality score or a trust bypass.
 
 The CLI produces an Xray server config with:
 
 - VLESS inbound.
 - Reality transport.
 - Vision flow: `xtls-rprx-vision`.
-- Freedom outbound, meaning the volunteer is the direct exit.
+- Freedom outbound, meaning the relay is the direct exit.
 
-The volunteer also supports a **CGNAT reverse-tunnel mode** for hosts that cannot
-expose a public port; see the Relay Hub section below.
+Volunteer-run relays also support a **CGNAT reverse-tunnel mode** for hosts that
+cannot expose a public port; see the Relay Hub section below. Foundation-token
+relays are forced into direct mode so their privileged credential never enters
+the hub path.
 
-**Mode auto-detection.** The volunteer picks direct vs tunnel via `-mode`
+**Mode auto-detection.** For volunteer-run relays, the CLI picks direct vs
+tunnel via `-mode`
 (`auto` | `direct` | `tunnel`). In `auto` (the default whenever a `-hub` is
 configured) it runs a startup **reachability probe**: it opens its listener and
 asks the hub's HTTP API to dial it back at its observed public IP with a nonce
@@ -57,19 +74,20 @@ have to know in advance whether a host is behind CGNAT. A probe that can't run
 (hub HTTP API down) is treated as inconclusive and defaults to tunnel. `-mode
 direct`/`tunnel` (and the legacy `-tunnel`) force a mode and skip the probe.
 
-### Relay Hub (CGNAT volunteers)
+### Relay Hub (CGNAT volunteer-run relays)
 
-Most volunteers expose a public reachable port. Volunteers behind **CGNAT**
-(carrier-grade NAT) have no inbound port and cannot. The relay hub (`cmd/relayhub`)
-is a separate, publicly reachable component that brings these volunteers online:
+Most volunteer-run relays expose a publicly reachable port. Relays behind
+**CGNAT** (carrier-grade NAT) have no inbound port and cannot. The relay hub
+(`cmd/relayhub`) is a separate, publicly reachable component that brings these
+volunteer-run relays online:
 
-- The volunteer runs Xray bound to **loopback** and dials the hub outbound over a
+- The relay runs Xray bound to **loopback** and dials the hub outbound over a
   single TLS connection (`-tunnel -hub <addr>`), authenticating with the same
   registration token.
-- The hub allocates one public TCP port per volunteer, registers the relay with
+- The hub allocates one public TCP port per relay, registers the relay with
   the broker over the existing `POST /api/v1/volunteers/register` API (with
   `transport: "tunnel"` and `public_host`/`public_port` pointing at the hub), and
-  multiplexes inbound client connections to the volunteer over the tunnel using
+  multiplexes inbound client connections to the relay over the tunnel using
   yamux. Clients connect to `hub:port` exactly as they would any direct relay — no
   client changes.
 - Descriptor liveness is tied to the tunnel: the hub heartbeats while the tunnel
@@ -79,26 +97,26 @@ is a separate, publicly reachable component that brings these volunteers online:
 The hub is a **data-plane** component, deliberately distinct from the control-plane
 broker — the broker stays out of the data path (see Goals). The hub only copies
 **opaque bytes**; it never holds the Reality private key and cannot decrypt the
-end-to-end traffic, so the volunteer-as-untrusted-network trust boundary is
+end-to-end traffic, so the relay-as-untrusted-network trust boundary is
 preserved across the hub too.
 
-Because all CGNAT-volunteer traffic transits the hub, the relay path is opt-in
-(public-IP/IPv6 volunteers stay direct and never touch the hub), and hubs should
-run where bandwidth is cheap rather than on metered cloud egress (see
+Because all CGNAT relay traffic transits the hub, the relay path is opt-in
+(public-IP/IPv6 volunteer-run relays stay direct and never touch the hub), and
+hubs should run where bandwidth is cheap rather than on metered cloud egress (see
 `deploy/relayhub/README.md`). To keep the hub out of the hot path when possible,
 CGNAT relays also support **direct NAT hole punching** (below); the hub tunnel
 remains as the always-available fallback. Per-relay/per-hub bandwidth caps are
 still future work.
 
-### Direct NAT Hole Punching (client ↔ CGNAT volunteer)
+### Direct NAT Hole Punching (client ↔ CGNAT volunteer-run relay)
 
-When both the client and a CGNAT volunteer are behind NAT, they can still reach
-each other **directly** by punching a UDP hole, taking the hub out of the data
-path. The hub coordinates but never carries the bytes.
+When both the client and a CGNAT volunteer-run relay are behind NAT, they can
+still reach each other **directly** by punching a UDP hole, taking the hub out
+of the data path. The hub coordinates but never carries the bytes.
 
 - **Rendezvous + reflector = the hub.** The hub already holds the only live,
-  authenticated control connection to each CGNAT volunteer (the yamux tunnel), so
-  it is the one component that can push a punch request to the volunteer. It also
+  authenticated control connection to each CGNAT relay (the yamux tunnel), so
+  it is the one component that can push a punch request to the relay. It also
   runs a small UDP **reflector** (STUN-like) so each peer learns its
   server-reflexive `ip:port`. The broker is untouched; it only gains an additive
   `punch_capable` descriptor flag so clients know to try.
@@ -111,22 +129,22 @@ path. The hub coordinates but never carries the bytes.
 - **Signalling.** The client asks the hub over a dedicated HTTP endpoint
   (`POST /api/v1/punch/request`, on the hub's own listener, not the broker and not
   Cloudflare-fronted, so it is separately rate-limited). The hub relays a
-  `PunchDirective` to the volunteer over the yamux control connection, using a
+  `PunchDirective` to the relay over the yamux control connection, using a
   one-byte stream-type discriminator that is only emitted when both ends negotiate
   it in the HELLO/HELLO_ACK handshake — so the tunnel control-protocol version is
-  unchanged and old volunteers/hubs keep working.
+  unchanged and older relay runtimes/hubs keep working.
 - **Transport.** After a token-authenticated simultaneous-open UDP punch, the two
   peers run **QUIC** (quic-go) over the punched socket: it gives the reliable,
   ordered, multiplexed byte stream that VLESS/Reality-over-TCP needs. The client
   exposes a loopback TCP bridge that sing-box dials in place of the relay; the
-  volunteer bridges each QUIC stream to its loopback Xray. Reality still
-  terminates only at client and volunteer — the QUIC layer carries opaque bytes,
+  relay bridges each QUIC stream to its loopback Xray. Reality still terminates
+  only at client and relay — the QUIC layer carries opaque bytes,
   so the E2E trust boundary is preserved (QUIC's TLS is a transport/pinning layer,
   not a new decryption point).
 - **Authentication.** The hub issues a per-session HMAC token (delivered over the
   authenticated HTTP and control channels); the UDP probes and the first QUIC
   stream carry it, verified in constant time. The QUIC certificate is pinned by a
-  fingerprint the volunteer reports through the hub.
+  fingerprint the relay reports through the hub.
 - **Fallback is invisible and fail-closed.** If the relay is not punch-capable,
   both NATs are symmetric, the relay id is stale, or any step times out within the
   budget, the client silently uses today's path (sing-box dials the hub's public
@@ -134,9 +152,10 @@ path. The hub coordinates but never carries the bytes.
   false-succeed.
 
 Honest scope: this reliably serves endpoint-independent-mapping (home-broadband /
-full-cone) volunteers; **double-symmetric CGNAT is deliberately not solved** and
-stays on the hub relay. The shared protocol core (wire format, discovery, punch
-mechanics, reflector, policies) lives in the nested `punchcore/` Go module
+full-cone) volunteer-run relays; **double-symmetric CGNAT is deliberately not
+solved** and stays on the hub relay. The shared protocol core (wire format,
+discovery, punch mechanics, reflector, policies) lives in the nested
+`punchcore/` Go module
 (`github.com/openrung/openrung/punchcore`) — the single source of truth with no
 hand-mirrored copies. The servers and the desktop client consume it in-repo via
 `internal/punch` (the quic-go session/transport/bridge layer); the Android app's
@@ -147,7 +166,7 @@ and uses the hub relay with no regression.
 
 #### punchcore pin/upgrade procedure (wire changes)
 
-1. Edit `punchcore/` in an openrung PR — the hub, volunteers, and desktop
+1. Edit `punchcore/` in an openrung PR — the hub, relay runtimes, and desktop
    clients consume it via the in-repo `replace`, so servers and desktop stay
    atomically consistent.
 2. Bump `punchcore/VERSION` in the same PR — the `go-checks` workflow fails
@@ -170,25 +189,25 @@ version).
 sequenceDiagram
     participant C as Client (behind NAT)
     participant H as Relay Hub (reflector + coordinator)
-    participant V as CGNAT Volunteer
+    participant V as CGNAT volunteer-run relay
 
     C->>H: STUN to reflector (2 IPs) → learn reflexive ip:port
     C->>H: POST /punch/request (relay_id, candidates)
     H->>V: PunchDirective over yamux control stream
     V->>H: STUN to reflector → PunchAck (reflexive, cert fp)
-    H-->>C: PunchResponse (volunteer candidates, token, cert fp)
+    H-->>C: PunchResponse (relay candidates, token, cert fp)
     par simultaneous open
         C->>V: token-authed UDP probes
         V->>C: token-authed UDP probes
     end
     C->>V: QUIC over punched socket (VLESS/Reality inside)
-    V->>V: Reality terminates at volunteer → Xray exits
+    V->>V: Reality terminates at relay → Xray exits
     Note over C,V: hub carries no data, falls back to hub relay on failure
 ```
 
 ```mermaid
 sequenceDiagram
-    participant V as CGNAT Volunteer
+    participant V as CGNAT volunteer-run relay
     participant H as Relay Hub
     participant B as Broker
     participant C as Mobile Client
@@ -206,7 +225,9 @@ sequenceDiagram
 
 ### Mobile Client
 
-The mobile client is an iOS/Android app using VPN mode. It asks the broker for relay candidates, configures a compatible VLESS Reality client, and routes device traffic through the selected volunteer.
+The mobile client is an iOS/Android app using VPN mode. It asks the broker for
+relay candidates, configures a compatible VLESS Reality client, and routes
+device traffic through the selected relay.
 
 It is developed in a separate React Native repository with native VPN modules:
 
@@ -215,10 +236,12 @@ It is developed in a separate React Native repository with native VPN modules:
 
 ### Future Dedicated Exit Mode
 
-In a later phase, volunteers should be able to choose one of two modes:
+In a later phase, volunteer operators should be able to choose one of two modes:
 
-- Direct exit mode: volunteer connects directly to destination websites.
-- Entry relay mode: volunteer accepts client traffic and routes it to a dedicated exit server.
+- Direct exit mode: the volunteer-run relay connects directly to destination
+  websites.
+- Entry relay mode: the volunteer-run relay accepts client traffic and routes
+  it to a dedicated exit server.
 
 Entry relay mode protects volunteers from being the destination-visible exit IP. The broker descriptor should therefore keep `exit_mode` as an explicit field from the start.
 
@@ -226,7 +249,7 @@ Entry relay mode protects volunteers from being the destination-visible exit IP.
 
 ```mermaid
 sequenceDiagram
-    participant V as Volunteer CLI
+    participant V as Relay CLI
     participant B as Broker
     participant C as Mobile Client
     participant W as Public Website/App
@@ -246,24 +269,32 @@ sequenceDiagram
 
 ## Trust Boundaries
 
-Volunteer relays are not inherently trusted. The client should treat each volunteer as a network provider:
+Relays are not inherently trusted. The client should treat each relay operator
+as a network provider. A broker-attested `node_class` identifies operator
+provenance; it does not relax any transport, signature, or destination-security
+requirement:
 
 - Use HTTPS/TLS to destination sites whenever possible.
-- Avoid sending broker credentials to volunteers.
+- Avoid sending broker credentials to relay operators.
 - Rotate relay credentials frequently.
 - Prefer short-lived relay descriptors.
 
-The broker should treat volunteer registrations as untrusted input:
+The broker should treat relay registrations as untrusted input:
 
-- Require authentication for volunteers outside local development.
+- Require authentication for relay operators outside local development.
 - Validate ports, hostnames, protocol fields, and advertised capabilities.
 - Expire inactive relays aggressively.
 
-The current scaffold advertises one generated VLESS client ID per volunteer process. That is acceptable for early private testing, but public versions should issue short-lived per-client credentials and push them into Xray dynamically.
+The current scaffold advertises one generated VLESS client ID per relay process.
+That is acceptable for early private testing, but public versions should issue
+short-lived per-client credentials and push them into Xray dynamically.
 
 ## Open Design Decisions
 
-- Public reachability probing: the broker should eventually verify the advertised endpoint from outside the volunteer network, especially for IPv6 hosts where residential firewalls may block inbound connections even without CGNAT.
+- Public reachability probing: the broker should eventually verify the
+  advertised endpoint from outside the relay operator's network, especially for
+  IPv6 hosts where residential firewalls may block inbound connections even
+  without CGNAT.
 - Relay selection: global score is implemented; later add country/ASN-specific scoring and reputation.
 - Abuse controls: add per-relay limits, destination policy, reporting, and blocklists before public rollout.
 - Mobile engine: choose whether to embed a maintained Xray-compatible engine or call into a separate core.

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -1,7 +1,7 @@
 # Desktop CLI Client
 
-The current desktop client is a command-line end-user client. It fetches volunteer
-relay candidates from the broker, selects the first usable direct-exit VLESS
+The current desktop client is a command-line end-user client. It fetches relay
+candidates from the broker, selects the first usable direct-exit VLESS
 Reality Vision relay, generates a sing-box TUN config, and runs sing-box to
 route device traffic through that relay.
 
@@ -12,7 +12,7 @@ can be reused by Linux and Windows clients later.
 ## Requirements
 
 - A running OpenRung broker.
-- At least one registered volunteer relay.
+- At least one registered relay.
 - A local `sing-box` binary. Use sing-box 1.14 or newer so the generated TUN
   config can install native DNS settings for the tunnel.
 - macOS privileges for TUN routing. In practice, run `connect` with `sudo`.
@@ -54,7 +54,7 @@ The generated config uses:
   port 53 DNS requests.
 - DNS servers detoured through the proxy.
 - `route_exclude_address` for literal relay IPs, so the client's own TCP
-  connection to the volunteer stays on the real network interface instead of
+  connection to the relay stays on the real network interface instead of
   being routed back into the TUN.
 - VLESS Reality Vision outbound from the selected relay descriptor.
 - Route final set to the proxy outbound.

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,14 +6,14 @@
     <title>OpenRung — Reach the open internet</title>
     <meta
       name="description"
-      content="OpenRung helps people facing network restrictions reach public websites and apps through a worldwide volunteer relay network. Always free, privacy-first, open source, and run by a nonprofit foundation."
+      content="OpenRung helps people facing network restrictions reach public websites and apps through a worldwide network of Foundation-operated and volunteer-run relays. Always free, privacy-first, and open source."
     >
     <meta name="theme-color" content="#12241b">
     <link rel="canonical" href="https://openrung.org/">
     <link rel="icon" type="image/svg+xml" href="/openrung-mark.svg">
     <link rel="apple-touch-icon" href="/openrung-white-on-black.png">
     <meta property="og:title" content="OpenRung — Reach the open internet">
-    <meta property="og:description" content="A free, privacy-first volunteer relay network that helps you reach the open internet. Open source and nonprofit-run.">
+    <meta property="og:description" content="A free, privacy-first relay network that helps you reach the open internet. Open source and nonprofit-run.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://openrung.org/">
     <meta property="og:image" content="https://openrung.org/openrung-white-on-black.png">
@@ -1105,7 +1105,7 @@
             </span>
             <h1 id="hero-title"><span data-i18n="heroHeadline">Internet access is a</span> <span class="hl" data-i18n="heroHeadlineHl">right, not a privilege.</span></h1>
             <p class="lead" data-i18n="heroLead">
-              OpenRung helps people facing network restrictions reach public websites and apps through a worldwide volunteer relay network. Always free, privacy-first, and run by a Delaware nonprofit foundation.
+              OpenRung helps people facing network restrictions reach public websites and apps through a worldwide network of Foundation-operated and volunteer-run relays. Always free and privacy-first, under the stewardship of a Delaware nonprofit foundation.
             </p>
             <div class="cta-row">
               <a class="button" href="#download">
@@ -1454,7 +1454,7 @@
               <div class="hiw-step" data-step="2" data-reveal style="--d:.08s">
                 <div class="num">2</div>
                 <h3 data-i18n="step2Title">Connect</h3>
-                <p data-i18n="step2Body">OpenRung asks the broker for healthy volunteer relays and picks the best one for you. The broker only matchmakes — your traffic never passes through it.</p>
+                <p data-i18n="step2Body">OpenRung asks the broker for healthy relays and picks the best one for you. The broker only matchmakes — your traffic never passes through it.</p>
               </div>
               <div class="hiw-step" data-step="3" data-reveal style="--d:.16s">
                 <div class="num">3</div>
@@ -1472,7 +1472,7 @@
           <div class="section-head" data-reveal>
             <p class="kicker" data-i18n="whyKicker">Why trust it</p>
             <h2 id="why-title" data-i18n="whyTitle">Built in the open, for the public good</h2>
-            <p data-i18n="whyLead">OpenRung is supported by volunteers and donors with a single goal: keeping open internet access free and reliable. Nothing is hidden — not the code, not the incentives.</p>
+            <p data-i18n="whyLead">OpenRung is operated by a nonprofit foundation and supported by volunteers and donors with a single goal: keeping open internet access free and reliable. Nothing is hidden — not the code, not the incentives.</p>
           </div>
           <div class="grid">
             <article class="tile" data-reveal>
@@ -1496,8 +1496,8 @@
             </article>
             <article class="tile" data-reveal>
               <div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18"/></svg></div>
-              <h3 data-i18n="whyVolunteerTitle">Volunteer-powered</h3>
-              <p data-i18n="whyVolunteerBody">Volunteer hosts provide relay capacity — the network exists because of its community.</p>
+              <h3 data-i18n="whyVolunteerTitle">Community-powered, Foundation-backed</h3>
+              <p data-i18n="whyVolunteerBody">Foundation-operated and volunteer-run relays provide network capacity — public-interest infrastructure and community participation help the network grow.</p>
             </article>
             <article class="tile" data-reveal style="--d:.07s">
               <div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18M5 21V8l7-5 7 5v13M9 21v-6h6v6"/></svg></div>
@@ -1574,13 +1574,13 @@
           <div class="section-head" data-reveal>
             <p class="kicker" data-i18n="supportKicker">Get involved</p>
             <h2 id="support-title" data-i18n="supportTitle">Help the network grow</h2>
-            <p data-i18n="supportLead">OpenRung relies on volunteers for relay capacity and donors to keep it running.</p>
+            <p data-i18n="supportLead">OpenRung combines Foundation-operated and volunteer-run relay capacity, with donors helping keep it running.</p>
           </div>
           <div class="split">
             <div class="promo" data-reveal>
               <h3 data-i18n="volunteerTitle">Become a volunteer</h3>
-              <p data-i18n="volunteerBody">If you're on the open internet, you can run a volunteer relay and give others a path to it. Relays run as a Docker container on any server with a public IP, and the setup guide walks you through it in a few minutes. Note: in the current version, volunteers act as direct exit nodes, which carries real legal and privacy risk — please review what's involved first.</p>
-              <a class="button ghost" href="https://github.com/openrung/openrung/blob/main/deploy/volunteer/README.md" rel="noopener" data-i18n="volunteerButton">Set up a volunteer relay</a>
+              <p data-i18n="volunteerBody">If you're on the open internet, you can run a relay as a volunteer and give others a path to it. Relays run as a Docker container on any server with a public IP, and the setup guide walks you through it in a few minutes. Note: in the current version, volunteers operate direct exits, which carries real legal and privacy risk — please review what's involved first.</p>
+              <a class="button ghost" href="https://github.com/openrung/openrung/blob/main/deploy/volunteer/README.md" rel="noopener" data-i18n="volunteerButton">Set up a relay as a volunteer</a>
             </div>
             <div class="promo" id="donate" data-reveal style="--d:.08s">
               <h3 data-i18n="donateTitle">Donate</h3>
@@ -1605,7 +1605,7 @@
                 <span data-i18n="faq1Q">Is OpenRung really free?</span>
                 <span class="chev" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>
               </summary>
-              <div class="faq-body"><p data-i18n="faq1A">Yes. OpenRung is run by a nonprofit foundation and powered by volunteers. There are no subscriptions, no ads, and no premium tier — and there never will be.</p></div>
+              <div class="faq-body"><p data-i18n="faq1A">Yes. OpenRung is run by a nonprofit foundation, with relay capacity provided by the Foundation and community volunteers. There are no subscriptions, no ads, and no premium tier — and there never will be.</p></div>
             </details>
             <details class="faq-item" data-reveal style="--d:.05s">
               <summary>
@@ -1626,7 +1626,7 @@
                 <span data-i18n="faq4Q">How is this different from a commercial VPN?</span>
                 <span class="chev" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>
               </summary>
-              <div class="faq-body"><p data-i18n="faq4A">VPN companies route you through servers they own and charge for it. OpenRung is a nonprofit network of everyday volunteers, built specifically to get past censorship: connections are disguised as ordinary web traffic, access is free, and the code is open for anyone to audit.</p></div>
+              <div class="faq-body"><p data-i18n="faq4A">VPN companies route you through servers they own and charge for it. OpenRung is a nonprofit network of Foundation-operated and volunteer-run relays, built specifically to get past censorship: connections are disguised as ordinary web traffic, access is free, and the code is open for anyone to audit.</p></div>
             </details>
             <details class="faq-item" data-reveal style="--d:.2s">
               <summary>
@@ -1637,7 +1637,7 @@
             </details>
             <details class="faq-item" data-reveal style="--d:.25s">
               <summary>
-                <span data-i18n="faq6Q">Is it safe to run a volunteer relay?</span>
+                <span data-i18n="faq6Q">Is it safe to run a relay as a volunteer?</span>
                 <span class="chev" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>
               </summary>
               <div class="faq-body"><p data-i18n="faq6A">Honest answer: it depends on where you live and your comfort level. Relays currently act as exits, so websites see the volunteer's IP address — much like a Tor exit node. Read the security notes on GitHub before volunteering; entry-relay modes that lower this risk are on the roadmap.</p></div>
@@ -1672,7 +1672,7 @@
               <span class="mark" aria-hidden="true"><svg style="color:#fff"><use href="#ladder"/></svg></span>
               <span>OpenRung</span>
             </a>
-            <p data-i18n="footTagline">A volunteer-powered relay network helping people reach the open internet.</p>
+            <p data-i18n="footTagline">A nonprofit relay network helping people reach the open internet.</p>
           </div>
           <div class="foot-col">
             <h4 data-i18n="footProject">Project</h4>
@@ -1737,7 +1737,7 @@
           footTelegramBot: "Download bot (Telegram)",
           dlTelegramNote: "If this site is blocked where you are, our Telegram bot always has working download links:",
           pageTitle: "OpenRung — Reach the open internet",
-          pageDescription: "OpenRung helps people facing network restrictions reach public websites and apps through a worldwide volunteer relay network. Always free, privacy-first, open source, and run by a nonprofit foundation.",
+          pageDescription: "OpenRung helps people facing network restrictions reach public websites and apps through a worldwide network of Foundation-operated and volunteer-run relays. Always free, privacy-first, and open source.",
           skip: "Skip to main content",
           navHow: "How it works",
           navWhy: "Why trust it",
@@ -1747,7 +1747,7 @@
           heroEyebrow: "Early access",
           heroHeadline: "Internet access is a",
           heroHeadlineHl: "right, not a privilege.",
-          heroLead: "OpenRung helps people facing network restrictions reach public websites and apps through a worldwide volunteer relay network. Always free, privacy-first, and run by a Delaware nonprofit foundation.",
+          heroLead: "OpenRung helps people facing network restrictions reach public websites and apps through a worldwide network of Foundation-operated and volunteer-run relays. Always free and privacy-first, under the stewardship of a Delaware nonprofit foundation.",
           heroDownload: "Download for Free",
           heroHow: "See how it works",
           poemQuote: "Spring fills the garden — no wall can shut it in; one branch of red apricot blossom reaches beyond the wall.",
@@ -1766,17 +1766,17 @@
           step1Title: "Download & install",
           step1Body: "Get the Android app and open it. No account, no configuration — the app is ready the moment it launches.",
           step2Title: "Connect",
-          step2Body: "OpenRung asks the broker for healthy volunteer relays and picks the best one for you. The broker only matchmakes — your traffic never passes through it.",
+          step2Body: "OpenRung asks the broker for healthy relays and picks the best one for you. The broker only matchmakes — your traffic never passes through it.",
           step3Title: "Browse freely",
           step3Body: "Your traffic travels through an encrypted tunnel that looks like ordinary web traffic — over the wall and out to the open internet.",
           diagYou: "You",
           diagBroker: "Broker — matchmaking only",
-          diagRelay: "Volunteer relay",
+          diagRelay: "Relay",
           diagWeb: "Open internet",
           diagWall: "Network filter",
           whyKicker: "Why trust it",
           whyTitle: "Built in the open, for the public good",
-          whyLead: "OpenRung is supported by volunteers and donors with a single goal: keeping open internet access free and reliable. Nothing is hidden — not the code, not the incentives.",
+          whyLead: "OpenRung is operated by a nonprofit foundation and supported by volunteers and donors with a single goal: keeping open internet access free and reliable. Nothing is hidden — not the code, not the incentives.",
           trustOpenTitle: "Open source, verifiable",
           trustOpenBody: "Every line of code is public under GPL-3.0. Anyone can read it, audit it, and build it themselves — trust doesn't have to be taken on faith.",
           trustOpenLink: "Read the code on GitHub",
@@ -1784,8 +1784,8 @@
           whyPrivacyBody: "No account is required and we never sell your data. During early-access testing, OpenRung collects diagnostic connection metadata to debug reliability.",
           trustBlockTitle: "Hard to block",
           trustBlockBody: "Relay connections use VLESS + REALITY — protocols engineered to be indistinguishable from ordinary encrypted web traffic.",
-          whyVolunteerTitle: "Volunteer-powered",
-          whyVolunteerBody: "Volunteer hosts provide relay capacity — the network exists because of its community.",
+          whyVolunteerTitle: "Community-powered, Foundation-backed",
+          whyVolunteerBody: "Foundation-operated and volunteer-run relays provide network capacity — public-interest infrastructure and community participation help the network grow.",
           whyNonprofitTitle: "Nonprofit-governed",
           whyNonprofitBody: "Run by the OpenRung Foundation, accountable to the public benefit and transparent.",
           whyFreeTitle: "Free forever",
@@ -1809,10 +1809,10 @@
           iosBetaHint: "Your email app should open with a pre-filled request — just press send.",
           supportKicker: "Get involved",
           supportTitle: "Help the network grow",
-          supportLead: "OpenRung relies on volunteers for relay capacity and donors to keep it running.",
+          supportLead: "OpenRung combines Foundation-operated and volunteer-run relay capacity, with donors helping keep it running.",
           volunteerTitle: "Become a volunteer",
-          volunteerBody: "If you're on the open internet, you can run a volunteer relay and give others a path to it. Relays run as a Docker container on any server with a public IP, and the setup guide walks you through it in a few minutes. Note: in the current version, volunteers act as direct exit nodes, which carries real legal and privacy risk — please review what's involved first.",
-          volunteerButton: "Set up a volunteer relay",
+          volunteerBody: "If you're on the open internet, you can run a relay as a volunteer and give others a path to it. Relays run as a Docker container on any server with a public IP, and the setup guide walks you through it in a few minutes. Note: in the current version, volunteers operate direct exits, which carries real legal and privacy risk — please review what's involved first.",
+          volunteerButton: "Set up a relay as a volunteer",
           donateTitle: "Donate",
           donateBody: "Your support keeps OpenRung free and funds infrastructure, security, volunteer tools, and user support. Online donations are coming soon.",
           donateButton: "Contact us to donate",
@@ -1820,21 +1820,21 @@
           faqTitle: "Questions, answered honestly",
           faqLead: "The short version of what people ask us most. For the full technical detail, everything is documented in the open.",
           faq1Q: "Is OpenRung really free?",
-          faq1A: "Yes. OpenRung is run by a nonprofit foundation and powered by volunteers. There are no subscriptions, no ads, and no premium tier — and there never will be.",
+          faq1A: "Yes. OpenRung is run by a nonprofit foundation, with relay capacity provided by the Foundation and community volunteers. There are no subscriptions, no ads, and no premium tier — and there never will be.",
           faq2Q: "Do I need an account?",
           faq2A: "No. The app works without sign-up, phone number, or email. Early-access builds use a persistent installation identifier and collect the diagnostic connection metadata described below.",
           faq3Q: "What can OpenRung see about my browsing?",
           faq3A: "During early-access testing, OpenRung collects diagnostic connection metadata to debug reliability. This can include source and destination IP addresses, app package names, device and network metadata, and persistent client and session identifiers. We do not sell this data. Traffic between your device and the relay is encrypted, and the technical telemetry documentation is public on GitHub.",
           faq4Q: "How is this different from a commercial VPN?",
-          faq4A: "VPN companies route you through servers they own and charge for it. OpenRung is a nonprofit network of everyday volunteers, built specifically to get past censorship: connections are disguised as ordinary web traffic, access is free, and the code is open for anyone to audit.",
+          faq4A: "VPN companies route you through servers they own and charge for it. OpenRung is a nonprofit network of Foundation-operated and volunteer-run relays, built specifically to get past censorship: connections are disguised as ordinary web traffic, access is free, and the code is open for anyone to audit.",
           faq5Q: "Why isn't it on Google Play or the App Store yet?",
           faq5A: "OpenRung is in early access while we harden the network. The Android APK and desktop builds on this site are official releases built by us. The iOS app is in TestFlight beta — request an invite in the Download section. App-store releases are on the roadmap.",
-          faq6Q: "Is it safe to run a volunteer relay?",
+          faq6Q: "Is it safe to run a relay as a volunteer?",
           faq6A: "Honest answer: it depends on where you live and your comfort level. Relays currently act as exits, so websites see the volunteer's IP address — much like a Tor exit node. Read the security notes on GitHub before volunteering; entry-relay modes that lower this risk are on the roadmap.",
           ctaTitle: "The open internet is worth reaching.",
           ctaLead: "Free, private, and powered by people.",
           ctaVolunteer: "Become a volunteer",
-          footTagline: "A volunteer-powered relay network helping people reach the open internet.",
+          footTagline: "A nonprofit relay network helping people reach the open internet.",
           footProject: "Project",
           footCommunity: "Community",
           footOpenSource: "Open source",
@@ -1853,7 +1853,7 @@
           footTelegramBot: "Telegram 下载机器人",
           dlTelegramNote: "如果本站在您所在的地区被封锁，我们的 Telegram 机器人始终提供有效的下载链接：",
           pageTitle: "OpenRung — 自由访问开放互联网",
-          pageDescription: "OpenRung 通过遍布世界各地的志愿者中继，帮助身处网络限制中的人访问公共网站与应用。永久免费、注重隐私、完全开源、由非营利基金会运营。",
+          pageDescription: "OpenRung 通过遍布世界各地、由基金会运营和社区志愿者运行的中继网络，帮助身处网络限制中的人访问公共网站与应用。永久免费、注重隐私、完全开源。",
           skip: "跳到主要内容",
           navHow: "工作原理",
           navWhy: "为何可信",
@@ -1863,7 +1863,7 @@
           heroEyebrow: "抢先体验",
           heroHeadline: "互联网访问是",
           heroHeadlineHl: "基本人权，而非特权。",
-          heroLead: "OpenRung 通过遍布世界各地的志愿者中继，帮助身处网络限制中的人访问公共网站与应用。永久免费、注重隐私，由一家特拉华州非营利基金会运营。",
+          heroLead: "OpenRung 通过遍布世界各地、由基金会运营和社区志愿者运行的中继网络，帮助身处网络限制中的人访问公共网站与应用。永久免费、注重隐私，并由一家特拉华州非营利基金会负责治理。",
           heroDownload: "免费下载",
           heroHow: "了解工作原理",
           poemQuote: "「春色满园关不住，一枝红杏出墙来。」",
@@ -1882,17 +1882,17 @@
           step1Title: "下载并安装",
           step1Body: "获取 Android 应用并打开。无需账号、无需配置——启动即可使用。",
           step2Title: "一键连接",
-          step2Body: "OpenRung 向调度服务器获取健康的志愿者中继列表，并为你选出最合适的一个。调度服务器只负责匹配——你的流量绝不会经过它。",
+          step2Body: "OpenRung 向调度服务器获取健康的中继列表，并为你选出最合适的一个。调度服务器只负责匹配——你的流量绝不会经过它。",
           step3Title: "自由访问",
           step3Body: "你的流量通过加密隧道传输，看起来与普通网页流量无异——翻过高墙，直达开放的互联网。",
           diagYou: "你",
           diagBroker: "调度服务器——只做匹配",
-          diagRelay: "志愿者中继",
+          diagRelay: "中继",
           diagWeb: "开放互联网",
           diagWall: "网络封锁",
           whyKicker: "为何可信",
           whyTitle: "公开构建，为公共利益而生",
-          whyLead: "OpenRung 由志愿者和捐赠者共同支持，目标只有一个：让开放的互联网访问始终免费、可靠。没有任何隐藏——代码公开，动机透明。",
+          whyLead: "OpenRung 由非营利基金会运营，并得到志愿者和捐赠者支持，目标只有一个：让开放的互联网访问始终免费、可靠。没有任何隐藏——代码公开，动机透明。",
           trustOpenTitle: "开源，可验证",
           trustOpenBody: "每一行代码都以 GPL-3.0 许可证公开发布。任何人都可以阅读、审计并自行构建——信任不必建立在盲从之上。",
           trustOpenLink: "在 GitHub 查看源码",
@@ -1900,8 +1900,8 @@
           whyPrivacyBody: "无需账号，我们也绝不会出售你的数据。在抢先体验测试期间，OpenRung 会收集连接诊断元数据，以排查可靠性问题。",
           trustBlockTitle: "难以封锁",
           trustBlockBody: "中继连接使用 VLESS + REALITY 协议——专为与普通加密网页流量难以区分而设计。",
-          whyVolunteerTitle: "志愿者网络",
-          whyVolunteerBody: "由全球志愿者主机提供中继容量，网络因社区而存在。",
+          whyVolunteerTitle: "社区参与，基金会支持",
+          whyVolunteerBody: "基金会运营的中继与志愿者运行的中继共同提供网络容量——公共利益基础设施与社区力量让网络不断成长。",
           whyNonprofitTitle: "非营利治理",
           whyNonprofitBody: "由 OpenRung 基金会运营，对公共利益负责并保持透明。",
           whyFreeTitle: "永久免费",
@@ -1925,10 +1925,10 @@
           iosBetaHint: "你的邮件应用将打开一封预填好的申请邮件——直接发送即可。",
           supportKicker: "参与支持",
           supportTitle: "帮助网络成长",
-          supportLead: "OpenRung 依靠志愿者提供中继、依靠捐赠者维持运转。",
+          supportLead: "OpenRung 结合基金会运营与志愿者运行的中继容量，捐赠者帮助维持网络运转。",
           volunteerTitle: "成为志愿者",
-          volunteerBody: "如果你身处自由的网络环境，可以运行一个志愿者中继，为他人提供通往开放互联网的通道。中继以 Docker 容器的形式运行在任何拥有公网 IP 的服务器上，按照部署指南几分钟即可完成。请注意：在当前阶段，志愿者作为直接出口节点，存在一定的法律与隐私风险，请先了解相关须知。",
-          volunteerButton: "部署志愿者中继",
+          volunteerBody: "如果你身处自由的网络环境，可以作为志愿者运行一个中继，为他人提供通往开放互联网的通道。中继以 Docker 容器的形式运行在任何拥有公网 IP 的服务器上，按照部署指南几分钟即可完成。请注意：在当前阶段，志愿者作为直接出口运营者，存在一定的法律与隐私风险，请先了解相关须知。",
+          volunteerButton: "作为志愿者部署中继",
           donateTitle: "捐赠支持",
           donateBody: "你的支持帮助 OpenRung 保持免费，并用于基础设施、安全、志愿者工具与用户支持。在线捐赠通道即将开放。",
           donateButton: "联系我们捐赠",
@@ -1936,21 +1936,21 @@
           faqTitle: "坦诚回答你的疑问",
           faqLead: "这里是大家最常问的问题的简短回答。完整的技术细节全部公开可查。",
           faq1Q: "OpenRung 真的免费吗？",
-          faq1A: "是的。OpenRung 由非营利基金会运营、由志愿者支撑。没有订阅、没有广告、没有付费高级版——将来也不会有。",
+          faq1A: "是的。OpenRung 由非营利基金会运营，中继容量由基金会和社区志愿者共同提供。没有订阅、没有广告、没有付费高级版——将来也不会有。",
           faq2Q: "需要注册账号吗？",
           faq2A: "不需要。应用无需注册、手机号或邮箱即可使用。抢先体验版本会使用长期安装标识符，并收集下方说明的连接诊断元数据。",
           faq3Q: "OpenRung 能看到我的浏览内容吗？",
           faq3A: "在抢先体验测试期间，OpenRung 会收集连接诊断元数据，以排查可靠性问题。这些数据可能包括源 IP 和目标 IP 地址、应用包名、设备与网络元数据，以及长期客户端标识符和会话标识符。我们不会出售这些数据。你的设备与中继之间的流量是加密的，完整的遥测技术文档已在 GitHub 公开。",
           faq4Q: "这与商业 VPN 有什么不同？",
-          faq4A: "VPN 公司用自有服务器为你转发流量并收取费用。OpenRung 是由普通志愿者组成的非营利网络，专为突破封锁而设计：连接伪装成普通网页流量，访问免费，代码开放，任何人都可以审计。",
+          faq4A: "VPN 公司用自有服务器为你转发流量并收取费用。OpenRung 是由基金会运营的中继与社区志愿者运行的中继组成的非营利网络，专为突破封锁而设计：连接伪装成普通网页流量，访问免费，代码开放，任何人都可以审计。",
           faq5Q: "为什么还没有上架 Google Play 或 App Store？",
           faq5A: "OpenRung 处于抢先体验阶段，我们正在加固网络。本站提供的 Android APK 与桌面版均为我们构建的官方版本。iOS 应用正在 TestFlight 测试中——可在下载区申请邀请。应用商店上架已在路线图中。",
-          faq6Q: "运行志愿者中继安全吗？",
+          faq6Q: "作为志愿者运行中继安全吗？",
           faq6A: "坦率地说：取决于你所在的地区和你的接受程度。目前中继作为出口节点，网站会看到志愿者的 IP 地址——与 Tor 出口节点类似。志愿之前请先阅读 GitHub 上的安全须知；降低此风险的入口中继模式已在路线图中。",
           ctaTitle: "开放的互联网，值得抵达。",
           ctaLead: "免费、私密，由人们共同支撑。",
           ctaVolunteer: "成为志愿者",
-          footTagline: "一个由志愿者支撑的中继网络，帮助人们抵达开放的互联网。",
+          footTagline: "一个帮助人们抵达开放互联网的非营利中继网络。",
           footProject: "项目",
           footCommunity: "社区",
           footOpenSource: "开源",
@@ -1969,7 +1969,7 @@
           dlTelegramNote: "اگر این سایت در منطقهٔ شما مسدود است، ربات تلگرام ما همیشه لینک دانلود سالم دارد:",
           dir: "rtl",
           pageTitle: "OpenRung — دسترسی به اینترنت آزاد",
-          pageDescription: "OpenRung به افرادی که با محدودیت‌های شبکه روبه‌رو هستند کمک می‌کند تا از طریق شبکهٔ جهانی رله‌های داوطلبانه به وب‌سایت‌ها و برنامه‌های عمومی دسترسی پیدا کنند. همیشه رایگان، با حفظ حریم خصوصی، متن‌باز و زیر نظر یک بنیاد غیرانتفاعی.",
+          pageDescription: "OpenRung به افرادی که با محدودیت‌های شبکه روبه‌رو هستند کمک می‌کند تا از طریق شبکه‌ای جهانی از رله‌های تحت ادارهٔ بنیاد و رله‌های اجراشده توسط داوطلبان جامعه به وب‌سایت‌ها و برنامه‌های عمومی دسترسی پیدا کنند. همیشه رایگان، با حفظ حریم خصوصی و متن‌باز.",
           skip: "پرش به محتوای اصلی",
           navHow: "چگونه کار می‌کند",
           navWhy: "چرا قابل اعتماد است",
@@ -1979,7 +1979,7 @@
           heroEyebrow: "دسترسی زودهنگام",
           heroHeadline: "دسترسی به اینترنت یک",
           heroHeadlineHl: "حق است، نه امتیاز.",
-          heroLead: "OpenRung به افرادی که با محدودیت‌های شبکه روبه‌رو هستند کمک می‌کند تا از طریق شبکهٔ جهانی رله‌های داوطلبانه به وب‌سایت‌ها و برنامه‌های عمومی دسترسی پیدا کنند. همیشه رایگان، با حفظ حریم خصوصی و زیر نظر یک بنیاد غیرانتفاعی در ایالت دلاور.",
+          heroLead: "OpenRung به افرادی که با محدودیت‌های شبکه روبه‌رو هستند کمک می‌کند تا از طریق شبکه‌ای جهانی از رله‌های تحت ادارهٔ بنیاد و رله‌های اجراشده توسط داوطلبان جامعه به وب‌سایت‌ها و برنامه‌های عمومی دسترسی پیدا کنند. همیشه رایگان و با حفظ حریم خصوصی، زیر نظر یک بنیاد غیرانتفاعی در ایالت دلاور.",
           heroDownload: "دانلود رایگان",
           heroHow: "چگونه کار می‌کند",
           poemQuote: "بهارِ باغ را پشتِ هیچ دیواری نتوان بست؛ شاخه‌ای شکوفهٔ سرخ، سر از دیوار برآورده است.",
@@ -1998,17 +1998,17 @@
           step1Title: "دانلود و نصب",
           step1Body: "برنامهٔ اندروید را دریافت و باز کنید. بدون حساب کاربری و بدون پیکربندی — برنامه از همان لحظهٔ اجرا آماده است.",
           step2Title: "اتصال",
-          step2Body: "OpenRung از هماهنگ‌کننده فهرست رله‌های داوطلب سالم را می‌گیرد و بهترین را برای شما انتخاب می‌کند. هماهنگ‌کننده فقط واسطهٔ معرفی است — ترافیک شما هرگز از آن عبور نمی‌کند.",
+          step2Body: "OpenRung از هماهنگ‌کننده فهرست رله‌های سالم را می‌گیرد و بهترین را برای شما انتخاب می‌کند. هماهنگ‌کننده فقط واسطهٔ معرفی است — ترافیک شما هرگز از آن عبور نمی‌کند.",
           step3Title: "مرور آزادانه",
           step3Body: "ترافیک شما از یک تونل رمزگذاری‌شده عبور می‌کند که مانند ترافیک عادی وب به نظر می‌رسد — از روی دیوار، به سوی اینترنت آزاد.",
           diagYou: "شما",
           diagBroker: "هماهنگ‌کننده — فقط معرفی",
-          diagRelay: "رلهٔ داوطلب",
+          diagRelay: "رله",
           diagWeb: "اینترنت آزاد",
           diagWall: "فیلتر شبکه",
           whyKicker: "چرا قابل اعتماد است",
           whyTitle: "ساخته‌شده در شفافیت کامل، برای منفعت عمومی",
-          whyLead: "OpenRung با پشتیبانی داوطلبان و حامیان مالی و تنها با یک هدف اداره می‌شود: حفظ دسترسی آزاد به اینترنت به‌صورت رایگان و پایدار. هیچ چیز پنهان نیست — نه کد و نه انگیزه‌ها.",
+          whyLead: "OpenRung توسط یک بنیاد غیرانتفاعی اداره و با پشتیبانی داوطلبان و حامیان مالی، تنها با یک هدف پیش برده می‌شود: حفظ دسترسی آزاد به اینترنت به‌صورت رایگان و پایدار. هیچ چیز پنهان نیست — نه کد و نه انگیزه‌ها.",
           trustOpenTitle: "متن‌باز و قابل راستی‌آزمایی",
           trustOpenBody: "تمام کد با مجوز GPL-3.0 به‌صورت عمومی منتشر شده است. هر کسی می‌تواند آن را بخواند، بررسی کند و خودش بسازد — اعتماد نباید کورکورانه باشد.",
           trustOpenLink: "مشاهدهٔ کد در GitHub",
@@ -2016,8 +2016,8 @@
           whyPrivacyBody: "نیازی به حساب کاربری نیست و ما هرگز داده‌های شما را نمی‌فروشیم. در دورهٔ دسترسی زودهنگام، OpenRung برای عیب‌یابی پایداری، فرادادهٔ تشخیصی اتصال را گردآوری می‌کند.",
           trustBlockTitle: "مقاوم در برابر مسدودسازی",
           trustBlockBody: "اتصال‌های رله از VLESS + REALITY استفاده می‌کنند — پروتکل‌هایی که طراحی شده‌اند تا از ترافیک رمزگذاری‌شدهٔ عادی وب قابل تشخیص نباشند.",
-          whyVolunteerTitle: "نیروی داوطلبان",
-          whyVolunteerBody: "میزبان‌های داوطلب ظرفیت رله را فراهم می‌کنند — این شبکه به‌خاطر جامعه‌اش وجود دارد.",
+          whyVolunteerTitle: "با نیروی جامعه، با پشتیبانی بنیاد",
+          whyVolunteerBody: "رله‌های تحت ادارهٔ بنیاد و رله‌های اجراشده توسط داوطلبان ظرفیت شبکه را فراهم می‌کنند — زیرساخت در خدمت منفعت عمومی و جامعه، شبکه را رشد می‌دهند.",
           whyNonprofitTitle: "مدیریت غیرانتفاعی",
           whyNonprofitBody: "زیر نظر بنیاد OpenRung اداره می‌شود؛ پاسخ‌گو به منفعت عمومی و شفاف.",
           whyFreeTitle: "همیشه رایگان",
@@ -2041,10 +2041,10 @@
           iosBetaHint: "برنامهٔ ایمیل شما با یک درخواست از پیش پرشده باز می‌شود — فقط ارسال را بزنید.",
           supportKicker: "مشارکت",
           supportTitle: "به رشد شبکه کمک کنید",
-          supportLead: "OpenRung برای ظرفیت رله به داوطلبان و برای ادامهٔ فعالیت به حامیان مالی متکی است.",
+          supportLead: "OpenRung ظرفیت رله‌های تحت ادارهٔ بنیاد و رله‌های اجراشده توسط داوطلبان را با هم به کار می‌گیرد و حامیان مالی به ادامهٔ فعالیت آن کمک می‌کنند.",
           volunteerTitle: "داوطلب شوید",
-          volunteerBody: "اگر به اینترنت آزاد دسترسی دارید، می‌توانید یک رلهٔ داوطلب اجرا کنید و راهی به آن را برای دیگران فراهم کنید. رله به‌صورت یک کانتینر Docker روی هر سروری با IP عمومی اجرا می‌شود و راهنمای راه‌اندازی، مراحل را در چند دقیقه به شما نشان می‌دهد. توجه: در نسخهٔ کنونی، داوطلبان به‌عنوان گرهٔ خروجی مستقیم عمل می‌کنند که خطرهای حقوقی و حریم خصوصی واقعی به همراه دارد — لطفاً ابتدا جزئیات را مطالعه کنید.",
-          volunteerButton: "راه‌اندازی رلهٔ داوطلب",
+          volunteerBody: "اگر به اینترنت آزاد دسترسی دارید، می‌توانید به‌عنوان داوطلب یک رله اجرا کنید و راهی به آن را برای دیگران فراهم کنید. رله به‌صورت یک کانتینر Docker روی هر سروری با IP عمومی اجرا می‌شود و راهنمای راه‌اندازی، مراحل را در چند دقیقه به شما نشان می‌دهد. توجه: در نسخهٔ کنونی، داوطلبان اپراتور خروجی مستقیم هستند و با خطرهای حقوقی و حریم خصوصی واقعی روبه‌رو می‌شوند — لطفاً ابتدا جزئیات را مطالعه کنید.",
+          volunteerButton: "راه‌اندازی رله به‌عنوان داوطلب",
           donateTitle: "حمایت مالی",
           donateBody: "حمایت شما کمک می‌کند OpenRung رایگان بماند و هزینهٔ زیرساخت، امنیت، ابزارهای داوطلبان و پشتیبانی کاربران را تأمین می‌کند. پرداخت آنلاین به‌زودی فعال می‌شود.",
           donateButton: "برای حمایت تماس بگیرید",
@@ -2052,21 +2052,21 @@
           faqTitle: "پاسخ‌های صادقانه به پرسش‌های شما",
           faqLead: "خلاصهٔ پاسخ به پرسش‌هایی که بیش از همه از ما می‌پرسند. جزئیات کامل فنی به‌صورت عمومی مستند شده است.",
           faq1Q: "آیا OpenRung واقعاً رایگان است؟",
-          faq1A: "بله. OpenRung توسط یک بنیاد غیرانتفاعی اداره و با نیروی داوطلبان اجرا می‌شود. نه اشتراکی در کار است، نه تبلیغات و نه نسخهٔ ویژهٔ پولی — و هرگز هم نخواهد بود.",
+          faq1A: "بله. OpenRung توسط یک بنیاد غیرانتفاعی اداره می‌شود و ظرفیت رله را بنیاد و داوطلبان جامعه با هم فراهم می‌کنند. نه اشتراکی در کار است، نه تبلیغات و نه نسخهٔ ویژهٔ پولی — و هرگز هم نخواهد بود.",
           faq2Q: "آیا به حساب کاربری نیاز دارم؟",
           faq2A: "خیر. برنامه بدون ثبت‌نام، شمارهٔ تلفن یا ایمیل کار می‌کند. نسخه‌های دسترسی زودهنگام از یک شناسهٔ پایدار نصب استفاده می‌کنند و فرادادهٔ تشخیصی اتصال را که در ادامه توضیح داده شده گردآوری می‌کنند.",
           faq3Q: "OpenRung چه چیزی از مرور من می‌بیند؟",
           faq3A: "در دورهٔ دسترسی زودهنگام، OpenRung برای عیب‌یابی پایداری، فرادادهٔ تشخیصی اتصال را گردآوری می‌کند. این داده‌ها ممکن است شامل نشانی IP مبدأ و مقصد، نام بستهٔ برنامه، فرادادهٔ دستگاه و شبکه، و شناسه‌های پایدار کاربر و نشست باشد. ما این داده‌ها را نمی‌فروشیم. ترافیک میان دستگاه شما و رله رمزگذاری شده و مستندات فنی تله‌متری به‌صورت عمومی در GitHub در دسترس است.",
           faq4Q: "چه تفاوتی با VPNهای تجاری دارد؟",
-          faq4A: "شرکت‌های VPN ترافیک شما را از سرورهای خودشان عبور می‌دهند و بابت آن پول می‌گیرند. OpenRung شبکه‌ای غیرانتفاعی از داوطلبان عادی است که به‌طور خاص برای عبور از سانسور ساخته شده: اتصال‌ها شبیه ترافیک عادی وب پنهان می‌شوند، دسترسی رایگان است و کد برای بررسی همه باز است.",
+          faq4A: "شرکت‌های VPN ترافیک شما را از سرورهای خودشان عبور می‌دهند و بابت آن پول می‌گیرند. OpenRung شبکه‌ای غیرانتفاعی از رله‌های تحت ادارهٔ بنیاد و رله‌های اجراشده توسط داوطلبان جامعه است که به‌طور خاص برای عبور از سانسور ساخته شده: اتصال‌ها شبیه ترافیک عادی وب پنهان می‌شوند، دسترسی رایگان است و کد برای بررسی همه باز است.",
           faq5Q: "چرا هنوز در Google Play یا App Store نیست؟",
           faq5A: "OpenRung در مرحلهٔ دسترسی زودهنگام است و ما در حال مقاوم‌سازی شبکه هستیم. فایل APK اندروید و نسخه‌های دسکتاپ این سایت، نسخه‌های رسمی ساخته‌شده توسط ما هستند. برنامهٔ iOS در بتای TestFlight است — در بخش دانلود درخواست دعوت‌نامه بدهید. انتشار در فروشگاه‌های اپ در نقشهٔ راه قرار دارد.",
-          faq6Q: "آیا اجرای رلهٔ داوطلب امن است؟",
+          faq6Q: "آیا اجرای رله به‌عنوان داوطلب امن است؟",
           faq6A: "پاسخ صادقانه: بستگی به محل زندگی و میزان پذیرش ریسک شما دارد. رله‌ها در حال حاضر به‌عنوان خروجی عمل می‌کنند، بنابراین وب‌سایت‌ها نشانی IP داوطلب را می‌بینند — مشابه گرهٔ خروجی Tor. پیش از داوطلب‌شدن، نکات امنیتی را در GitHub بخوانید؛ حالت‌های رلهٔ ورودی برای کاهش این ریسک در نقشهٔ راه قرار دارند.",
           ctaTitle: "اینترنت آزاد ارزش رسیدن را دارد.",
           ctaLead: "رایگان، خصوصی و با نیروی مردم.",
           ctaVolunteer: "داوطلب شوید",
-          footTagline: "شبکه‌ای از رله‌های داوطلبانه که به مردم کمک می‌کند به اینترنت آزاد برسند.",
+          footTagline: "یک شبکهٔ غیرانتفاعی رله که به مردم کمک می‌کند به اینترنت آزاد برسند.",
           footProject: "پروژه",
           footCommunity: "جامعه",
           footOpenSource: "متن‌باز",
@@ -2085,7 +2085,7 @@
           dlTelegramNote: "Если сайт заблокирован там, где вы находитесь, в нашем Telegram-боте всегда рабочие ссылки:",
           dir: "ltr",
           pageTitle: "OpenRung — доступ к открытому интернету",
-          pageDescription: "OpenRung помогает людям с ограничениями доступа открывать публичные сайты и приложения через всемирную волонтёрскую сеть ретрансляторов. Всегда бесплатно, с заботой о приватности, с открытым кодом, под управлением некоммерческого фонда.",
+          pageDescription: "OpenRung помогает людям с ограничениями доступа открывать публичные сайты и приложения через всемирную сеть ретрансляторов фонда и волонтёров сообщества. Всегда бесплатно, с заботой о приватности и с открытым кодом.",
           skip: "Перейти к основному содержанию",
           navHow: "Как это работает",
           navWhy: "Почему это надёжно",
@@ -2095,7 +2095,7 @@
           heroEyebrow: "Ранний доступ",
           heroHeadline: "Доступ в интернет —",
           heroHeadlineHl: "это право, а не привилегия.",
-          heroLead: "OpenRung помогает людям с ограничениями доступа открывать публичные сайты и приложения через всемирную волонтёрскую сеть ретрансляторов. Всегда бесплатно, с заботой о приватности, под управлением некоммерческого фонда из штата Делавэр.",
+          heroLead: "OpenRung помогает людям с ограничениями доступа открывать публичные сайты и приложения через всемирную сеть ретрансляторов фонда и волонтёров сообщества. Всегда бесплатно и с заботой о приватности, под управлением некоммерческого фонда из штата Делавэр.",
           heroDownload: "Скачать бесплатно",
           heroHow: "Как это работает",
           poemQuote: "«Весну, что полнит сад, не запереть на ключ — ветвь абрикоса в алом цвету перебралась через стену».",
@@ -2114,17 +2114,17 @@
           step1Title: "Скачайте и установите",
           step1Body: "Установите приложение для Android и откройте его. Без аккаунта и без настройки — приложение готово с первого запуска.",
           step2Title: "Подключитесь",
-          step2Body: "OpenRung запрашивает у координатора список работающих волонтёрских ретрансляторов и выбирает для вас лучший. Координатор только сводит стороны — ваш трафик никогда не проходит через него.",
+          step2Body: "OpenRung запрашивает у координатора список работающих ретрансляторов и выбирает для вас лучший. Координатор только сводит стороны — ваш трафик никогда не проходит через него.",
           step3Title: "Пользуйтесь свободно",
           step3Body: "Ваш трафик идёт по зашифрованному туннелю, который выглядит как обычный веб-трафик, — поверх блокировок, к открытому интернету.",
           diagYou: "Вы",
           diagBroker: "Координатор — только подбор",
-          diagRelay: "Волонтёрский ретранслятор",
+          diagRelay: "Ретранслятор",
           diagWeb: "Открытый интернет",
           diagWall: "Сетевой фильтр",
           whyKicker: "Почему это надёжно",
           whyTitle: "Создано открыто, ради общественного блага",
-          whyLead: "OpenRung поддерживается волонтёрами и донорами с одной целью: сохранять доступ к открытому интернету бесплатным и надёжным. Здесь ничего не скрыто — ни код, ни мотивы.",
+          whyLead: "OpenRung управляется некоммерческим фондом и поддерживается волонтёрами и донорами с одной целью: сохранять доступ к открытому интернету бесплатным и надёжным. Здесь ничего не скрыто — ни код, ни мотивы.",
           trustOpenTitle: "Открытый и проверяемый код",
           trustOpenBody: "Каждая строка кода опубликована под лицензией GPL-3.0. Любой может прочитать её, проверить и собрать самостоятельно — доверие не должно быть слепым.",
           trustOpenLink: "Смотреть код на GitHub",
@@ -2132,8 +2132,8 @@
           whyPrivacyBody: "Аккаунт не нужен, и мы никогда не продаём ваши данные. Во время раннего тестирования OpenRung собирает диагностические метаданные соединений для отладки надёжности.",
           trustBlockTitle: "Трудно заблокировать",
           trustBlockBody: "Соединения с ретрансляторами используют VLESS + REALITY — протоколы, спроектированные так, чтобы не отличаться от обычного зашифрованного веб-трафика.",
-          whyVolunteerTitle: "Сила волонтёров",
-          whyVolunteerBody: "Волонтёрские узлы обеспечивают пропускную способность сети — она существует благодаря сообществу.",
+          whyVolunteerTitle: "Сила сообщества, поддержка фонда",
+          whyVolunteerBody: "Ретрансляторы фонда и ретрансляторы волонтёров вместе обеспечивают пропускную способность — инфраструктура в общественных интересах и сообщество помогают сети расти.",
           whyNonprofitTitle: "Некоммерческое управление",
           whyNonprofitBody: "Управляется фондом OpenRung, подотчётным обществу и прозрачным.",
           whyFreeTitle: "Всегда бесплатно",
@@ -2157,10 +2157,10 @@
           iosBetaHint: "Откроется ваша почтовая программа с готовым письмом — просто отправьте его.",
           supportKicker: "Участие",
           supportTitle: "Помогите сети расти",
-          supportLead: "OpenRung полагается на волонтёров для пропускной способности и на доноров, чтобы продолжать работу.",
+          supportLead: "OpenRung объединяет ретрансляторы фонда и волонтёров, а доноры помогают поддерживать работу сети.",
           volunteerTitle: "Стать волонтёром",
-          volunteerBody: "Если у вас есть свободный доступ в интернет, вы можете запустить волонтёрский ретранслятор и открыть путь к нему для других. Ретранслятор работает как Docker-контейнер на любом сервере с публичным IP — по инструкции установка занимает несколько минут. Внимание: в текущей версии волонтёры выступают прямыми выходными узлами, что несёт реальные юридические риски и риски для приватности — сначала ознакомьтесь с деталями.",
-          volunteerButton: "Запустить волонтёрский ретранслятор",
+          volunteerBody: "Если у вас есть свободный доступ в интернет, вы можете как волонтёр запустить ретранслятор и открыть путь к нему для других. Ретранслятор работает как Docker-контейнер на любом сервере с публичным IP — по инструкции установка занимает несколько минут. Внимание: в текущей версии волонтёры выступают операторами прямых выходов, что несёт реальные юридические риски и риски для приватности — сначала ознакомьтесь с деталями.",
+          volunteerButton: "Запустить ретранслятор как волонтёр",
           donateTitle: "Поддержать",
           donateBody: "Ваша поддержка помогает OpenRung оставаться бесплатным и финансирует инфраструктуру, безопасность, инструменты для волонтёров и поддержку пользователей. Онлайн-пожертвования скоро появятся.",
           donateButton: "Связаться, чтобы поддержать",
@@ -2168,21 +2168,21 @@
           faqTitle: "Честные ответы на ваши вопросы",
           faqLead: "Краткие ответы на то, о чём нас спрашивают чаще всего. Полные технические детали задокументированы открыто.",
           faq1Q: "OpenRung действительно бесплатен?",
-          faq1A: "Да. OpenRung управляется некоммерческим фондом и работает силами волонтёров. Никаких подписок, рекламы и платных тарифов — и никогда не будет.",
+          faq1A: "Да. OpenRung управляется некоммерческим фондом, а пропускную способность обеспечивают фонд и волонтёры сообщества. Никаких подписок, рекламы и платных тарифов — и никогда не будет.",
           faq2Q: "Нужен ли аккаунт?",
           faq2A: "Нет. Приложение работает без регистрации, номера телефона и почты. Версии раннего доступа используют постоянный идентификатор установки и собирают диагностические метаданные соединения, описанные ниже.",
           faq3Q: "Что OpenRung видит о моих посещениях?",
           faq3A: "Во время раннего тестирования OpenRung собирает диагностические метаданные соединений для отладки надёжности. Они могут включать исходный и целевой IP-адреса, имена пакетов приложений, метаданные устройства и сети, а также постоянные идентификаторы клиента и сеанса. Мы не продаём эти данные. Трафик между вашим устройством и ретранслятором зашифрован, а техническая документация по телеметрии открыто опубликована на GitHub.",
           faq4Q: "Чем это отличается от коммерческого VPN?",
-          faq4A: "VPN-компании пропускают ваш трафик через собственные серверы и берут за это деньги. OpenRung — некоммерческая сеть обычных волонтёров, созданная именно для обхода цензуры: соединения маскируются под обычный веб-трафик, доступ бесплатен, а код открыт для проверки любым желающим.",
+          faq4A: "VPN-компании пропускают ваш трафик через собственные серверы и берут за это деньги. OpenRung — некоммерческая сеть, объединяющая ретрансляторы фонда и волонтёров сообщества, созданная именно для обхода цензуры: соединения маскируются под обычный веб-трафик, доступ бесплатен, а код открыт для проверки любым желающим.",
           faq5Q: "Почему приложения ещё нет в Google Play или App Store?",
           faq5A: "OpenRung находится в раннем доступе, пока мы укрепляем сеть. APK для Android и настольные сборки на этом сайте — официальные выпуски, собранные нами. Приложение для iOS в бете TestFlight — запросите приглашение в разделе «Скачать». Публикация в магазинах приложений есть в планах.",
-          faq6Q: "Безопасно ли запускать волонтёрский ретранслятор?",
+          faq6Q: "Безопасно ли запускать ретранслятор как волонтёр?",
           faq6A: "Честный ответ: зависит от того, где вы живёте, и от вашей готовности к риску. Сейчас ретрансляторы работают как выходные узлы, поэтому сайты видят IP-адрес волонтёра — как у выходного узла Tor. Перед тем как стать волонтёром, прочитайте заметки о безопасности на GitHub; режимы входных ретрансляторов, снижающие этот риск, есть в планах.",
           ctaTitle: "Открытый интернет стоит того, чтобы до него добраться.",
           ctaLead: "Бесплатно, приватно и силами людей.",
           ctaVolunteer: "Стать волонтёром",
-          footTagline: "Волонтёрская сеть ретрансляторов, помогающая людям достигать открытого интернета.",
+          footTagline: "Некоммерческая сеть ретрансляторов, помогающая людям достигать открытого интернета.",
           footProject: "Проект",
           footCommunity: "Сообщество",
           footOpenSource: "Открытый код",

--- a/docs/openrung-how-it-works-animated.svg
+++ b/docs/openrung-how-it-works-animated.svg
@@ -1,6 +1,6 @@
 <svg width="1200" height="675" viewBox="0 0 1200 675" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">How OpenRung works</title>
-  <desc id="desc">Animated diagram showing a client asking the OpenRung broker for healthy volunteer relays, then sending encrypted traffic through a volunteer relay to the open internet while the broker stays out of the data path.</desc>
+  <desc id="desc">Animated diagram showing a client asking the OpenRung broker for healthy relays, then sending encrypted traffic through a relay to the open internet while the broker stays out of the data path.</desc>
   <defs>
     <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#fbfdfb"/>
@@ -35,10 +35,10 @@
     </clipPath>
     <path id="clientToBroker" d="M 258 365 C 318 278 420 227 555 208"/>
     <path id="brokerToClient" d="M 555 224 C 418 252 323 302 260 382"/>
-    <path id="volunteerToBroker" d="M 835 323 C 768 249 692 211 637 207"/>
-    <path id="brokerToVolunteer" d="M 637 225 C 706 240 783 280 842 340"/>
+    <path id="relayToBroker" d="M 835 323 C 768 249 692 211 637 207"/>
+    <path id="brokerToRelay" d="M 637 225 C 706 240 783 280 842 340"/>
     <path id="clientDataPath" d="M 268 438 C 415 535 652 530 823 414"/>
-    <path id="volunteerDataPath" d="M 915 407 C 979 393 1022 350 1054 296"/>
+    <path id="relayDataPath" d="M 915 407 C 979 393 1022 350 1054 296"/>
     <path id="fullDataPath" d="M 268 438 C 415 535 652 530 823 414 C 901 362 982 362 1054 296"/>
     <style>
       svg {
@@ -273,7 +273,7 @@
   <path d="M 93 585 C 256 636 461 642 658 590 C 815 548 967 555 1110 617" fill="none" stroke="#d8e7fb" stroke-width="1.5" stroke-dasharray="5 13" opacity="0.8"/>
 
   <text x="74" y="166" class="subhead">Broker matches relays.</text>
-  <text x="74" y="196" class="subhead">Volunteers carry encrypted traffic.</text>
+  <text x="74" y="196" class="subhead">Relays carry encrypted traffic.</text>
 
   <g transform="translate(73 224)">
     <rect class="zone" x="0" y="0" width="295" height="316" rx="26"/>
@@ -311,13 +311,13 @@
   </circle>
   <circle r="7" fill="#f2b84b" class="control-packet" opacity="0">
     <animateMotion dur="6s" repeatCount="indefinite" begin="0s">
-      <mpath href="#volunteerToBroker"/>
+      <mpath href="#relayToBroker"/>
     </animateMotion>
     <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.12;0.56;1" dur="6s" repeatCount="indefinite"/>
   </circle>
   <circle r="6" fill="#f2b84b" class="control-packet" opacity="0">
     <animateMotion dur="6s" repeatCount="indefinite" begin="2.1s">
-      <mpath href="#brokerToVolunteer"/>
+      <mpath href="#brokerToRelay"/>
     </animateMotion>
     <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.12;0.56;1" dur="6s" repeatCount="indefinite" begin="2.1s"/>
   </circle>
@@ -390,8 +390,8 @@
         <rect x="-12" y="-3" width="28" height="6" rx="2" fill="#1d8a4f"/>
       </g>
     </g>
-    <text x="94" y="184" text-anchor="middle" class="label">Volunteer relay</text>
-    <text x="94" y="205" text-anchor="middle" class="small">everyday people help</text>
+    <text x="94" y="184" text-anchor="middle" class="label">Relay</text>
+    <text x="94" y="205" text-anchor="middle" class="small">Foundation / community</text>
   </g>
 
   <g transform="translate(1005 213)">
@@ -411,7 +411,7 @@
     <g class="step-one">
       <circle cx="0" cy="0" r="15" fill="#f2b84b"/>
       <text x="-4.5" y="5" fill="#1a241d" font-size="14" font-weight="900">1</text>
-      <text x="25" y="5" class="small">Volunteers register and send heartbeats</text>
+      <text x="25" y="5" class="small">Relays register and send heartbeats</text>
     </g>
   </g>
   <g transform="translate(425 574)">
@@ -425,7 +425,7 @@
     <g class="step-three">
       <circle cx="0" cy="0" r="15" fill="#1d8a4f"/>
       <text x="-4.5" y="5" fill="#ffffff" font-size="14" font-weight="900">3</text>
-      <text x="25" y="5" class="small">Encrypted traffic flows through the volunteer</text>
+      <text x="25" y="5" class="small">Encrypted traffic flows through the relay</text>
     </g>
   </g>
 

--- a/docs/security-abuse.md
+++ b/docs/security-abuse.md
@@ -2,11 +2,14 @@
 
 ## Current Risk
 
-Direct volunteer exits are simple, but they put volunteers in the destination-visible path. Destination services, abuse desks, and network operators may see the volunteer's IP as the source.
+Direct-exit relays are simple, but they put relay operators in the
+destination-visible path. Destination services, abuse desks, and network
+operators may see the relay's public IP as the source. For a volunteer-run
+relay, that is typically the volunteer's own residential or server IP.
 
 Before any public rollout, add controls for:
 
-- Per-volunteer bandwidth and session limits.
+- Per-relay bandwidth and session limits.
 - Destination blocklists for obvious abuse categories.
 - Emergency relay disablement.
 - Volunteer opt-in terms and warnings.
@@ -20,11 +23,11 @@ The broker should eventually use:
 
 - Persistent storage.
 - Signed relay descriptors.
-- Per-client ephemeral VLESS credentials instead of one shared client ID per volunteer process.
-- Volunteer authentication and reputation.
+- Per-client ephemeral VLESS credentials instead of one shared client ID per relay process.
+- Relay registration authentication and operator reputation.
 - Rate limiting.
 - Audit logs for control-plane events.
-- Separate public client API and private volunteer API.
+- Separate public client API and private relay-registration API.
 
 The broker should avoid storing:
 
@@ -34,7 +37,7 @@ The broker should avoid storing:
 
 ## Relay Hardening
 
-The volunteer CLI should eventually support:
+The relay CLI (currently `cmd/volunteer`) should eventually support:
 
 - OS-level firewall policy generation.
 - Bandwidth ceilings.
@@ -48,7 +51,7 @@ The volunteer CLI should eventually support:
 Dedicated exit mode should become the preferred public mode:
 
 ```text
-Censored client -> volunteer entry relay -> dedicated exit server -> public website/app
+Censored client -> volunteer-run entry relay -> dedicated exit server -> public website/app
 ```
 
 This reduces volunteer exposure and enables centralized abuse handling at the dedicated exit layer.

--- a/internal/broker/auth_hardening_test.go
+++ b/internal/broker/auth_hardening_test.go
@@ -31,16 +31,16 @@ func TestAuthorizedRejectsInvalidTokens(t *testing.T) {
 	}
 }
 
-// TestServerRateLimitsRegister confirms the volunteer registration endpoint is
+// TestServerRateLimitsRegister confirms the relay registration endpoint is
 // behind the per-IP limiter (the pre-fix endpoint was unthrottled).
 func TestServerRateLimitsRegister(t *testing.T) {
 	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
 	status := 0
-	for i := 0; i < volunteerBurst+1; i++ {
+	for i := 0; i < relayRegistrationBurst+1; i++ {
 		recorder := httptest.NewRecorder()
 		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil))
 		status = recorder.Code
-		if i < volunteerBurst && status == http.StatusTooManyRequests {
+		if i < relayRegistrationBurst && status == http.StatusTooManyRequests {
 			t.Fatalf("request %d inside burst unexpectedly limited", i+1)
 		}
 	}

--- a/internal/broker/nodeclass_test.go
+++ b/internal/broker/nodeclass_test.go
@@ -120,7 +120,7 @@ func TestRegisterAcceptsFoundationClassWithFoundationToken(t *testing.T) {
 
 // The foundation token bounds the class a request may claim; it does not force
 // it. A privileged holder can still register a volunteer-class relay, though
-// routine volunteer and hub traffic should use the volunteer token.
+// routine volunteer-class relay and hub traffic should use the volunteer token.
 func TestRegisterFoundationTokenDefaultsToVolunteerClass(t *testing.T) {
 	server := NewServer(NewStore(), Config{
 		SigningSeed:       testSigningSeed(),
@@ -271,7 +271,7 @@ func TestHeartbeatForbiddenForFoundationRelayWithoutFoundationCredential(t *test
 	}
 	desc := decodeDescriptor(t, recorder)
 
-	// Anonymous heartbeat (valid volunteer credential on this open broker)
+	// Anonymous heartbeat (valid volunteer-class credential on this open broker)
 	// must not extend a foundation relay's lease.
 	anonymous := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/"+desc.ID+"/heartbeat", nil)
 	anonymousRecorder := httptest.NewRecorder()
@@ -301,7 +301,7 @@ func TestStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 	}
 
 	if _, err := store.Heartbeat(desc.ID, relay.NodeClassVolunteer, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
-		t.Fatalf("volunteer-credential heartbeat of foundation relay: err = %v, want ErrNodeClassForbidden", err)
+		t.Fatalf("volunteer-class credential heartbeat of foundation relay: err = %v, want ErrNodeClassForbidden", err)
 	}
 	// The refused heartbeat must not have extended the lease.
 	if listed, err := store.List(now.Add(2*time.Minute), 10); err != nil || len(listed) != 0 {
@@ -340,7 +340,7 @@ func TestRegisterCannotOverwriteFoundationEndpointAnonymously(t *testing.T) {
 	}
 	original := decodeDescriptor(t, recorder)
 
-	// Attacker registers the same host:port anonymously (as a volunteer).
+	// Attacker registers the same host:port anonymously as a volunteer-class relay.
 	attacker := validRegisterRequest() // same public_host:public_port
 	attacker.RealityPublicKey = "attacker-key"
 	attackRecorder := postRegister(t, server, attacker, "")
@@ -362,16 +362,16 @@ func TestRegisterCannotOverwriteFoundationEndpointAnonymously(t *testing.T) {
 	_ = original
 }
 
-// An authorized foundation registration replaces both a volunteer that
-// pre-squatted the endpoint and an older foundation descriptor. The in-memory
-// store must retain the same one-row-per-endpoint invariant as postgres.
+// An authorized foundation registration replaces both a volunteer-class relay
+// that pre-squatted the endpoint and an older foundation descriptor. The
+// in-memory store must retain the same one-row-per-endpoint invariant as postgres.
 func TestRegisterFoundationCanRefreshOwnEndpoint(t *testing.T) {
 	store := NewStore()
 	now := time.Now().UTC()
 
 	preSquat, err := store.Register(validRegisterRequest(), now, time.Minute)
 	if err != nil {
-		t.Fatalf("register pre-squatting volunteer: %v", err)
+		t.Fatalf("register pre-squatting volunteer-class relay: %v", err)
 	}
 
 	req := validRegisterRequest()
@@ -381,7 +381,7 @@ func TestRegisterFoundationCanRefreshOwnEndpoint(t *testing.T) {
 		t.Fatalf("first foundation register: %v", err)
 	}
 	if _, err := store.Heartbeat(preSquat.ID, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
-		t.Fatalf("pre-squatting volunteer ID survived foundation registration: %v", err)
+		t.Fatalf("pre-squatting volunteer-class relay ID survived foundation registration: %v", err)
 	}
 
 	// Re-register at the same endpoint, still foundation-class: allowed.
@@ -403,10 +403,10 @@ func TestRegisterFoundationCanRefreshOwnEndpoint(t *testing.T) {
 		t.Fatalf("expected exactly the refreshed foundation descriptor, got %+v", listed)
 	}
 
-	// A volunteer registration at the same endpoint: refused.
+	// A volunteer-class relay registration at the same endpoint is refused.
 	vol := validRegisterRequest()
 	if _, err := store.Register(vol, now.Add(4*time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
-		t.Fatalf("volunteer collision: err = %v, want ErrNodeClassForbidden", err)
+		t.Fatalf("volunteer-class relay collision: err = %v, want ErrNodeClassForbidden", err)
 	}
 }
 
@@ -421,8 +421,8 @@ func TestStoreExpiredFoundationEndpointIsReclaimable(t *testing.T) {
 		t.Fatalf("register foundation relay: %v", err)
 	}
 
-	volunteer := validRegisterRequest()
-	reclaimed, err := store.Register(volunteer, now.Add(2*time.Minute), time.Minute)
+	volunteerClassRelay := validRegisterRequest()
+	reclaimed, err := store.Register(volunteerClassRelay, now.Add(2*time.Minute), time.Minute)
 	if err != nil {
 		t.Fatalf("reclaim expired foundation endpoint: %v", err)
 	}
@@ -437,6 +437,6 @@ func TestStoreExpiredFoundationEndpointIsReclaimable(t *testing.T) {
 		t.Fatalf("list reclaimed endpoint: %v", err)
 	}
 	if len(listed) != 1 || listed[0].ID != reclaimed.ID {
-		t.Fatalf("expected exactly the volunteer replacement, got %+v", listed)
+		t.Fatalf("expected exactly the volunteer-class relay replacement, got %+v", listed)
 	}
 }

--- a/internal/broker/postgres_store.go
+++ b/internal/broker/postgres_store.go
@@ -207,7 +207,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		ExitMode:         req.ExitMode,
 		MaxSessions:      req.MaxSessions,
 		MaxMbps:          req.MaxMbps,
-		VolunteerVersion: req.VolunteerVersion,
+		RelayVersion:     req.RelayVersion,
 		Transport:        normalizeTransport(req.Transport),
 		PunchCapable:     req.PunchCapable,
 		PunchEndpoint:    req.PunchEndpoint,
@@ -219,7 +219,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 	// Geo columns are deliberately absent from the INSERT: a re-registration
 	// at the same host:port keeps its previously resolved location until the
 	// handler's next successful UpdateGeo — except when the exit host changed
-	// (a hub port reused by a different volunteer), where the upsert clears
+	// (a hub port reused by a different relay), where the upsert clears
 	// the stale location so the handler resolves the new exit.
 	//
 	// The DO UPDATE WHERE guards a LIVE foundation endpoint: a foundation row
@@ -227,7 +227,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 	// public_host:public_port is client-supplied and foundation endpoints are
 	// public in the signed list, so without this guard an anonymous
 	// registration could seize a foundation relay's row (new id, attacker's
-	// keys, downgraded class) and knock the real node into a re-registration
+	// keys, downgraded class) and knock the real relay into a re-registration
 	// race. The handler already gates node_class=foundation behind the
 	// foundation token, so "EXCLUDED.node_class = foundation" can only be true
 	// for a token-authorized caller. The expires_at disjunct keeps this to
@@ -306,7 +306,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		desc.ExitMode,
 		desc.MaxSessions,
 		desc.MaxMbps,
-		desc.VolunteerVersion,
+		desc.RelayVersion,
 		desc.RegisteredAt,
 		desc.LastHeartbeatAt,
 		desc.ExpiresAt,
@@ -733,7 +733,7 @@ func scanDescriptor(row pgx.Row) (relay.Descriptor, error) {
 		&desc.ExitMode,
 		&desc.MaxSessions,
 		&desc.MaxMbps,
-		&desc.VolunteerVersion,
+		&desc.RelayVersion,
 		&desc.RegisteredAt,
 		&desc.LastHeartbeatAt,
 		&desc.ExpiresAt,

--- a/internal/broker/postgres_store_test.go
+++ b/internal/broker/postgres_store_test.go
@@ -246,7 +246,7 @@ func TestPostgresStoreExitHostChangeClearsGeo(t *testing.T) {
 		t.Fatalf("expected geo to survive same-exit re-registration, got %+v", sameExit.GeoLocation)
 	}
 
-	// Same hub endpoint reused by a different volunteer: stale location cleared.
+	// Same hub endpoint reused by a different relay: stale location cleared.
 	req.ExitHost = "198.51.100.99"
 	newExit, err := store.Register(req, now.Add(2*time.Second), time.Minute)
 	if err != nil {
@@ -328,17 +328,17 @@ func TestPostgresStoreRoundTripsNodeClass(t *testing.T) {
 		t.Fatalf("listed node_class not preserved: %+v", listed)
 	}
 
-	// A volunteer-class registration at a DIFFERENT endpoint round-trips as
-	// volunteer. (A volunteer registration at the SAME endpoint is refused by
-	// the foundation guard; see TestPostgresStoreRegisterGuardsFoundationEndpoint.)
+	// A volunteer-class relay registration at a DIFFERENT endpoint round-trips
+	// with node_class=volunteer. (A registration at the SAME endpoint is refused
+	// by the foundation guard; see TestPostgresStoreRegisterGuardsFoundationEndpoint.)
 	vol := validRegisterRequest()
 	vol.PublicHost = "2001:db8::abcd"
 	volDesc, err := store.Register(vol, now.Add(2*time.Second), time.Minute)
 	if err != nil {
-		t.Fatalf("register volunteer relay: %v", err)
+		t.Fatalf("register volunteer-class relay: %v", err)
 	}
 	if volDesc.NodeClass != relay.NodeClassVolunteer {
-		t.Fatalf("volunteer node_class = %q, want %q", volDesc.NodeClass, relay.NodeClassVolunteer)
+		t.Fatalf("volunteer-class node_class = %q, want %q", volDesc.NodeClass, relay.NodeClassVolunteer)
 	}
 }
 
@@ -354,7 +354,7 @@ func TestPostgresStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 	}
 
 	if _, err := store.Heartbeat(desc.ID, relay.NodeClassVolunteer, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
-		t.Fatalf("volunteer-credential heartbeat of foundation relay: err = %v, want ErrNodeClassForbidden", err)
+		t.Fatalf("volunteer-class credential heartbeat of foundation relay: err = %v, want ErrNodeClassForbidden", err)
 	}
 	// The refused heartbeat must not have extended the lease: past the
 	// original TTL the relay is gone.
@@ -387,8 +387,8 @@ func TestPostgresStoreRegisterGuardsFoundationEndpoint(t *testing.T) {
 		t.Fatalf("register foundation relay: %v", err)
 	}
 
-	// Anonymous/volunteer registration at the same host:port must be refused,
-	// not overwrite the foundation descriptor.
+	// Anonymous/volunteer-class registration at the same host:port must be
+	// refused, not overwrite the foundation descriptor.
 	attacker := validRegisterRequest() // same public_host:public_port
 	attacker.RealityPublicKey = "attacker-key"
 	if _, err := store.Register(attacker, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
@@ -431,14 +431,14 @@ func TestPostgresStoreExpiredFoundationEndpointIsReclaimable(t *testing.T) {
 		t.Fatalf("register foundation relay: %v", err)
 	}
 
-	// A live foundation row still blocks a volunteer takeover.
+	// A live foundation row still blocks a volunteer-class relay takeover.
 	vol := validRegisterRequest()
 	if _, err := store.Register(vol, now.Add(30*time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
 		t.Fatalf("live foundation endpoint: err = %v, want ErrNodeClassForbidden", err)
 	}
 
-	// Past the foundation lease (but before any prune), the same volunteer
-	// registration succeeds and reclaims the endpoint as volunteer.
+	// Past the foundation lease (but before any prune), the same volunteer-class
+	// relay registration succeeds and reclaims the endpoint as that class.
 	reclaimed, err := store.Register(vol, now.Add(2*time.Minute), time.Minute)
 	if err != nil {
 		t.Fatalf("reclaim expired foundation endpoint: %v", err)

--- a/internal/broker/ratelimit.go
+++ b/internal/broker/ratelimit.go
@@ -18,12 +18,12 @@ const (
 	telemetryRatePerSecond = 1.0
 	telemetryBurst         = 20
 
-	// Volunteer registration/heartbeat are token-gated in production; this limiter
+	// Relay registration/heartbeat are token-gated in production; this limiter
 	// is a backstop against a flood if the token leaks or the broker is
 	// deliberately run open. Generous: one relay hub re-registers and heartbeats
 	// every relay it fronts (a whole port range) from a single origin IP.
-	volunteerRatePerSecond = 20.0
-	volunteerBurst         = 256
+	relayRegistrationRatePerSecond = 20.0
+	relayRegistrationBurst         = 256
 
 	// A full speed test streams up to 25 MB, so sustained refills are slow and
 	// the real egress bound is the concurrency cap below.

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -14,7 +14,7 @@ import (
 	"openrung/internal/relay"
 )
 
-// maxRegisterBodyBytes caps volunteer registration payloads; descriptors are
+// maxRegisterBodyBytes caps relay registration payloads; descriptors are
 // small structs, so anything near the cap is malformed or hostile.
 const maxRegisterBodyBytes = 64 << 10
 
@@ -23,15 +23,15 @@ type Config struct {
 	// FoundationToken is the privileged bearer token that authorizes
 	// registrations claiming node_class "foundation". It must differ from
 	// RegistrationToken (cmd/broker refuses to start otherwise — a shared
-	// value would let every volunteer self-promote) and its holder can still
-	// register volunteer-class relays: the token bounds the maximum class a
-	// request may claim, it does not force one. Routine volunteer and relay-hub
-	// traffic should still use RegistrationToken so this credential stays out
-	// of the hub path.
+	// value would let every volunteer-token holder self-promote) and its holder
+	// can still register volunteer-class relays: the token bounds the maximum
+	// class a request may claim, it does not force one. Routine volunteer-class
+	// relay and relay-hub traffic should still use RegistrationToken so this
+	// credential stays out of the hub path.
 	// Empty disables foundation registration entirely.
-	FoundationToken   string
-	VolunteerLeaseTTL time.Duration
-	TelemetrySink     TelemetrySink
+	FoundationToken string
+	RelayLeaseTTL   time.Duration
+	TelemetrySink   TelemetrySink
 	// TelemetryReader backs the dashboard by aggregating records in Go on
 	// every request (the JSONL sink's path). TelemetryQuerier backs it with
 	// pre-aggregated queries (the Postgres store) and wins when both are set.
@@ -42,7 +42,7 @@ type Config struct {
 	// CF-Connecting-IP / X-Forwarded-For headers the broker will trust for the real client IP.
 	TrustedProxyCIDRs []string
 	// GeoIP resolves the city/country of a relay's public endpoint so clients
-	// can show where volunteer relays are located. Nil disables lookups;
+	// can show where relays are located. Nil disables lookups;
 	// descriptors then carry empty geo fields.
 	GeoIP GeoIPResolver
 	// SigningSeed is the 32-byte Ed25519 seed that signs every relay-list
@@ -53,8 +53,8 @@ type Config struct {
 }
 
 func NewServer(store RelayStore, cfg Config) http.Handler {
-	if cfg.VolunteerLeaseTTL == 0 {
-		cfg.VolunteerLeaseTTL = 3 * time.Minute
+	if cfg.RelayLeaseTTL == 0 {
+		cfg.RelayLeaseTTL = 3 * time.Minute
 	}
 	relaySigner := newSigner(cfg.SigningSeed)
 	clientIP := newClientIPResolver(cfg.TrustedProxyCIDRs)
@@ -62,7 +62,7 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	relayListLimiter := newIPRateLimiter(relayListRatePerSecond, relayListBurst, rateLimiterMaxTrackedIPs)
 	telemetryLimiter := newIPRateLimiter(telemetryRatePerSecond, telemetryBurst, rateLimiterMaxTrackedIPs)
 	speedTestLimiter := newIPRateLimiter(speedTestRatePerSecond, speedTestBurst, rateLimiterMaxTrackedIPs)
-	volunteerLimiter := newIPRateLimiter(volunteerRatePerSecond, volunteerBurst, rateLimiterMaxTrackedIPs)
+	relayRegistrationLimiter := newIPRateLimiter(relayRegistrationRatePerSecond, relayRegistrationBurst, rateLimiterMaxTrackedIPs)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -75,8 +75,8 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 		// lets the monitor assert the active key without parsing a relay list.
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "signing_key_id": relaySigner.keyID})
 	})
-	mux.HandleFunc("POST /api/v1/volunteers/register", rateLimited(volunteerLimiter, clientIP, 10, registerHandler(store, cfg)))
-	mux.HandleFunc("POST /api/v1/volunteers/", rateLimited(volunteerLimiter, clientIP, 10, heartbeatHandler(store, cfg)))
+	mux.HandleFunc("POST /api/v1/volunteers/register", rateLimited(relayRegistrationLimiter, clientIP, 10, registerHandler(store, cfg)))
+	mux.HandleFunc("POST /api/v1/volunteers/", rateLimited(relayRegistrationLimiter, clientIP, 10, heartbeatHandler(store, cfg)))
 	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen, relaySigner)))
 	mux.HandleFunc("GET /api/v1/relays.mirror", rateLimited(relayListLimiter, clientIP, 10, listRelaysMirrorHandler(store, relaySigner)))
 	mux.HandleFunc("POST /api/v1/telemetry/events", rateLimited(telemetryLimiter, clientIP, 10, telemetryHandler(cfg.TelemetrySink, store, clientIP)))
@@ -98,7 +98,7 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		maxClass, ok := credentialNodeClass(r, cfg)
 		if !ok {
-			writeError(w, http.StatusUnauthorized, "missing or invalid volunteer registration token")
+			writeError(w, http.StatusUnauthorized, "missing or invalid relay registration token")
 			return
 		}
 
@@ -124,7 +124,7 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 		req.NodeClass = nodeClass
 		// Fail loudly instead of clamping: a foundation relay that lost its
 		// token should crash-loop where the operator sees it, not silently
-		// serve as a volunteer.
+		// serve as a volunteer-class relay.
 		if req.NodeClass == relay.NodeClassFoundation && maxClass != relay.NodeClassFoundation {
 			writeError(w, http.StatusForbidden, "node_class foundation requires the foundation registration token")
 			return
@@ -135,7 +135,7 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 			return
 		}
 
-		desc, err := store.Register(req, time.Now().UTC(), cfg.VolunteerLeaseTTL)
+		desc, err := store.Register(req, time.Now().UTC(), cfg.RelayLeaseTTL)
 		if errors.Is(err, ErrNodeClassForbidden) {
 			// The endpoint is held by a live foundation relay; a
 			// non-foundation registration may not seize it.
@@ -143,12 +143,12 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 			return
 		}
 		if err != nil {
-			slog.Error("could not register volunteer", "error", err)
+			slog.Error("could not register relay", "error", err)
 			writeError(w, http.StatusServiceUnavailable, "could not register relay")
 			return
 		}
 		resolveRelayGeo(r.Context(), store, cfg.GeoIP, &desc)
-		slog.Info("volunteer registered", "relay_id", desc.ID, "node_class", desc.NodeClass, "public", desc.PublicHost, "port", desc.PublicPort, "city", desc.City, "country", desc.Country, "max_sessions", desc.MaxSessions, "version", desc.VolunteerVersion)
+		slog.Info("relay registered", "relay_id", desc.ID, "node_class", desc.NodeClass, "public", desc.PublicHost, "port", desc.PublicPort, "city", desc.City, "country", desc.Country, "max_sessions", desc.MaxSessions, "version", desc.RelayVersion)
 
 		writeJSON(w, http.StatusCreated, desc)
 	}
@@ -156,21 +156,22 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 
 func heartbeatHandler(store RelayStore, cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Any registration credential may heartbeat a volunteer relay, so
-		// foundation relays can present the foundation token on both calls.
+		// A registration credential may heartbeat a relay at or below its
+		// authorized node class, so foundation relays can present the foundation
+		// token on both calls.
 		maxClass, ok := credentialNodeClass(r, cfg)
 		if !ok {
-			writeError(w, http.StatusUnauthorized, "missing or invalid volunteer registration token")
+			writeError(w, http.StatusUnauthorized, "missing or invalid relay registration token")
 			return
 		}
 
 		id, ok := heartbeatRelayID(r.URL.Path)
 		if !ok {
-			writeError(w, http.StatusNotFound, "unknown volunteer endpoint")
+			writeError(w, http.StatusNotFound, "unknown relay endpoint")
 			return
 		}
 
-		desc, err := store.Heartbeat(id, maxClass, time.Now().UTC(), cfg.VolunteerLeaseTTL)
+		desc, err := store.Heartbeat(id, maxClass, time.Now().UTC(), cfg.RelayLeaseTTL)
 		if errors.Is(err, ErrRelayNotFound) {
 			writeError(w, http.StatusNotFound, "relay not found")
 			return
@@ -180,7 +181,7 @@ func heartbeatHandler(store RelayStore, cfg Config) http.HandlerFunc {
 			return
 		}
 		if err != nil {
-			slog.Error("could not update volunteer heartbeat", "relay_id", id, "error", err)
+			slog.Error("could not update relay heartbeat", "relay_id", id, "error", err)
 			writeError(w, http.StatusServiceUnavailable, "could not update relay heartbeat")
 			return
 		}
@@ -217,7 +218,7 @@ func resolveRelayGeo(ctx context.Context, store RelayStore, resolver GeoIPResolv
 }
 
 // geoLookupHost picks the address whose location clients care about: the
-// volunteer's exit IP when the hub reported one (tunnel transport), otherwise
+// relay's observed exit IP when the hub reported one (tunnel transport), otherwise
 // the advertised public endpoint (direct transport, where they coincide).
 func geoLookupHost(desc *relay.Descriptor) string {
 	if desc.ExitHost != "" {
@@ -362,11 +363,11 @@ func bearerMatches(r *http.Request, token string) bool {
 	return subtle.ConstantTimeCompare([]byte(presented), []byte(expected)) == 1
 }
 
-// credentialNodeClass resolves the volunteer-endpoint credential to the
+// credentialNodeClass resolves the relay-registration credential to the
 // highest node class it may vouch for, or ok=false when the request is not
 // authorized at all. The foundation token is checked first: with anonymous
 // registration enabled (RegistrationToken empty) every request already passes
-// the volunteer check, and the foundation credential must still win.
+// the volunteer-class check, and the foundation credential must still win.
 func credentialNodeClass(r *http.Request, cfg Config) (string, bool) {
 	if bearerMatches(r, cfg.FoundationToken) {
 		return relay.NodeClassFoundation, true

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -169,7 +169,7 @@ func TestRegisterGeolocatesTunnelRelayByExitHostWithoutExposingIt(t *testing.T) 
 	req := validRegisterRequest()
 	req.PublicHost = "203.0.113.1" // relay hub
 	req.Transport = relay.TransportTunnel
-	req.ExitHost = "198.51.100.7" // volunteer's real IP
+	req.ExitHost = "198.51.100.7" // relay's observed exit IP
 	body, _ := json.Marshal(req)
 	recorder := httptest.NewRecorder()
 	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
@@ -186,7 +186,7 @@ func TestRegisterGeolocatesTunnelRelayByExitHostWithoutExposingIt(t *testing.T) 
 	if !strings.Contains(listBody, `"city":"Tehran"`) {
 		t.Fatalf("expected exit-host geo in list response: %s", listBody)
 	}
-	// The volunteer's real IP must never leak through the public API.
+	// The relay's observed exit IP must never leak through the public API.
 	for _, response := range []string{recorder.Body.String(), listBody} {
 		if strings.Contains(response, "198.51.100.7") {
 			t.Fatalf("exit host leaked into API response: %s", response)

--- a/internal/broker/store.go
+++ b/internal/broker/store.go
@@ -57,7 +57,7 @@ type Store struct {
 }
 
 type StoreStats struct {
-	// ActiveRelays counts every unexpired relay, foundation and volunteer alike.
+	// ActiveRelays counts every unexpired foundation- and volunteer-class relay.
 	ActiveRelays              int
 	AdvertisedSessionCapacity int
 }
@@ -96,7 +96,7 @@ func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Dura
 		ExitMode:         req.ExitMode,
 		MaxSessions:      req.MaxSessions,
 		MaxMbps:          req.MaxMbps,
-		VolunteerVersion: req.VolunteerVersion,
+		RelayVersion:     req.RelayVersion,
 		Transport:        normalizeTransport(req.Transport),
 		PunchCapable:     req.PunchCapable,
 		PunchEndpoint:    req.PunchEndpoint,
@@ -385,7 +385,7 @@ func normalizeTransport(transport string) string {
 	return transport
 }
 
-// normalizeNodeClass defaults an empty node class to volunteer so every
+// normalizeNodeClass defaults an empty node class to the volunteer class so every
 // stored descriptor carries a concrete value. Authorization of a foundation
 // claim happens in the handler; the store trusts its caller.
 func normalizeNodeClass(class string) string {

--- a/internal/broker/store_test.go
+++ b/internal/broker/store_test.go
@@ -396,7 +396,7 @@ func TestStoreRoundTripsPunchCapable(t *testing.T) {
 
 func validRegisterRequest() relay.RegisterRequest {
 	return relay.RegisterRequest{
-		PublicHost:       "volunteer.example.com",
+		PublicHost:       "relay.example.com",
 		PublicPort:       443,
 		Protocol:         relay.ProtocolVLESSRealityVision,
 		ClientID:         "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff",
@@ -407,6 +407,6 @@ func validRegisterRequest() relay.RegisterRequest {
 		ExitMode:         relay.ExitModeDirect,
 		MaxSessions:      8,
 		MaxMbps:          20,
-		VolunteerVersion: "test",
+		RelayVersion:     "test",
 	}
 }

--- a/internal/client/selector_test.go
+++ b/internal/client/selector_test.go
@@ -157,7 +157,7 @@ func TestParseRelayFamilyRejectsUnknownValue(t *testing.T) {
 func validRelay(now time.Time) relay.Descriptor {
 	return relay.Descriptor{
 		ID:               "relay_123",
-		PublicHost:       "volunteer.example.com",
+		PublicHost:       "relay.example.com",
 		PublicPort:       443,
 		Protocol:         relay.ProtocolVLESSRealityVision,
 		ClientID:         "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff",
@@ -168,7 +168,7 @@ func validRelay(now time.Time) relay.Descriptor {
 		ExitMode:         relay.ExitModeDirect,
 		MaxSessions:      8,
 		MaxMbps:          20,
-		VolunteerVersion: "dev",
+		RelayVersion:     "dev",
 		RegisteredAt:     now.Add(-time.Minute),
 		LastHeartbeatAt:  now.Add(-time.Second),
 		ExpiresAt:        now.Add(time.Minute),

--- a/internal/client/singbox_config.go
+++ b/internal/client/singbox_config.go
@@ -40,10 +40,10 @@ type SingBoxConfigInput struct {
 	// BridgeHost and BridgePort, when set, redirect the VLESS outbound to a local
 	// punch bridge (127.0.0.1:BridgePort) instead of the relay's public endpoint.
 	// The Reality identity fields are unchanged, so the end-to-end target is still
-	// the real volunteer.
+	// the real relay.
 	BridgeHost string
 	BridgePort int
-	// PunchPeerExcludeAddress is the volunteer's reflexive UDP IP on the punched
+	// PunchPeerExcludeAddress is the relay's reflexive UDP IP on the punched
 	// path. It MUST be excluded from the TUN routes or the QUIC datagrams the punch
 	// socket sends would be captured by sing-box's own auto_route/strict_route TUN
 	// and loop back into the tunnel (deadlock). The loopback bridge address needs
@@ -187,7 +187,7 @@ func buildInbound(input SingBoxConfigInput, tunnelIPv4Address, tunnelIPv6Address
 	}
 	// Exclude the real transport peers from the TUN so their traffic is not
 	// captured by auto_route/strict_route. On the direct path that is the relay's
-	// public IP; on the punch path it is additionally the volunteer's reflexive
+	// public IP; on the punch path it is additionally the relay's reflexive
 	// UDP IP the QUIC socket talks to (see Correction #1 in the plan).
 	var excludeAddresses []string
 	for _, host := range []string{input.Relay.PublicHost, input.PunchPeerExcludeAddress} {

--- a/internal/client/singbox_config_test.go
+++ b/internal/client/singbox_config_test.go
@@ -29,7 +29,7 @@ func TestBuildSingBoxConfig(t *testing.T) {
 
 	outbounds := decoded["outbounds"].([]any)
 	proxy := outbounds[0].(map[string]any)
-	if proxy["type"] != "vless" || proxy["server"] != "volunteer.example.com" {
+	if proxy["type"] != "vless" || proxy["server"] != "relay.example.com" {
 		t.Fatalf("unexpected proxy outbound: %+v", proxy)
 	}
 	if proxy["server_port"].(float64) != 443 {
@@ -120,7 +120,7 @@ func TestBuildSingBoxConfigPunchBridgeRedirectsAndExcludesPeer(t *testing.T) {
 		Relay:                   rly,
 		BridgeHost:              "127.0.0.1",
 		BridgePort:              54321,
-		PunchPeerExcludeAddress: "198.51.100.7", // the volunteer's reflexive IP
+		PunchPeerExcludeAddress: "198.51.100.7", // the relay's reflexive IP
 	})
 	if err != nil {
 		t.Fatalf("build sing-box config: %v", err)
@@ -136,13 +136,13 @@ func TestBuildSingBoxConfigPunchBridgeRedirectsAndExcludesPeer(t *testing.T) {
 	if proxy["server"] != "127.0.0.1" || proxy["server_port"].(float64) != 54321 {
 		t.Fatalf("outbound not pointed at the bridge: %+v", proxy)
 	}
-	// ...but the Reality identity must be unchanged (still targets the volunteer).
+	// ...but the Reality identity must be unchanged (still targets the relay).
 	reality := proxy["tls"].(map[string]any)["reality"].(map[string]any)
 	if reality["public_key"] != "public-key" {
 		t.Fatalf("reality identity changed on punch path: %+v", reality)
 	}
 
-	// Correction #1: the volunteer's reflexive peer IP MUST be excluded from the
+	// Correction #1: the relay's reflexive peer IP MUST be excluded from the
 	// TUN route so the QUIC datagrams are not captured and looped.
 	tun := decoded["inbounds"].([]any)[0].(map[string]any)
 	excluded := tun["route_exclude_address"].([]any)
@@ -188,7 +188,7 @@ func TestBuildSingBoxProxyModeUsesMixedInbound(t *testing.T) {
 	}
 	// The outbound (VLESS+Reality) and final route are shared with TUN mode.
 	proxy := decoded["outbounds"].([]any)[0].(map[string]any)
-	if proxy["type"] != "vless" || proxy["server"] != "volunteer.example.com" {
+	if proxy["type"] != "vless" || proxy["server"] != "relay.example.com" {
 		t.Fatalf("proxy mode should keep the VLESS outbound: %+v", proxy)
 	}
 	if decoded["route"].(map[string]any)["final"] != "proxy" {

--- a/internal/punch/bridge.go
+++ b/internal/punch/bridge.go
@@ -15,17 +15,17 @@ import (
 	"github.com/openrung/openrung/punchcore"
 )
 
-// streamAuthTimeout bounds how long the volunteer waits for a stream's token
+// streamAuthTimeout bounds how long the relay waits for a stream's token
 // prefix before dropping it.
 const streamAuthTimeout = 5 * time.Second
 
-// VolunteerBridge accepts the client's QUIC connection on the punched socket and
-// bridges each stream to the volunteer's loopback Xray listener. Every stream is
+// RelayBridge accepts the client's QUIC connection on the punched socket and
+// bridges each stream to the relay's loopback Xray listener. Every stream is
 // prefixed by the punch token, verified constant-time, as defence-in-depth over
 // the pinned certificate. It returns when ctx is done or the connection drops;
 // the listener (and therefore the punched socket) is closed on return so a failed
 // or finished punch never leaks the socket.
-func VolunteerBridge(ctx context.Context, ln *quic.Listener, token []byte, targetHost string, targetPort int, logger *slog.Logger) error {
+func RelayBridge(ctx context.Context, ln *quic.Listener, token []byte, targetHost string, targetPort int, logger *slog.Logger) error {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -52,12 +52,12 @@ func VolunteerBridge(ctx context.Context, ln *quic.Listener, token []byte, targe
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			handleVolunteerStream(conn, stream, token, targetHost, targetPort, logger)
+			handleRelayStream(conn, stream, token, targetHost, targetPort, logger)
 		}()
 	}
 }
 
-func handleVolunteerStream(conn *quic.Conn, stream *quic.Stream, token []byte, targetHost string, targetPort int, logger *slog.Logger) {
+func handleRelayStream(conn *quic.Conn, stream *quic.Stream, token []byte, targetHost string, targetPort int, logger *slog.Logger) {
 	defer stream.Close()
 
 	_ = stream.SetReadDeadline(time.Now().Add(streamAuthTimeout))

--- a/internal/punch/bridge_test.go
+++ b/internal/punch/bridge_test.go
@@ -86,33 +86,33 @@ func punchPair(t *testing.T, a, b *net.UDPConn, aToken, bToken []byte, deadline 
 
 func TestTransportBridgeEchoOverPunchedSocket(t *testing.T) {
 	echoHost, echoPort := startEcho(t)
-	vsock := mustUDP(t, "127.0.0.1")
-	csock := mustUDP(t, "127.0.0.1")
+	relaySock := mustUDP(t, "127.0.0.1")
+	clientSock := mustUDP(t, "127.0.0.1")
 	token := randomToken(t)
 
-	_, cConfirmed, vErr, cErr := punchPair(t, vsock, csock, token, token, time.Now().Add(2*time.Second))
-	if vErr != nil || cErr != nil {
-		t.Fatalf("punch failed: volunteer=%v client=%v", vErr, cErr)
+	_, clientConfirmed, relayErr, clientErr := punchPair(t, relaySock, clientSock, token, token, time.Now().Add(2*time.Second))
+	if relayErr != nil || clientErr != nil {
+		t.Fatalf("punch failed: relay=%v client=%v", relayErr, clientErr)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Volunteer: QUIC server bridging to the echo (loopback "Xray").
+	// Relay: QUIC server bridging to the echo (loopback "Xray").
 	cert, fingerprint, err := GenerateSessionCert()
 	if err != nil {
 		t.Fatalf("cert: %v", err)
 	}
-	ln, err := ListenQUIC(vsock, cert)
+	ln, err := ListenQUIC(relaySock, cert)
 	if err != nil {
 		t.Fatalf("listen quic: %v", err)
 	}
-	go func() { _ = VolunteerBridge(ctx, ln, token, echoHost, echoPort, discardLogger()) }()
+	go func() { _ = RelayBridge(ctx, ln, token, echoHost, echoPort, discardLogger()) }()
 
 	// Client: QUIC dial + loopback bridge.
 	dialCtx, dialCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer dialCancel()
-	conn, err := DialQUIC(dialCtx, csock, cConfirmed, fingerprint)
+	conn, err := DialQUIC(dialCtx, clientSock, clientConfirmed, fingerprint)
 	if err != nil {
 		t.Fatalf("dial quic: %v", err)
 	}
@@ -135,28 +135,28 @@ func TestTransportBridgeEchoOverPunchedSocket(t *testing.T) {
 
 func TestClientBridgeRejectsUnauthenticatedStream(t *testing.T) {
 	echoHost, echoPort := startEcho(t)
-	vsock := mustUDP(t, "127.0.0.1")
-	csock := mustUDP(t, "127.0.0.1")
+	relaySock := mustUDP(t, "127.0.0.1")
+	clientSock := mustUDP(t, "127.0.0.1")
 	token := randomToken(t)
 
-	_, cConfirmed, vErr, cErr := punchPair(t, vsock, csock, token, token, time.Now().Add(2*time.Second))
-	if vErr != nil || cErr != nil {
-		t.Fatalf("punch failed: volunteer=%v client=%v", vErr, cErr)
+	_, clientConfirmed, relayErr, clientErr := punchPair(t, relaySock, clientSock, token, token, time.Now().Add(2*time.Second))
+	if relayErr != nil || clientErr != nil {
+		t.Fatalf("punch failed: relay=%v client=%v", relayErr, clientErr)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	cert, fingerprint, _ := GenerateSessionCert()
-	ln, err := ListenQUIC(vsock, cert)
+	ln, err := ListenQUIC(relaySock, cert)
 	if err != nil {
 		t.Fatalf("listen quic: %v", err)
 	}
-	// Volunteer verifies the real token; the client presents a WRONG one.
-	go func() { _ = VolunteerBridge(ctx, ln, token, echoHost, echoPort, discardLogger()) }()
+	// Relay verifies the real token; the client presents a WRONG one.
+	go func() { _ = RelayBridge(ctx, ln, token, echoHost, echoPort, discardLogger()) }()
 
 	dialCtx, dialCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer dialCancel()
-	conn, err := DialQUIC(dialCtx, csock, cConfirmed, fingerprint)
+	conn, err := DialQUIC(dialCtx, clientSock, clientConfirmed, fingerprint)
 	if err != nil {
 		t.Fatalf("dial quic: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestClientBridgeRejectsUnauthenticatedStream(t *testing.T) {
 	go func() { _ = wrongBridge.Serve(ctx) }()
 
 	host, port := wrongBridge.Endpoint()
-	// The volunteer should reject the stream after the bad token, so the echo
+	// The relay should reject the stream after the bad token, so the echo
 	// never completes within the window.
 	if err := echoRoundTrip(host, port, []byte("should-not-pass")); err == nil {
 		t.Fatal("expected bad-token stream to be rejected, but echo succeeded")

--- a/internal/punch/session.go
+++ b/internal/punch/session.go
@@ -173,7 +173,7 @@ func (d *Dialer) Establish(ctx context.Context) (*Establishment, punchcore.Punch
 	}, res, nil
 }
 
-// RespondToDirective runs the volunteer side of a punch. It synchronously gathers
+// RespondToDirective runs the relay side of a punch. It synchronously gathers
 // its own reflexive candidates and returns a PunchAck for the hub to relay to the
 // client, then punches and serves QUIC in the background (bounded by the
 // directive TTL and ctx), bridging streams to targetHost:targetPort (the loopback
@@ -246,7 +246,7 @@ func RespondToDirective(ctx context.Context, dir punchcore.PunchDirective, targe
 			logger.Warn("punch listen quic failed", "session", dir.SessionID, "error", err)
 			return
 		}
-		if err := VolunteerBridge(ctx, ln, token, targetHost, targetPort, logger); err != nil && ctx.Err() == nil {
+		if err := RelayBridge(ctx, ln, token, targetHost, targetPort, logger); err != nil && ctx.Err() == nil {
 			logger.Info("punch bridge closed", "session", dir.SessionID, "error", err)
 		}
 	}()

--- a/internal/punch/transport.go
+++ b/internal/punch/transport.go
@@ -93,7 +93,7 @@ func clientTLSConfig(fingerprint string) *tls.Config {
 }
 
 // ListenQUIC starts a QUIC listener on the (unconnected) punched socket. The
-// volunteer accepts one connection from the client, then bridges its streams.
+// relay accepts one connection from the client, then bridges its streams.
 func ListenQUIC(sock net.PacketConn, cert tls.Certificate) (*quic.Listener, error) {
 	return quic.Listen(sock, serverTLSConfig(cert), quicConfig())
 }

--- a/internal/relay/network_test.go
+++ b/internal/relay/network_test.go
@@ -11,7 +11,7 @@ func TestIsIPv6Host(t *testing.T) {
 		{name: "ipv6", host: "2001:db8::1", want: true},
 		{name: "bracketed ipv6", host: "[2001:db8::1]", want: true},
 		{name: "ipv4", host: "203.0.113.10", want: false},
-		{name: "hostname", host: "volunteer.example.com", want: false},
+		{name: "hostname", host: "relay.example.com", want: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -14,9 +14,9 @@ const (
 	ExitModeDirect             = "direct"
 	ExitModeDedicated          = "dedicated"
 
-	// TransportDirect means clients reach the volunteer directly at its
+	// TransportDirect means clients reach the relay directly at its
 	// advertised public endpoint. TransportTunnel means the endpoint is a relay
-	// hub forwarding opaque bytes to a volunteer behind CGNAT over a reverse
+	// hub forwarding opaque bytes to a relay behind CGNAT over a reverse
 	// tunnel.
 	TransportDirect = "direct"
 	TransportTunnel = "tunnel"
@@ -30,7 +30,7 @@ const (
 
 	// NodeClassFoundation marks a relay operated by the OpenRung Foundation
 	// itself; NodeClassVolunteer (the default) marks community-operated
-	// hardware. The class records provenance — who runs the node — not a
+	// hardware. The class records provenance — who runs the relay — not a
 	// quality score: reliability is measured per-relay by telemetry either
 	// way. The broker only accepts a foundation claim from a registration
 	// that presents the foundation token, and the class travels inside the
@@ -52,8 +52,10 @@ type RegisterRequest struct {
 	ExitMode         string `json:"exit_mode"`
 	MaxSessions      int    `json:"max_sessions"`
 	MaxMbps          int    `json:"max_mbps"`
-	VolunteerVersion string `json:"volunteer_version"`
-	Label            string `json:"label,omitempty"`
+	// RelayVersion retains the legacy volunteer_version JSON name for wire
+	// compatibility with deployed brokers, relays, and clients.
+	RelayVersion string `json:"volunteer_version"`
+	Label        string `json:"label,omitempty"`
 	// NodeClass declares who operates this relay: NodeClassVolunteer (the
 	// default when empty) or NodeClassFoundation. A foundation claim is only
 	// honored when the request presents the broker's foundation token;
@@ -62,8 +64,8 @@ type RegisterRequest struct {
 	NodeClass string `json:"node_class,omitempty"`
 	Transport string `json:"transport,omitempty"`
 	// PunchCapable reports that this relay can attempt a direct NAT-hole-punched
-	// path (client<->volunteer) via the hub's punch coordinator, bypassing the
-	// hub data path. Only tunnel-transport volunteers set it. Clients that do not
+	// path (client<->relay) via the hub's punch coordinator, bypassing the
+	// hub data path. Only tunnel-transport relays set it. Clients that do not
 	// understand it ignore it and use the advertised public endpoint as today.
 	PunchCapable bool `json:"punch_capable,omitempty"`
 	// PunchEndpoint is the hub's punch coordinator HTTP(S) base URL (e.g.
@@ -72,7 +74,7 @@ type RegisterRequest struct {
 	// actual listener. Empty means "derive http://PublicHost:9444".
 	PunchEndpoint string `json:"punch_endpoint,omitempty"`
 	// ExitHost is set by the relay hub for tunnel-transport registrations: the
-	// volunteer's source IP as observed on its control connection, i.e. where
+	// relay's source IP as observed on its control connection, i.e. where
 	// tunneled traffic actually exits. The broker uses it only to geolocate the
 	// relay (instead of PublicHost, which is the hub for tunnel transport) and
 	// never serves it to clients. Rejected for direct transport, where
@@ -82,7 +84,7 @@ type RegisterRequest struct {
 
 // GeoLocation is the broker-resolved physical location of the relay's exit:
 // exit_host for tunnel relays, public_host for direct relays. It is derived by
-// the broker, never supplied by the volunteer, and is best-effort: all fields
+// the broker, never supplied by the relay, and is best-effort: all fields
 // are empty when the lookup has not succeeded (yet).
 type GeoLocation struct {
 	City        string `json:"city,omitempty"`
@@ -103,30 +105,32 @@ type Descriptor struct {
 	GeoLocation
 	// ExitHost is stored so heartbeat-time geo backfills keep resolving the
 	// true exit location of tunnel relays, but it is never serialized: exposing
-	// a CGNAT volunteer's real IP through the public API would defeat the
+	// a CGNAT relay's observed exit IP through the public API would defeat the
 	// privacy the hub provides.
 	ExitHost string `json:"-"`
 	// NodeClass is the broker-attested operator class (NodeClassFoundation or
 	// NodeClassVolunteer). Always serialized, and covered by the relay-list
 	// signature like every other descriptor field; clients that predate it
-	// ignore it, clients that read it treat a missing value as volunteer.
-	NodeClass        string    `json:"node_class"`
-	Protocol         string    `json:"protocol"`
-	ClientID         string    `json:"client_id"`
-	RealityPublicKey string    `json:"reality_public_key"`
-	ShortID          string    `json:"short_id"`
-	ServerName       string    `json:"server_name"`
-	Flow             string    `json:"flow"`
-	ExitMode         string    `json:"exit_mode"`
-	MaxSessions      int       `json:"max_sessions"`
-	MaxMbps          int       `json:"max_mbps"`
-	VolunteerVersion string    `json:"volunteer_version"`
-	Transport        string    `json:"transport,omitempty"`
-	PunchCapable     bool      `json:"punch_capable,omitempty"`
-	PunchEndpoint    string    `json:"punch_endpoint,omitempty"`
-	RegisteredAt     time.Time `json:"registered_at"`
-	LastHeartbeatAt  time.Time `json:"last_heartbeat_at"`
-	ExpiresAt        time.Time `json:"expires_at"`
+	// ignore it, clients that read it treat a missing value as the volunteer class.
+	NodeClass        string `json:"node_class"`
+	Protocol         string `json:"protocol"`
+	ClientID         string `json:"client_id"`
+	RealityPublicKey string `json:"reality_public_key"`
+	ShortID          string `json:"short_id"`
+	ServerName       string `json:"server_name"`
+	Flow             string `json:"flow"`
+	ExitMode         string `json:"exit_mode"`
+	MaxSessions      int    `json:"max_sessions"`
+	MaxMbps          int    `json:"max_mbps"`
+	// RelayVersion retains the legacy volunteer_version JSON name for wire
+	// compatibility with deployed brokers, relays, and clients.
+	RelayVersion    string    `json:"volunteer_version"`
+	Transport       string    `json:"transport,omitempty"`
+	PunchCapable    bool      `json:"punch_capable,omitempty"`
+	PunchEndpoint   string    `json:"punch_endpoint,omitempty"`
+	RegisteredAt    time.Time `json:"registered_at"`
+	LastHeartbeatAt time.Time `json:"last_heartbeat_at"`
+	ExpiresAt       time.Time `json:"expires_at"`
 }
 
 // ListResponse is the signed relay directory. The whole marshaled body is

--- a/internal/relay/types_test.go
+++ b/internal/relay/types_test.go
@@ -1,0 +1,36 @@
+package relay
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestRelayVersionKeepsLegacyJSONField(t *testing.T) {
+	values := map[string]any{
+		"register request": RegisterRequest{RelayVersion: "1.2.3"},
+		"descriptor":       Descriptor{RelayVersion: "1.2.3"},
+	}
+	for name, value := range values {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !bytes.Contains(encoded, []byte(`"volunteer_version":"1.2.3"`)) {
+				t.Fatalf("legacy volunteer_version field missing from %s", encoded)
+			}
+			if bytes.Contains(encoded, []byte(`"relay_version"`)) {
+				t.Fatalf("unexpected relay_version wire field in %s", encoded)
+			}
+		})
+	}
+
+	var request RegisterRequest
+	if err := json.Unmarshal([]byte(`{"volunteer_version":"4.5.6"}`), &request); err != nil {
+		t.Fatalf("unmarshal register request: %v", err)
+	}
+	if request.RelayVersion != "4.5.6" {
+		t.Fatalf("RelayVersion = %q, want %q", request.RelayVersion, "4.5.6")
+	}
+}

--- a/internal/relayhub/config.go
+++ b/internal/relayhub/config.go
@@ -1,6 +1,6 @@
 // Package relayhub holds the configuration for the relay hub binary, the
 // publicly reachable component that terminates reverse tunnels from CGNAT
-// volunteers and forwards client traffic to them.
+// volunteer-run relays and forwards client traffic to them.
 package relayhub
 
 import (
@@ -12,7 +12,7 @@ import (
 
 // Config holds the relay hub's runtime configuration.
 type Config struct {
-	// ControlAddr is the address volunteers dial to establish a tunnel.
+	// ControlAddr is the address volunteer-run relays dial to establish a tunnel.
 	ControlAddr string
 	// PublicHost is the hostname/IP advertised to clients for tunneled relays.
 	PublicHost string
@@ -24,8 +24,8 @@ type Config struct {
 	PortRangeEnd   int
 	// BrokerURL is the broker base URL the hub registers relays against.
 	BrokerURL string
-	// Token is the shared bearer token used both to authenticate volunteers and
-	// to authorize the hub's broker calls.
+	// Token is the shared bearer token used both to authenticate volunteer-class
+	// relays and to authorize the hub's broker calls.
 	Token string
 	// TLSCertPath and TLSKeyPath enable TLS on the control channel when both set.
 	TLSCertPath string

--- a/internal/tunnel/client.go
+++ b/internal/tunnel/client.go
@@ -19,16 +19,16 @@ import (
 	"openrung/internal/punch"
 )
 
-// Client is the volunteer side of the reverse tunnel. It dials the hub, performs
+// Client is the relay side of the reverse tunnel. It dials the hub, performs
 // the HELLO handshake, then accepts multiplexed streams from the hub and pipes
-// each one to the volunteer's local (loopback) Xray listener.
+// each one to the relay's local (loopback) Xray listener.
 type Client struct {
 	// HubAddr is the hub control address (host:port).
 	HubAddr string
 	// TLSConfig configures the control connection to the hub. When nil the
 	// client dials plaintext TCP (local development and tests only).
 	TLSConfig *tls.Config
-	// Hello is the handshake the volunteer announces (token + relay metadata).
+	// Hello is the handshake the relay announces (token + relay metadata).
 	Hello HelloFrame
 	// TargetHost and TargetPort point at the local Xray listener that streams
 	// are piped to.
@@ -213,11 +213,11 @@ func (c *Client) handleAccepted(ctx context.Context, stream net.Conn, typed bool
 	}
 }
 
-// handlePunchControl reads a punch directive, gathers the volunteer's reflexive
+// handlePunchControl reads a punch directive, gathers the relay's reflexive
 // candidates, replies with an ack, and lets the punch package run the direct path
 // in the background (bridging to the same loopback Xray listener as tunnelled
 // traffic). ctx is the long-lived tunnel context so the punched session survives
-// this control stream closing but stops on volunteer shutdown.
+// this control stream closing but stops on relay shutdown.
 func (c *Client) handlePunchControl(ctx context.Context, stream net.Conn) {
 	defer stream.Close()
 	_ = stream.SetReadDeadline(time.Now().Add(punchControlTimeout))

--- a/internal/tunnel/hardening_test.go
+++ b/internal/tunnel/hardening_test.go
@@ -50,7 +50,7 @@ func TestHubReapsSilentClientConnection(t *testing.T) {
 		Hello: HelloFrame{
 			Token: "secret", RealityPublicKey: "pk", ShortID: "sid", ServerName: "www.example.com",
 			ClientID: "cid", Flow: relay.FlowVision, ExitMode: relay.ExitModeDirect,
-			MaxSessions: 4, MaxMbps: 10, VolunteerVersion: "test",
+			MaxSessions: 4, MaxMbps: 10, RelayVersion: "test",
 		},
 		TargetHost:   echoHost,
 		TargetPort:   echoPort,

--- a/internal/tunnel/probe.go
+++ b/internal/tunnel/probe.go
@@ -13,12 +13,12 @@ import (
 	"time"
 )
 
-// PathProbe is the hub HTTP endpoint a volunteer calls to test whether it is
+// PathProbe is the hub HTTP endpoint a relay calls to test whether it is
 // reachable from the public internet.
 const PathProbe = "/api/v1/probe"
 
-// ProbeLinePrefix is the line a volunteer's temporary probe listener writes on an
-// accepted connection so the hub can confirm it reached that specific volunteer
+// ProbeLinePrefix is the line a relay's temporary probe listener writes on an
+// accepted connection so the hub can confirm it reached that specific relay
 // (not some other device answering on the same public IP:port).
 const ProbeLinePrefix = "ORPROBE "
 
@@ -27,7 +27,7 @@ const (
 	probeMaxLine     = 128
 )
 
-// ProbeRequest is the volunteer -> hub body for POST PathProbe. The volunteer
+// ProbeRequest is the relay -> hub body for POST PathProbe. The relay
 // only chooses the port and a nonce; the hub always dials the request's own
 // source IP, never a caller-specified host, so this cannot be used for SSRF.
 type ProbeRequest struct {
@@ -36,14 +36,14 @@ type ProbeRequest struct {
 }
 
 // ProbeResponse reports whether the hub could open an inbound TCP connection to
-// the volunteer at its observed public IP and the requested port.
+// the relay at its observed public IP and the requested port.
 type ProbeResponse struct {
 	Reachable    bool   `json:"reachable"`
 	ObservedHost string `json:"observed_host"`
 	Error        string `json:"error,omitempty"`
 }
 
-// ReachabilityProber is the hub-side self-check service. It lets a volunteer
+// ReachabilityProber is the hub-side self-check service. It lets a relay
 // discover whether it can accept inbound connections (so it should register
 // directly) or is behind CGNAT/a firewall (so it should tunnel).
 type ReachabilityProber struct {
@@ -109,7 +109,7 @@ func (p *ReachabilityProber) handle(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(w, http.StatusOK, p.dialAndVerify(ip, req.Port, req.Nonce))
 }
 
-// dialAndVerify dials back the volunteer's observed source IP at the requested
+// dialAndVerify dials back the relay's observed source IP at the requested
 // port and confirms it answers with the expected nonce line. It only ever dials
 // ip (the caller's own address), so it is not an SSRF vector.
 func (p *ReachabilityProber) dialAndVerify(ip string, port int, nonce string) ProbeResponse {

--- a/internal/tunnel/probe_test.go
+++ b/internal/tunnel/probe_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // serveNonceListener starts a listener that writes the probe nonce line to every
-// accepted connection, standing in for a volunteer's temporary probe listener.
+// accepted connection, standing in for a relay's temporary probe listener.
 func serveNonceListener(t *testing.T, nonce string) int {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/tunnel/protocol.go
+++ b/internal/tunnel/protocol.go
@@ -8,10 +8,10 @@ import (
 	"io"
 )
 
-// ProtocolVersion is the tunnel control-protocol version. The volunteer sends it
+// ProtocolVersion is the tunnel control-protocol version. The relay sends it
 // in the HELLO frame and the hub rejects mismatches. It stays 1: the punch
 // stream-typing extension is negotiated with additive HELLO/HELLO_ACK bools so a
-// mixed fleet of old and new volunteers/hubs keeps working (bumping the version
+// mixed fleet of old and new relays/hubs keeps working (bumping the version
 // would make either side hard-reject the other and break tunnelling entirely).
 const ProtocolVersion = 1
 
@@ -21,7 +21,7 @@ const maxFrameSize = 16 << 10 // 16 KiB
 
 // Stream-type discriminator. When both ends negotiate stream typing (see
 // HelloFrame/HelloAckFrame StreamTyping), the hub writes one of these bytes as
-// the first byte of every stream it opens, so the volunteer can tell client data
+// the first byte of every stream it opens, so the relay can tell client data
 // (piped to Xray) from punch-control messages. Old peers never negotiate typing
 // and never see the byte, so their raw client-data streams are unchanged.
 const (
@@ -34,8 +34,8 @@ var (
 	errProtocolMismatch = errors.New("unsupported tunnel protocol version")
 )
 
-// HelloFrame is the first frame a volunteer sends after the TLS handshake. It
-// authenticates the volunteer and announces the relay metadata the hub forwards
+// HelloFrame is the first frame a relay sends after the TLS handshake. It
+// authenticates the relay and announces the metadata the hub forwards
 // to the broker. Fields mirror relay.RegisterRequest.
 type HelloFrame struct {
 	ProtocolVersion  int    `json:"protocol_version"`
@@ -49,10 +49,12 @@ type HelloFrame struct {
 	MaxSessions      int    `json:"max_sessions"`
 	MaxMbps          int    `json:"max_mbps"`
 	Label            string `json:"label,omitempty"`
-	VolunteerVersion string `json:"volunteer_version"`
-	// StreamTyping announces that this volunteer understands the stream-type
+	// RelayVersion retains the legacy volunteer_version JSON key for compatibility
+	// with deployed relay runtimes and hubs.
+	RelayVersion string `json:"volunteer_version"`
+	// StreamTyping announces that this relay understands the stream-type
 	// discriminator byte and can handle punch-control streams. Additive: omitted
-	// by old volunteers, which the hub then treats as untyped (data-only).
+	// by old relays, which the hub then treats as untyped (data-only).
 	StreamTyping bool `json:"stream_typing,omitempty"`
 	// PunchCapable requests that the hub advertise this relay as punch-capable to
 	// clients. Only meaningful when StreamTyping is also set.
@@ -60,7 +62,7 @@ type HelloFrame struct {
 }
 
 // HelloAckFrame is the hub's reply to a HelloFrame. On success it carries the
-// public endpoint the hub allocated for this volunteer and the broker relay ID.
+// public endpoint the hub allocated for this relay and the broker relay ID.
 type HelloAckFrame struct {
 	OK         bool   `json:"ok"`
 	Error      string `json:"error,omitempty"`
@@ -68,11 +70,11 @@ type HelloAckFrame struct {
 	PublicPort int    `json:"public_port,omitempty"`
 	RelayID    string `json:"relay_id,omitempty"`
 	// StreamTyping confirms the hub will emit the stream-type discriminator byte
-	// on the streams it opens. The volunteer only reads the byte when this is set,
-	// so an old hub (which never sets it) drives a new volunteer in legacy mode.
+	// on the streams it opens. The relay only reads the byte when this is set,
+	// so an old hub (which never sets it) drives a new relay in legacy mode.
 	StreamTyping bool `json:"stream_typing,omitempty"`
 	// ReflectorAddrs are the hub's UDP reflector endpoints, informational for the
-	// volunteer (the authoritative list is also carried in each PunchDirective).
+	// relay (the authoritative list is also carried in each PunchDirective).
 	ReflectorAddrs []string `json:"reflector_addrs,omitempty"`
 }
 

--- a/internal/tunnel/protocol_test.go
+++ b/internal/tunnel/protocol_test.go
@@ -22,10 +22,16 @@ func TestFrameRoundTrip(t *testing.T) {
 		MaxSessions:      4,
 		MaxMbps:          10,
 		Label:            "lbl",
-		VolunteerVersion: "dev",
+		RelayVersion:     "dev",
 	}
 	if err := writeFrame(&buf, in); err != nil {
 		t.Fatalf("writeFrame: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"volunteer_version":"dev"`)) {
+		t.Fatalf("legacy volunteer_version wire key missing from %q", buf.Bytes())
+	}
+	if bytes.Contains(buf.Bytes(), []byte(`"relay_version"`)) {
+		t.Fatalf("unexpected relay_version wire key in %q", buf.Bytes())
 	}
 	var out HelloFrame
 	if err := readFrame(&buf, &out); err != nil {

--- a/internal/tunnel/punch.go
+++ b/internal/tunnel/punch.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openrung/openrung/punchcore"
 )
 
-// punchControlTimeout bounds the hub<->volunteer punch-control exchange over the
+// punchControlTimeout bounds the hub<->relay punch-control exchange over the
 // yamux stream.
 const punchControlTimeout = 5 * time.Second
 
@@ -30,7 +30,7 @@ var (
 	// ErrRelayNotConnected means no live tunnel is registered for the relay ID
 	// (stale/rotated descriptor); the client should re-fetch relays.
 	ErrRelayNotConnected = errors.New("relay not connected to hub")
-	// ErrPunchUnsupported means the connected volunteer did not negotiate stream
+	// ErrPunchUnsupported means the connected relay did not negotiate stream
 	// typing and cannot receive punch directives.
 	ErrPunchUnsupported = errors.New("relay does not support punch")
 )
@@ -61,8 +61,8 @@ func (h *Hub) lookupTunnel(relayID string) *tunnel {
 	return h.registry[relayID]
 }
 
-// SendPunchDirective pushes a punch directive to the connected volunteer over its
-// existing control connection and returns the volunteer's ack. It re-looks up the
+// SendPunchDirective pushes a punch directive to the connected relay over its
+// existing control connection and returns the relay's ack. It re-looks up the
 // live tunnel at send time so a reconnect between coordination steps is handled
 // cleanly.
 func (h *Hub) SendPunchDirective(ctx context.Context, relayID string, dir punchcore.PunchDirective) (punchcore.PunchAck, error) {
@@ -195,11 +195,11 @@ func (c *PunchCoordinator) handleRequest(w http.ResponseWriter, r *http.Request)
 	// Classify the client from the hub's OWN reflector observations (keyed by the
 	// client nonce), never trusting the client's self-declared class or reflexive
 	// address. A client-declared reflexive could name any victim IP, which the
-	// volunteer would then spray with punch probes — an open UDP reflector. So we
+	// relay would then spray with punch probes — an open UDP reflector. So we
 	// forward ONLY reflector-observed reflexive endpoints; when the reflector saw
 	// nothing for this nonce we send none (the client falls back to the hub
 	// relay). Host candidates are clamped and filtered to non-routable addresses
-	// (see punchcore.Policy.SanitizePeers) so they can only reach the volunteer's
+	// (see punchcore.Policy.SanitizePeers) so they can only reach the relay's
 	// own LAN.
 	var clientReflexive []punchcore.Endpoint
 	clientClass := punchcore.ClassUnknown
@@ -244,11 +244,11 @@ func (c *PunchCoordinator) handleRequest(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		c.Logger.Warn("punch directive failed", "relay_id", req.RelayID, "error", err)
-		writeJSONResponse(w, http.StatusOK, punchcore.PunchResponse{OK: false, Error: "volunteer unreachable"})
+		writeJSONResponse(w, http.StatusOK, punchcore.PunchResponse{OK: false, Error: "relay unreachable"})
 		return
 	}
 	if !ack.OK {
-		writeJSONResponse(w, http.StatusOK, punchcore.PunchResponse{OK: false, Error: "volunteer declined: " + ack.Error})
+		writeJSONResponse(w, http.StatusOK, punchcore.PunchResponse{OK: false, Error: "relay declined: " + ack.Error})
 		return
 	}
 

--- a/internal/tunnel/punch_test.go
+++ b/internal/tunnel/punch_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestTypedRelayStillEchoes verifies that when stream typing is negotiated the
-// hub prefixes data streams with the discriminator and the volunteer strips it,
+// hub prefixes data streams with the discriminator and the relay strips it,
 // so ordinary relayed traffic is unaffected even with typing on.
 func TestTypedRelayStillEchoes(t *testing.T) {
 	echoHost, echoPort := startEchoServer(t)
@@ -31,7 +31,7 @@ func TestTypedRelayStillEchoes(t *testing.T) {
 		Hello: HelloFrame{
 			Token: "secret", RealityPublicKey: "pk", ShortID: "sid", ServerName: "www.example.com",
 			ClientID: "cid", Flow: relay.FlowVision, ExitMode: relay.ExitModeDirect,
-			MaxSessions: 4, MaxMbps: 10, VolunteerVersion: "test",
+			MaxSessions: 4, MaxMbps: 10, RelayVersion: "test",
 			StreamTyping: true, PunchCapable: true,
 		},
 		TargetHost:   echoHost,
@@ -61,7 +61,7 @@ func TestTypedRelayStillEchoes(t *testing.T) {
 	}
 
 	// The hub has no reflector, so the relay must NOT be advertised punch-capable
-	// even though the volunteer offered it.
+	// even though the relay offered it.
 	_, _, lastReq := registrar.stats()
 	if lastReq.PunchCapable {
 		t.Fatal("relay advertised punch_capable without a hub reflector")
@@ -124,7 +124,7 @@ func TestPunchLimiterPrunesIdleBuckets(t *testing.T) {
 }
 
 // setupPunchHub wires an echo server + reflector + hub + coordinator + a real
-// volunteer Client on loopback and waits for the volunteer to be registered and
+// relay Client on loopback and waits for the relay to be registered and
 // present in the hub registry. It returns the session context (drives the whole
 // setup), the coordinator base URL, and the relay ID.
 func setupPunchHub(t *testing.T, ttl time.Duration) (context.Context, string, string) {
@@ -172,12 +172,12 @@ func setupPunchHub(t *testing.T, ttl time.Duration) (context.Context, string, st
 	t.Cleanup(ts.Close)
 
 	ackCh := make(chan HelloAckFrame, 1)
-	volunteer := &Client{
+	relayClient := &Client{
 		HubAddr: controlLn.Addr().String(),
 		Hello: HelloFrame{
 			RealityPublicKey: "pk", ShortID: "sid", ServerName: "www.example.com",
 			ClientID: "cid", Flow: relay.FlowVision, ExitMode: relay.ExitModeDirect,
-			MaxSessions: 4, MaxMbps: 10, VolunteerVersion: "test",
+			MaxSessions: 4, MaxMbps: 10, RelayVersion: "test",
 			StreamTyping: true, PunchCapable: true,
 		},
 		TargetHost:   echoHost,
@@ -191,12 +191,12 @@ func setupPunchHub(t *testing.T, ttl time.Duration) (context.Context, string, st
 			}
 		},
 	}
-	go func() { _ = volunteer.Run(ctx) }()
+	go func() { _ = relayClient.Run(ctx) }()
 
 	select {
 	case <-ackCh:
 	case <-time.After(3 * time.Second):
-		t.Fatal("volunteer did not register")
+		t.Fatal("relay did not register")
 	}
 	if !eventually(2*time.Second, func() bool { return hub.lookupTunnel("relay_punch") != nil }) {
 		t.Fatal("relay not present in hub registry")
@@ -226,7 +226,7 @@ func establishPunch(t *testing.T, ctx context.Context, hubURL, relayID string) *
 }
 
 // TestHubPunchEndToEnd drives the whole coordination path on loopback: a real
-// volunteer Client tunnels to a hub with a reflector + coordinator, then a
+// relay Client tunnels to a hub with a reflector + coordinator, then a
 // punch.Dialer establishes a direct QUIC path and echoes bytes through it. This
 // exercises control + discovery + punch + QUIC + bridge, though loopback is not
 // real NAT.
@@ -240,7 +240,7 @@ func TestHubPunchEndToEnd(t *testing.T) {
 
 // TestHubPunchSessionOutlivesTTL is the regression test for the lifetime bug: the
 // punch TTL bounds only hole-opening, so a session established under a short TTL
-// must keep working well after the TTL elapses (the volunteer bridge must run for
+// must keep working well after the TTL elapses (the relay bridge must run for
 // the tunnel lifetime, not the punch budget).
 func TestHubPunchSessionOutlivesTTL(t *testing.T) {
 	const ttl = 700 * time.Millisecond
@@ -251,7 +251,7 @@ func TestHubPunchSessionOutlivesTTL(t *testing.T) {
 		t.Fatalf("echo immediately after punch: %v", err)
 	}
 	// Wait well past the punch TTL, then confirm the direct path still carries a
-	// fresh connection (would fail if the volunteer tore down at TTL).
+	// fresh connection (would fail if the relay tore down at TTL).
 	time.Sleep(2 * ttl)
 	if err := dialEchoThroughTunnel(est.BridgePort); err != nil {
 		t.Fatalf("echo after TTL elapsed (session should outlive punch TTL): %v", err)

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -34,7 +34,7 @@ type Registrar interface {
 }
 
 // brokerRegistrar registers relays over the broker's HTTP API using the same
-// Bearer token volunteers use, reusing the relay.RegisterRequest/Descriptor
+// bearer token volunteer-class relays use, reusing the relay.RegisterRequest/Descriptor
 // shapes from the existing register and heartbeat endpoints.
 type brokerRegistrar struct {
 	brokerURL string

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -16,15 +16,15 @@ import (
 	"openrung/internal/relay"
 )
 
-// Hub is the public, relay-side of the reverse tunnel. It accepts outbound
-// control connections from CGNAT volunteers, authenticates them, allocates a
-// public TCP port per volunteer, registers the relay with the broker, and pipes
-// inbound client connections through yamux streams to the volunteer.
+// Hub is the public side of the reverse tunnel. It accepts outbound control
+// connections from CGNAT relays, authenticates them, allocates a public TCP port
+// per relay, registers each relay with the broker, and pipes inbound client
+// connections through yamux streams to it.
 //
 // The hub forwards opaque bytes only; it never holds the Reality private key and
 // cannot decrypt the end-to-end VLESS Reality traffic.
 type Hub struct {
-	// ControlListener accepts volunteer control connections. In production this
+	// ControlListener accepts relay control connections. In production this
 	// is a TLS listener (see crypto/tls.NewListener); tests may use plain TCP.
 	ControlListener net.Listener
 	// PublicHost is advertised to clients as the relay's public host.
@@ -44,7 +44,7 @@ type Hub struct {
 	// HandshakeTimeout bounds the HELLO/HELLO_ACK exchange. Defaults to 10s.
 	HandshakeTimeout time.Duration
 	// ReflectorAddrs are the hub's UDP reflector endpoints advertised to punch-
-	// capable volunteers (in HELLO_ACK and each PunchDirective). Empty means the
+	// capable relays (in HELLO_ACK and each PunchDirective). Empty means the
 	// hub offers no punch coordination, so no relay is advertised punch-capable.
 	ReflectorAddrs []string
 	// PunchEndpoint is the hub's punch coordinator HTTP(S) base URL advertised to
@@ -130,7 +130,7 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	// Negotiate stream typing: the hub supports it, so it is on iff the volunteer
+	// Negotiate stream typing: the hub supports it, so it is on iff the relay
 	// asked for it. Only a typed session can carry punch-control streams.
 	streamTyping := hello.StreamTyping
 	ack := HelloAckFrame{
@@ -172,7 +172,7 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 		logger:         logger.With("relay_id", registration.RelayID, "public_port", port, "remote", remote),
 	}
 	// Publish before the blocking accept loop so the punch coordinator can find
-	// this volunteer as soon as it is registered.
+	// this relay as soon as it is registered.
 	h.addTunnel(registration.RelayID, t)
 	// The relay ID can change if the heartbeat loop re-registers (broker forgot
 	// us), so remove whatever ID the tunnel holds at teardown time.
@@ -199,7 +199,7 @@ func (h *Hub) registerRequest(hello HelloFrame, port int, exitHost string) relay
 		ExitMode:         hello.ExitMode,
 		MaxSessions:      hello.MaxSessions,
 		MaxMbps:          hello.MaxMbps,
-		VolunteerVersion: hello.VolunteerVersion,
+		RelayVersion:     hello.RelayVersion,
 		Label:            hello.Label,
 		Transport:        relay.TransportTunnel,
 		PunchCapable:     punchOn,
@@ -207,7 +207,7 @@ func (h *Hub) registerRequest(hello HelloFrame, port int, exitHost string) relay
 	}
 }
 
-// remoteHost extracts the bare IP of the volunteer's control connection — its
+// remoteHost extracts the bare IP of the relay's control connection — its
 // public (post-NAT) source address, which is where tunneled traffic exits.
 // Returns "" when the address cannot be parsed so registration proceeds
 // without an exit host rather than sending junk to the broker.
@@ -260,8 +260,8 @@ func (h *Hub) heartbeatInterval() time.Duration {
 	return 30 * time.Second
 }
 
-// tunnel is one live volunteer connection: a yamux session plus the public
-// listener whose inbound connections are multiplexed to the volunteer.
+// tunnel is one live relay connection: a yamux session plus the public listener
+// whose inbound connections are multiplexed to the relay.
 type tunnel struct {
 	hub            *Hub
 	session        *yamux.Session
@@ -304,7 +304,7 @@ func (t *tunnel) run(parent context.Context) {
 		t.heartbeatLoop(ctx)
 	}()
 
-	// Tear down when the yamux session dies (volunteer disconnected) or the
+	// Tear down when the yamux session dies (relay disconnected) or the
 	// parent context is cancelled (hub shutting down).
 	go func() {
 		select {
@@ -317,8 +317,8 @@ func (t *tunnel) run(parent context.Context) {
 	}()
 
 	// Bound concurrent public-port connections: each costs a goroutine, a yamux
-	// stream, and a volunteer-side dial, so an unbounded accept loop lets anyone
-	// exhaust hub/volunteer file descriptors and the yamux stream window just by
+	// stream, and a relay-side dial, so an unbounded accept loop lets anyone
+	// exhaust hub/relay file descriptors and the yamux stream window just by
 	// opening TCP connections. Excess connections are dropped, not queued.
 	sem := make(chan struct{}, t.maxConcurrentConns())
 	t.logger.Info("tunnel ready", "max_conns", cap(sem))
@@ -359,8 +359,8 @@ func (t *tunnel) handleClient(clientConn net.Conn) {
 	}
 	defer stream.Close()
 	// With stream typing negotiated, prefix client-data streams with the data
-	// discriminator so the volunteer can distinguish them from punch-control
-	// streams. Untyped sessions (old volunteers) get raw bytes as before.
+	// discriminator so the relay can distinguish them from punch-control streams.
+	// Untyped sessions (old relays) get raw bytes as before.
 	if t.streamTyping {
 		if _, err := stream.Write([]byte{StreamTypeData}); err != nil {
 			t.logger.Warn("write stream type failed", "error", err)
@@ -392,7 +392,7 @@ func (t *tunnel) handleClient(clientConn net.Conn) {
 var clientHandshakeTimeout = 30 * time.Second
 
 // Per-tunnel bound on concurrent public-port connections. The cap scales with
-// the volunteer's advertised session capacity (one session fans out into many
+// the relay's advertised session capacity (one session fans out into many
 // short-lived connections) but is clamped so it can be neither unbounded nor
 // trivially small. Overflow from a hostile MaxSessions falls through to the
 // floor, never a panic.

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -196,7 +196,7 @@ func TestHubClientEndToEnd(t *testing.T) {
 			MaxSessions:      4,
 			MaxMbps:          10,
 			Label:            "lbl",
-			VolunteerVersion: "test",
+			RelayVersion:     "test",
 		},
 		TargetHost:   echoHost,
 		TargetPort:   echoPort,
@@ -242,7 +242,7 @@ func TestHubClientEndToEnd(t *testing.T) {
 		t.Fatalf("register endpoint mismatch: host=%q port=%d", lastReq.PublicHost, lastReq.PublicPort)
 	}
 	if lastReq.ExitHost != "127.0.0.1" {
-		t.Fatalf("exit_host = %q, want the volunteer's source IP 127.0.0.1", lastReq.ExitHost)
+		t.Fatalf("exit_host = %q, want the relay's source IP 127.0.0.1", lastReq.ExitHost)
 	}
 
 	if !eventually(2*time.Second, func() bool {

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1,12 +1,12 @@
-// Package tunnel implements a minimal reverse tunnel that lets a volunteer relay
+// Package tunnel implements a minimal reverse tunnel that lets a relay
 // behind CGNAT serve client traffic without any inbound port.
 //
-// A volunteer (Client) dials a publicly reachable relay hub (Hub) over a single
+// A relay Client dials a publicly reachable relay hub (Hub) over a single
 // outbound TLS connection, authenticates, and announces its relay metadata. The
 // hub allocates a public TCP port, registers the relay with the broker, and then
 // multiplexes inbound client connections over the same connection using yamux:
 // for each client connection on the public port the hub opens a stream that the
-// volunteer pipes to its loopback Xray listener.
+// relay pipes to its loopback Xray listener.
 //
 // The hub only copies opaque bytes between the public connection and the stream;
 // it never holds the Reality private key, so it cannot decrypt the end-to-end

--- a/internal/volunteer/broker.go
+++ b/internal/volunteer/broker.go
@@ -14,7 +14,7 @@ import (
 	"openrung/internal/relay"
 )
 
-// BrokerClient speaks the volunteer side of the broker HTTP API: registration
+// BrokerClient speaks the relay side of the broker HTTP API: registration
 // and heartbeats. The zero HTTPClient falls back to http.DefaultClient; Token
 // is optional (anonymous registration when the broker allows it).
 type BrokerClient struct {

--- a/internal/volunteer/engine/engine.go
+++ b/internal/volunteer/engine/engine.go
@@ -1,7 +1,7 @@
-// Package engine runs a volunteer relay as an embeddable, supervised service:
+// Package engine runs a relay as an embeddable, supervised service:
 // Start/Stop lifecycle, status/identity callbacks, and live traffic counters
 // instead of cmd/volunteer's one-shot signal-driven flow. GUI apps (the
-// desktop volunteer app) bind it to their bridge layer; the orchestration
+// OpenRung Volunteer desktop app) bind it to their bridge layer; the orchestration
 // mirrors cmd/volunteer/main.go run/runTunnelMode.
 package engine
 
@@ -65,7 +65,7 @@ func (id Identity) complete() bool {
 	return id.ClientID != "" && id.RealityPrivateKey != "" && id.RealityPublicKey != "" && id.ShortID != ""
 }
 
-// Config describes one volunteer relay. Zero values take the same defaults as
+// Config describes one relay. Zero values take the same defaults as
 // cmd/volunteer where one exists.
 type Config struct {
 	// BrokerURL is required for direct and auto modes (direct registration).
@@ -109,7 +109,7 @@ type Config struct {
 	// ConfigDir is where the generated xray config (which contains the Reality
 	// private key) is written, 0600. Defaults to os.TempDir().
 	ConfigDir string
-	// Version is reported to the broker/hub as the volunteer version.
+	// Version is reported to the broker/hub as the relay runtime version.
 	Version string
 	// PunchCapable offers NAT hole punching in tunnel mode.
 	PunchCapable bool
@@ -187,7 +187,7 @@ type Status struct {
 	RelayID   string `json:"relayId,omitempty"`
 	Label     string `json:"label,omitempty"`
 	// PublicHost/PublicPort are the endpoint clients see (the hub's in tunnel
-	// mode, this machine's in direct mode).
+	// mode, the relay host's in direct mode).
 	PublicHost string `json:"publicHost,omitempty"`
 	PublicPort int    `json:"publicPort,omitempty"`
 	LastError  string `json:"lastError,omitempty"`
@@ -214,7 +214,7 @@ type Events struct {
 	Log io.Writer
 }
 
-// Engine supervises one volunteer relay. Use New, then Start/Stop. Safe for
+// Engine supervises one relay. Use New, then Start/Stop. Safe for
 // concurrent use.
 type Engine struct {
 	mu     sync.Mutex
@@ -421,7 +421,7 @@ func (e *Engine) run(ctx context.Context, done chan struct{}) {
 var errPublicIPChanged = errors.New("public address changed")
 
 // errReresolve restarts the session because auto mode re-evaluated reachability
-// and now prefers a different transport — e.g. a machine that fell back to the
+// and now prefers a different transport — e.g. a relay host that fell back to the
 // hub (or started while the hub was down) is now confirmed directly reachable,
 // so it should stop tunnelling and serve directly.
 var errReresolve = errors.New("auto mode re-resolved to a different transport")
@@ -437,7 +437,7 @@ var detectPublicIPv6 = volunteer.DefaultPublicIPv6Address
 var autoReprobeInterval = 3 * time.Minute
 
 // autoResolve decides the transport for auto mode. Direct mode is chosen ONLY
-// when a probe positively confirms this machine is reachable from the internet
+// when a probe positively confirms this relay host is reachable from the internet
 // — never speculatively. A probe error means the hub's HTTP API is unreachable,
 // so we cannot verify reachability; guessing "direct" there would advertise a
 // possibly-firewalled address (a public IPv6 does not imply inbound reachability
@@ -462,7 +462,7 @@ func (e *Engine) autoResolve(ctx context.Context, cfg Config) (mode, publicHost 
 // watchForModeChange runs only in auto mode: it periodically re-resolves the
 // reachability decision and signals on ch when the preferred transport differs
 // from current, so the supervisor restarts in the better mode. This is what lets
-// a directly-reachable volunteer recover to direct after a hub outage instead of
+// a directly reachable relay recover to direct after a hub outage instead of
 // tunnelling forever, and switch back when reachability changes.
 func (e *Engine) watchForModeChange(ctx context.Context, cfg Config, current string, ch chan<- struct{}) {
 	ticker := time.NewTicker(autoReprobeInterval)
@@ -594,7 +594,7 @@ func (e *Engine) probeClient(cfg Config) *http.Client {
 	// hub presents the same leaf the tunnel pins. It must apply the SAME trust
 	// policy as the tunnel dial (hubTLSClientConfig) — otherwise the probe fails
 	// certificate validation, auto mode always falls back to tunnel, and a
-	// publicly reachable volunteer never selects direct mode.
+	// publicly reachable relay never selects direct mode.
 	return &http.Client{
 		Timeout:   10 * time.Second,
 		Transport: &http.Transport{TLSClientConfig: hubTLSClientConfig(cfg)},
@@ -705,7 +705,7 @@ func (e *Engine) runDirectSession(ctx context.Context, cfg Config, label string,
 		ExitMode:         relay.ExitModeDirect,
 		MaxSessions:      cfg.MaxSessions,
 		MaxMbps:          cfg.MaxMbps,
-		VolunteerVersion: cfg.Version,
+		RelayVersion:     cfg.Version,
 		Label:            label,
 	}
 	desc, err := registerWithRetry(ctx, broker, req)
@@ -843,7 +843,7 @@ func (e *Engine) runTunnelSession(ctx context.Context, cfg Config, label string,
 			MaxSessions:      cfg.MaxSessions,
 			MaxMbps:          cfg.MaxMbps,
 			Label:            label,
-			VolunteerVersion: cfg.Version,
+			RelayVersion:     cfg.Version,
 			StreamTyping:     true,
 			PunchCapable:     cfg.PunchCapable,
 		},
@@ -881,9 +881,9 @@ func (e *Engine) runTunnelSession(ctx context.Context, cfg Config, label string,
 	go func() { clientDone <- client.Run(sessionCtx) }()
 	e.logf("connecting to relay hub %s", cfg.HubAddr)
 
-	// In auto mode, keep re-checking whether this machine could serve directly
+	// In auto mode, keep re-checking whether this relay host could serve directly
 	// and switch off the hub when it can — so a hub outage or a newly-opened
-	// port doesn't leave a directly-reachable volunteer tunnelling forever.
+	// port doesn't leave a directly reachable relay tunnelling forever.
 	becameDirect := make(chan struct{}, 1)
 	if cfg.Mode == ModeAuto {
 		go e.watchForModeChange(sessionCtx, cfg, ModeTunnel, becameDirect)
@@ -933,7 +933,7 @@ func hubTLSConfig(cfg Config) *tls.Config {
 	return tc
 }
 
-// hubTLSClientConfig is the single source of truth for how the volunteer trusts
+// hubTLSClientConfig is the single source of truth for how the relay trusts
 // the hub's TLS certificate, shared by the tunnel control dial (hubTLSConfig)
 // and the reachability probe's HTTP client (probeClient). When a fingerprint is
 // pinned it verifies the exact leaf (the hub self-signs on a bare IP, so

--- a/internal/volunteer/engine/engine_test.go
+++ b/internal/volunteer/engine/engine_test.go
@@ -36,7 +36,7 @@ func freePort(t *testing.T) int {
 	return port
 }
 
-// fakeBroker implements the two volunteer endpoints with configurable
+// fakeBroker implements the two legacy-named relay endpoints with configurable
 // heartbeat failures.
 type fakeBroker struct {
 	mu           sync.Mutex

--- a/internal/volunteer/engine/probe_pin_test.go
+++ b/internal/volunteer/engine/probe_pin_test.go
@@ -19,7 +19,7 @@ import (
 // probeClient ignored HubCertFingerprint: the reachability probe hits the hub's
 // HTTPS API, so if it does not apply the same cert pin as the tunnel dial it
 // fails verification against the hub's self-signed cert, and auto mode can never
-// choose direct — every publicly reachable volunteer is forced through the hub.
+// choose direct — every publicly reachable relay is forced through the hub.
 //
 // It stands up the real reachability prober behind a self-signed TLS server and
 // asserts that with the matching pin the probe SUCCEEDS (reachable → direct
@@ -40,7 +40,7 @@ func TestProbePinnedSelfSignedHubSelectsDirect(t *testing.T) {
 	eng := New(Config{}, Events{})
 	port := freePort(t)
 
-	// Matching pin: the HTTPS probe validates, the hub dials the volunteer's
+	// Matching pin: the HTTPS probe validates, the hub dials the relay's
 	// loopback listener back, and detection reports reachable → direct mode.
 	reachable, host, err := volunteer.DetectDirectReachable(
 		context.Background(), ts.URL, "", "::", port, eng.probeClient(Config{HubCertFingerprint: fp}))

--- a/internal/volunteer/labels.go
+++ b/internal/volunteer/labels.go
@@ -9,7 +9,7 @@ import (
 // "happy-hippo". Keep both lists lowercase and within the safe label charset
 // (see relay.NormalizeLabel). The two lists are intentionally large so the
 // adjective-noun namespace is wide and accidental collisions between
-// independently-named volunteer relays stay unlikely.
+// independently named relays stay unlikely.
 var labelAdjectives = []string{
 	"amber", "ample", "arctic", "autumn", "balmy", "bold", "bouncy", "brave",
 	"breezy", "bright", "bubbly", "calm", "candid", "cheery", "chipper", "clever",

--- a/internal/volunteer/labels_test.go
+++ b/internal/volunteer/labels_test.go
@@ -25,7 +25,7 @@ func TestGenerateLabelProducesValidNames(t *testing.T) {
 
 // minLabelCombinations guards against the vocabulary shrinking back toward a
 // collision-prone size. The adjective-noun namespace should stay comfortably
-// large so independently-named volunteer relays rarely clash.
+// large so independently named relays rarely clash.
 const minLabelCombinations = 10000
 
 func TestLabelVocabularyIsLargeAndUnique(t *testing.T) {

--- a/internal/volunteer/probe.go
+++ b/internal/volunteer/probe.go
@@ -17,15 +17,15 @@ import (
 	"openrung/internal/tunnel"
 )
 
-// detectAttempts is how many times the volunteer retries the probe before
+// detectAttempts is how many times the relay retries the probe before
 // treating the hub HTTP API as unavailable.
 const detectAttempts = 3
 
 // DetectDirectReachable opens a temporary TCP listener on port, asks the hub to
-// dial it back at the volunteer's observed public IP, and reports whether that
+// dial it back at the relay's observed public IP, and reports whether that
 // inbound connection succeeded. The temporary listener answers each accepted
 // connection with the nonce line so the hub can confirm it reached this
-// volunteer. reachable=false with err=nil means "probed, not reachable" (→
+// relay. reachable=false with err=nil means "probed, not reachable" (→
 // tunnel); a non-nil err means the probe itself could not run (hub HTTP API
 // unreachable), which the caller treats as inconclusive.
 func DetectDirectReachable(ctx context.Context, hubHTTPBase, token, listenHost string, port int, httpClient *http.Client) (reachable bool, observedHost string, err error) {

--- a/internal/volunteer/probe_test.go
+++ b/internal/volunteer/probe_test.go
@@ -27,8 +27,8 @@ func freeTCPPort(t *testing.T) int {
 	return port
 }
 
-// TestDetectDirectReachableReachable wires the real hub prober to the volunteer
-// detection client on loopback: the volunteer opens its temp listener, the hub
+// TestDetectDirectReachableReachable wires the real hub prober to the relay
+// detection client on loopback: the relay opens its temporary listener, the hub
 // dials it back at the observed source IP, and detection reports reachable.
 func TestDetectDirectReachableReachable(t *testing.T) {
 	prober := tunnel.NewReachabilityProber("token123", testLogger())

--- a/punchcore/README.md
+++ b/punchcore/README.md
@@ -5,7 +5,7 @@ only) core of OpenRung's NAT hole-punch protocol. It is a nested Go module of
 the OpenRung repository and the **single source of truth** for the punch wire
 format and mechanics, consumed by:
 
-- the relay hub and volunteer servers (this repository, via `internal/punch`
+- the relay hub and relay runtimes (this repository, via `internal/punch`
   and `internal/tunnel`),
 - the desktop CLI and GUI clients (this repository),
 - the Android app's gomobile binding (`android/punchbridge` in
@@ -22,7 +22,7 @@ format and mechanics, consumed by:
 - **The UDP `Reflector` server** the hub runs.
 - **The hub HTTP client** (`HubClient`) and `HardenedHTTPClient`.
 - **The `Policy` presets**: `DesktopPolicy()` (historical
-  `internal/punch` behavior; also what the hub and volunteers run) and
+  `internal/punch` behavior; also what the hub and relay runtimes run) and
   `MobilePolicy()` (the hardened Android profile). Zero-value `Policy` is not
   valid; always start from a preset.
 
@@ -44,7 +44,7 @@ protocol change and must be treated as one (see `ProtoVersion`).
 
 ## Pin/upgrade procedure (wire changes)
 
-1. Edit punchcore in an OpenRung PR — the hub, volunteers, and desktop clients
+1. Edit punchcore in an OpenRung PR — the hub, relay runtimes, and desktop clients
    consume it via the in-repo `replace`, so servers and desktop stay atomically
    consistent.
 2. Bump `punchcore/VERSION` in the same PR — a `go-checks` job fails any PR


### PR DESCRIPTION
## Summary

- use “relay” as the generic machine, process, endpoint, directory-entry, log, and help-text term across the broker, relay runtime, relay hub, desktop client, Volunteer desktop app, deployment guidance, architecture docs, and website translations
- reserve “volunteer” for people, community operation, `node_class=volunteer`, the explicit OpenRung Volunteer product, and compatibility surfaces
- rename internal runtime identifiers to relay terminology, including `RelayVersion`, `RelayBridge`, relay registration limiters, leases, locals, tests, and diagnostics
- document the Foundation-operated versus volunteer-run distinction throughout public and operator-facing copy
- add `make relay` while retaining `make volunteer` as a compatibility alias

## Compatibility

This PR deliberately does not migrate external compatibility surfaces. The following remain unchanged:

- `/api/v1/volunteers/...` routes
- `volunteer_version` and other frozen JSON/wire keys
- `OPENRUNG_VOLUNTEER_TOKEN`, `node_class=volunteer`, and `NodeClassVolunteer`
- `cmd/volunteer`, `internal/volunteer`, deployment paths, binary/image names, workflow names, and package artifacts
- punchcore’s separately versioned exported `Volunteer*` fields

A new serialization test pins the legacy `volunteer_version` key while internal code uses `RelayVersion`.

## Companion PR

- openrung/openrung-mobile-app#44

## Validation

- root: `go test ./...` and `go vet ./...`
- punchcore: `go test ./...` and `go vet ./...`
- desktop: `go test ./...` and `go vet ./...`
- OpenRung Volunteer desktop app: `go test ./...` and `go vet ./...`
- desktop frontend: 17/17 Vitest tests and production build
- Volunteer desktop frontend: production build
- deployment shell syntax checks
- SVG/XML validation
- website inline-script parsing and translation parity: 4 locales, 114 keys each
- `git diff --check`
