### PR TITLE
Add canonical relay write API routes

### DIFF
--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -4,9 +4,14 @@ The broker runs plaintext HTTP on `:8080`. Fronts terminate client TLS at the
 edge, but the **edge → origin** leg was HTTP. On the AWS CloudFront front
 (distribution `E2PLKW8FO3JZSA`, `d2r7mdpyevvs1m.cloudfront.net`) that leg
 carried the high-value **Foundation registration token** (`Authorization`
-header on `POST /api/v1/volunteers/register`) in cleartext across the public
-internet. This runbook closes that leg with a TLS-terminating reverse proxy on
-the broker box so the token is encrypted **relay → CloudFront edge → origin**.
+header on the shipped runtime's `POST /api/v1/volunteers/register` request) in
+cleartext across the public internet. This runbook closes that leg with a
+TLS-terminating reverse proxy on the broker box so the token is encrypted
+**relay → CloudFront edge → origin**.
+
+The legacy `POST /api/v1/volunteers/register` route reaches the same handler and
+is retained as a compatibility alias with no scheduled removal date. New
+operational checks should use the canonical relay route shown here.
 
 ```
 relay ──HTTPS──► CloudFront edge ──HTTPS(:443)──► Caddy ──HTTP(127.0.0.1:8080)──► broker
@@ -212,7 +217,7 @@ sudo bash -c '
   # sed strips ONLY the first NAME= prefix, so a token containing = (base64
   # padding) survives verbatim; awk -F= "{print \$2}" would truncate it and 403.
   sed -n "s|^OPENRUNG_FOUNDATION_TOKEN=|Authorization: Bearer |p" /etc/openrung/broker.env > "$hdr"
-  CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
+  CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/relays/register
   # WITH token   -> 400 public_host is required  => token SURVIVED CloudFront->origin
   curl -sS -H @"$hdr" -o /dev/null -w "with-token: %{http_code}\n" \
     -X POST -H "Content-Type: application/json" -d "{\"node_class\":\"foundation\"}" "$CF"
@@ -233,7 +238,7 @@ bash -c '
   hdr=$(mktemp); trap "rm -f \"$hdr\"" EXIT INT TERM
   read -rs -p "Foundation token: " FT </dev/tty; echo
   printf "Authorization: Bearer %s\n" "$FT" > "$hdr"; unset FT
-  CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/volunteers/register
+  CF=https://d2r7mdpyevvs1m.cloudfront.net/api/v1/relays/register
   curl -sS -H @"$hdr" -o /dev/null -w "with-token: %{http_code}\n" \
     -X POST -H "Content-Type: application/json" -d "{\"node_class\":\"foundation\"}" "$CF"
   curl -sS          -o /dev/null -w "no-token:   %{http_code}\n" \

--- a/docs/api.md
+++ b/docs/api.md
@@ -205,13 +205,15 @@ payload so a load balancer can stop routing to that broker instance.
 ## Register Relay
 
 ```http
-POST /api/v1/volunteers/register
+POST /api/v1/relays/register
 Authorization: Bearer <registration-token>
 Content-Type: application/json
 ```
 
-The `/api/v1/volunteers/register` path is a legacy compatibility name. It
-registers both `volunteer`-class and `foundation`-class relays.
+The legacy `POST /api/v1/volunteers/register` path is retained as a
+compatibility alias with identical authentication, rate limiting, validation,
+and response behavior. It has no scheduled removal date. Both paths register
+`volunteer`-class and `foundation`-class relays.
 
 Request:
 
@@ -329,9 +331,13 @@ resolves.
 ## Heartbeat
 
 ```http
-POST /api/v1/volunteers/{id}/heartbeat
+POST /api/v1/relays/{id}/heartbeat
 Authorization: Bearer <registration-token>
 ```
+
+The legacy `POST /api/v1/volunteers/{id}/heartbeat` path is retained as a
+compatibility alias with identical authentication, rate limiting, validation,
+and response behavior. It has no scheduled removal date.
 
 Response:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,11 +85,13 @@ volunteer-run relays online:
   single TLS connection (`-tunnel -hub <addr>`), authenticating with the same
   registration token.
 - The hub allocates one public TCP port per relay, registers the relay with
-  the broker over the existing `POST /api/v1/volunteers/register` API (with
-  `transport: "tunnel"` and `public_host`/`public_port` pointing at the hub), and
-  multiplexes inbound client connections to the relay over the tunnel using
-  yamux. Clients connect to `hub:port` exactly as they would any direct relay — no
-  client changes.
+  the broker (with `transport: "tunnel"` and `public_host`/`public_port` pointing
+  at the hub), and multiplexes inbound client connections to the relay over the
+  tunnel using yamux. The current hub calls the legacy
+  `POST /api/v1/volunteers/register` compatibility alias; the broker also accepts
+  the canonical `POST /api/v1/relays/register` route with identical behavior.
+  Clients connect to `hub:port` exactly as they would any direct relay — no client
+  changes.
 - Descriptor liveness is tied to the tunnel: the hub heartbeats while the tunnel
   is healthy and stops when it drops, so the relay expires via the broker's normal
   lease TTL.

--- a/internal/broker/nodeclass_test.go
+++ b/internal/broker/nodeclass_test.go
@@ -15,11 +15,16 @@ import (
 
 func postRegister(t *testing.T, server http.Handler, req relay.RegisterRequest, bearer string) *httptest.ResponseRecorder {
 	t.Helper()
+	return postRegisterAt(t, server, "/api/v1/volunteers/register", req, bearer)
+}
+
+func postRegisterAt(t *testing.T, server http.Handler, path string, req relay.RegisterRequest, bearer string) *httptest.ResponseRecorder {
+	t.Helper()
 	body, err := json.Marshal(req)
 	if err != nil {
 		t.Fatalf("marshal register request: %v", err)
 	}
-	httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body))
+	httpReq := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
 	if bearer != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+bearer)
 	}
@@ -52,6 +57,71 @@ func TestRegisterDefaultsNodeClassVolunteer(t *testing.T) {
 	server.ServeHTTP(listRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
 	if !strings.Contains(listRecorder.Body.String(), `"node_class":"volunteer"`) {
 		t.Fatalf("expected node_class in signed list response: %s", listRecorder.Body.String())
+	}
+}
+
+func TestRegisterRouteAliasesPreserveNodeClassAuthorization(t *testing.T) {
+	routes := []struct {
+		name string
+		path string
+	}{
+		{name: "canonical", path: "/api/v1/relays/register"},
+		{name: "legacy", path: "/api/v1/volunteers/register"},
+	}
+	tests := []struct {
+		name          string
+		bearer        string
+		claimClass    string
+		wantStatus    int
+		wantNodeClass string
+	}{
+		{
+			name:          "volunteer credential registers volunteer relay",
+			bearer:        "volunteer-token",
+			wantStatus:    http.StatusCreated,
+			wantNodeClass: relay.NodeClassVolunteer,
+		},
+		{
+			name:          "foundation credential registers foundation relay",
+			bearer:        "foundation-token",
+			claimClass:    relay.NodeClassFoundation,
+			wantStatus:    http.StatusCreated,
+			wantNodeClass: relay.NodeClassFoundation,
+		},
+		{
+			name:       "volunteer credential cannot claim foundation relay",
+			bearer:     "volunteer-token",
+			claimClass: relay.NodeClassFoundation,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "invalid credential is rejected",
+			bearer:     "wrong-token",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, route := range routes {
+		for _, test := range tests {
+			t.Run(route.name+"/"+test.name, func(t *testing.T) {
+				server := NewServer(NewStore(), Config{
+					SigningSeed:       testSigningSeed(),
+					RegistrationToken: "volunteer-token",
+					FoundationToken:   "foundation-token",
+				})
+				req := validRegisterRequest()
+				req.NodeClass = test.claimClass
+				recorder := postRegisterAt(t, server, route.path, req, test.bearer)
+				if recorder.Code != test.wantStatus {
+					t.Fatalf("expected %d, got %d: %s", test.wantStatus, recorder.Code, recorder.Body.String())
+				}
+				if test.wantStatus == http.StatusCreated {
+					if desc := decodeDescriptor(t, recorder); desc.NodeClass != test.wantNodeClass {
+						t.Fatalf("node_class = %q, want %q", desc.NodeClass, test.wantNodeClass)
+					}
+				}
+			})
+		}
 	}
 }
 
@@ -175,6 +245,39 @@ func TestHeartbeatAcceptsFoundationToken(t *testing.T) {
 	server.ServeHTTP(heartbeatRecorder, heartbeat)
 	if heartbeatRecorder.Code != http.StatusOK {
 		t.Fatalf("heartbeat: expected 200, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
+	}
+}
+
+func TestCanonicalHeartbeatEnforcesFoundationToken(t *testing.T) {
+	server := NewServer(NewStore(), Config{
+		SigningSeed:       testSigningSeed(),
+		RegistrationToken: "volunteer-token",
+		FoundationToken:   "foundation-token",
+	})
+
+	req := validRegisterRequest()
+	req.NodeClass = relay.NodeClassFoundation
+	recorder := postRegisterAt(t, server, "/api/v1/relays/register", req, "foundation-token")
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("register: expected 201, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	desc := decodeDescriptor(t, recorder)
+	heartbeatPath := "/api/v1/relays/" + desc.ID + "/heartbeat"
+
+	volunteerHeartbeat := httptest.NewRequest(http.MethodPost, heartbeatPath, nil)
+	volunteerHeartbeat.Header.Set("Authorization", "Bearer volunteer-token")
+	volunteerRecorder := httptest.NewRecorder()
+	server.ServeHTTP(volunteerRecorder, volunteerHeartbeat)
+	if volunteerRecorder.Code != http.StatusForbidden {
+		t.Fatalf("volunteer heartbeat: expected 403, got %d: %s", volunteerRecorder.Code, volunteerRecorder.Body.String())
+	}
+
+	foundationHeartbeat := httptest.NewRequest(http.MethodPost, heartbeatPath, nil)
+	foundationHeartbeat.Header.Set("Authorization", "Bearer foundation-token")
+	foundationRecorder := httptest.NewRecorder()
+	server.ServeHTTP(foundationRecorder, foundationHeartbeat)
+	if foundationRecorder.Code != http.StatusOK {
+		t.Fatalf("foundation heartbeat: expected 200, got %d: %s", foundationRecorder.Code, foundationRecorder.Body.String())
 	}
 }
 

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -63,6 +63,8 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	telemetryLimiter := newIPRateLimiter(telemetryRatePerSecond, telemetryBurst, rateLimiterMaxTrackedIPs)
 	speedTestLimiter := newIPRateLimiter(speedTestRatePerSecond, speedTestBurst, rateLimiterMaxTrackedIPs)
 	relayRegistrationLimiter := newIPRateLimiter(relayRegistrationRatePerSecond, relayRegistrationBurst, rateLimiterMaxTrackedIPs)
+	registerRelay := rateLimited(relayRegistrationLimiter, clientIP, 10, registerHandler(store, cfg))
+	heartbeatRelay := rateLimited(relayRegistrationLimiter, clientIP, 10, heartbeatHandler(store, cfg))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -75,8 +77,14 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 		// lets the monitor assert the active key without parsing a relay list.
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "signing_key_id": relaySigner.keyID})
 	})
-	mux.HandleFunc("POST /api/v1/volunteers/register", rateLimited(relayRegistrationLimiter, clientIP, 10, registerHandler(store, cfg)))
-	mux.HandleFunc("POST /api/v1/volunteers/", rateLimited(relayRegistrationLimiter, clientIP, 10, heartbeatHandler(store, cfg)))
+	mux.HandleFunc("POST /api/v1/relays/register", registerRelay)
+	mux.HandleFunc("POST /api/v1/relays/", heartbeatRelay)
+	// Keep the original volunteer-named routes as compatibility aliases for
+	// deployed relays. Both route families intentionally share the same handler
+	// closures and rate limiter so aliases cannot change behavior or double a
+	// client's registration budget.
+	mux.HandleFunc("POST /api/v1/volunteers/register", registerRelay)
+	mux.HandleFunc("POST /api/v1/volunteers/", heartbeatRelay)
 	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen, relaySigner)))
 	mux.HandleFunc("GET /api/v1/relays.mirror", rateLimited(relayListLimiter, clientIP, 10, listRelaysMirrorHandler(store, relaySigner)))
 	mux.HandleFunc("POST /api/v1/telemetry/events", rateLimited(telemetryLimiter, clientIP, 10, telemetryHandler(cfg.TelemetrySink, store, clientIP)))
@@ -333,13 +341,27 @@ func validateRegisterRequest(req relay.RegisterRequest) error {
 }
 
 func heartbeatRelayID(path string) (string, bool) {
-	const prefix = "/api/v1/volunteers/"
-	const suffix = "/heartbeat"
-	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+	const (
+		relayPrefix     = "/api/v1/relays/"
+		volunteerPrefix = "/api/v1/volunteers/"
+		suffix          = "/heartbeat"
+	)
+
+	var remainder string
+	switch {
+	case strings.HasPrefix(path, relayPrefix):
+		remainder = strings.TrimPrefix(path, relayPrefix)
+	case strings.HasPrefix(path, volunteerPrefix):
+		remainder = strings.TrimPrefix(path, volunteerPrefix)
+	default:
 		return "", false
 	}
-	id := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
-	return id, id != ""
+
+	id, ok := strings.CutSuffix(remainder, suffix)
+	if !ok || id == "" || strings.ContainsRune(id, '/') {
+		return "", false
+	}
+	return id, true
 }
 
 func authorized(r *http.Request, token string) bool {

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -27,9 +27,90 @@ func TestValidateRegisterRequest(t *testing.T) {
 }
 
 func TestHeartbeatRelayID(t *testing.T) {
-	id, ok := heartbeatRelayID("/api/v1/volunteers/relay_abc/heartbeat")
-	if !ok || id != "relay_abc" {
-		t.Fatalf("expected relay_abc, got id=%q ok=%v", id, ok)
+	tests := []struct {
+		name   string
+		path   string
+		wantID string
+		wantOK bool
+	}{
+		{name: "canonical relay route", path: "/api/v1/relays/relay_abc/heartbeat", wantID: "relay_abc", wantOK: true},
+		{name: "legacy volunteer route", path: "/api/v1/volunteers/relay_abc/heartbeat", wantID: "relay_abc", wantOK: true},
+		{name: "missing relay ID", path: "/api/v1/relays//heartbeat"},
+		{name: "nested relay ID", path: "/api/v1/relays/group/relay_abc/heartbeat"},
+		{name: "wrong suffix", path: "/api/v1/relays/relay_abc/pulse"},
+		{name: "unrelated route", path: "/api/v1/telemetry/relay_abc/heartbeat"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id, ok := heartbeatRelayID(test.path)
+			if id != test.wantID || ok != test.wantOK {
+				t.Fatalf("heartbeatRelayID(%q) = (%q, %v), want (%q, %v)", test.path, id, ok, test.wantID, test.wantOK)
+			}
+		})
+	}
+}
+
+func TestRelayRouteAliasesRegisterAndHeartbeat(t *testing.T) {
+	tests := []struct {
+		name          string
+		registerPath  string
+		heartbeatBase string
+	}{
+		{name: "canonical routes", registerPath: "/api/v1/relays/register", heartbeatBase: "/api/v1/relays/"},
+		{name: "canonical register legacy heartbeat", registerPath: "/api/v1/relays/register", heartbeatBase: "/api/v1/volunteers/"},
+		{name: "legacy register canonical heartbeat", registerPath: "/api/v1/volunteers/register", heartbeatBase: "/api/v1/relays/"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+			body, err := json.Marshal(validRegisterRequest())
+			if err != nil {
+				t.Fatalf("marshal register request: %v", err)
+			}
+
+			registerRecorder := httptest.NewRecorder()
+			server.ServeHTTP(registerRecorder, httptest.NewRequest(http.MethodPost, test.registerPath, bytes.NewReader(body)))
+			if registerRecorder.Code != http.StatusCreated {
+				t.Fatalf("register: expected 201, got %d: %s", registerRecorder.Code, registerRecorder.Body.String())
+			}
+
+			var desc relay.Descriptor
+			if err := json.Unmarshal(registerRecorder.Body.Bytes(), &desc); err != nil {
+				t.Fatalf("decode descriptor: %v", err)
+			}
+			heartbeatRecorder := httptest.NewRecorder()
+			heartbeatPath := test.heartbeatBase + desc.ID + "/heartbeat"
+			server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, heartbeatPath, nil))
+			if heartbeatRecorder.Code != http.StatusOK {
+				t.Fatalf("heartbeat: expected 200, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestRegisterRouteAliasesRejectMalformedJSONIdentically(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+	paths := []string{
+		"/api/v1/relays/register",
+		"/api/v1/volunteers/register",
+	}
+
+	var wantBody string
+	for _, path := range paths {
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, path, strings.NewReader("{")))
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("%s: expected 400, got %d: %s", path, recorder.Code, recorder.Body.String())
+		}
+		if wantBody == "" {
+			wantBody = recorder.Body.String()
+			continue
+		}
+		if recorder.Body.String() != wantBody {
+			t.Fatalf("%s: body = %q, want %q", path, recorder.Body.String(), wantBody)
+		}
 	}
 }
 
@@ -278,13 +359,55 @@ func TestListRelaysIsNeverCacheable(t *testing.T) {
 	}
 }
 
-func TestHeartbeatMissingRelayStillReturnsNotFound(t *testing.T) {
-	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
-	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/relay_missing/heartbeat", nil))
+func TestHeartbeatRoutesRejectMissingOrMalformedRelays(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "canonical missing relay", path: "/api/v1/relays/relay_missing/heartbeat"},
+		{name: "legacy missing relay", path: "/api/v1/volunteers/relay_missing/heartbeat"},
+		{name: "canonical malformed endpoint", path: "/api/v1/relays/relay_missing/pulse"},
+		{name: "legacy malformed endpoint", path: "/api/v1/volunteers/relay_missing/pulse"},
+	}
 
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", recorder.Code, recorder.Body.String())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, test.path, nil))
+			if recorder.Code != http.StatusNotFound {
+				t.Fatalf("expected 404, got %d: %s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestRelayRouteAliasesShareRegistrationRateLimit(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+
+	// Exhaust the registration budget through the legacy alias. Invalid JSON
+	// still consumes a token because limiting deliberately happens before body
+	// parsing and authentication.
+	exhausted := false
+	for i := 0; i < relayRegistrationBurst+32; i++ {
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil))
+		if recorder.Code == http.StatusTooManyRequests {
+			exhausted = true
+			break
+		}
+	}
+	if !exhausted {
+		t.Fatal("expected legacy route to exhaust the shared budget")
+	}
+
+	// The canonical alias must immediately see that exhausted bucket. Separate
+	// limiters would let callers double the effective registration budget by
+	// alternating route names.
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", nil))
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected canonical route to share exhausted budget, got %d: %s", recorder.Code, recorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add canonical `POST /api/v1/relays/register` and `POST /api/v1/relays/{id}/heartbeat` endpoints
- retain `/api/v1/volunteers/...` as compatibility aliases with the same handler closures, authentication, validation, and shared rate limiter
- add parity coverage for anonymous, volunteer, and Foundation registration, cross-route heartbeats, malformed requests, missing relays, and alias rate-limit bypass
- update API, architecture, and broker TLS documentation to distinguish the canonical routes from the callers that still use the legacy aliases

## Why

Broker-attested `node_class` now supports both `volunteer` and `foundation` relays, so the write API should no longer imply that every registering relay is volunteer-operated. This creates the relay-first API surface additively without breaking deployed runtimes.

## Rollout and compatibility

This is intentionally broker-only. Existing relay runtimes and relay hubs continue using `/api/v1/volunteers/...` unchanged. Deploy the broker aliases first; caller migration can happen in a later PR after the new routes are live.

This PR does not rename `node_class=volunteer`, `OPENRUNG_VOLUNTEER_TOKEN`, v1 JSON fields, database columns, binaries, images, or desktop product branding.

## Validation

- `go vet ./...`
- `go test -race ./...`
- `cd punchcore && go vet ./...`
- `cd punchcore && go test -race ./...`
- focused route-alias tests, including 50 repeated shared-rate-limit runs
- `git diff --check`
