### PR TITLE
Migrate relay hub to canonical broker routes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,9 +87,12 @@ volunteer-run relays online:
 - The hub allocates one public TCP port per relay, registers the relay with
   the broker (with `transport: "tunnel"` and `public_host`/`public_port` pointing
   at the hub), and multiplexes inbound client connections to the relay over the
-  tunnel using yamux. The current hub calls the legacy
-  `POST /api/v1/volunteers/register` compatibility alias; the broker also accepts
-  the canonical `POST /api/v1/relays/register` route with identical behavior.
+  tunnel using yamux. The hub prefers the canonical
+  `POST /api/v1/relays/register` route. If a broker reports that route unsupported
+  with the old ServeMux's route-missing `404` response or with `405`, the hub
+  selects the legacy `POST /api/v1/volunteers/register` compatibility alias for
+  subsequent registrations and heartbeats. Other broker errors never trigger
+  fallback.
   Clients connect to `hub:port` exactly as they would any direct relay — no client
   changes.
 - Descriptor liveness is tied to the tunnel: the hub heartbeats while the tunnel

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"openrung/internal/relay"
@@ -17,6 +19,11 @@ import (
 // longer knows the relay — e.g. an in-memory store lost it across a broker
 // restart. The caller should re-register rather than keep heartbeating.
 var ErrRelayNotFound = errors.New("relay not found")
+
+const (
+	maxBrokerErrorBodyBytes    = 64 << 10
+	legacyServeMuxNotFoundBody = "404 page not found\n"
+)
 
 // RelayRegistration is the result of registering a tunneled relay with the broker.
 type RelayRegistration struct {
@@ -33,13 +40,19 @@ type Registrar interface {
 	Heartbeat(ctx context.Context, relayID string) error
 }
 
-// brokerRegistrar registers relays over the broker's HTTP API using the same
-// bearer token volunteer-class relays use, reusing the relay.RegisterRequest/Descriptor
-// shapes from the existing register and heartbeat endpoints.
+// brokerRegistrar registers relays over the broker's canonical HTTP API using
+// the same bearer token volunteer-class relays use. It keeps the legacy route
+// family available for brokers that predate the canonical write endpoints.
 type brokerRegistrar struct {
 	brokerURL string
 	token     string
 	client    *http.Client
+
+	// legacyRoutes is broker-wide for this registrar: once either canonical
+	// write endpoint proves unavailable, registration and heartbeats both stay
+	// on the compatibility route family. Atomic state keeps concurrent hub
+	// registrations race-safe and the transition monotonic.
+	legacyRoutes atomic.Bool
 }
 
 // NewBrokerRegistrar builds a Registrar backed by the broker HTTP API.
@@ -47,16 +60,37 @@ func NewBrokerRegistrar(brokerURL, token string, client *http.Client) Registrar 
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
+	// Broker write endpoints are canonical and must never redirect. Refusing
+	// redirects prevents forwarding the bearer token to another URL and ensures
+	// a redirected 404/405 cannot be mistaken for an unsupported route.
+	noRedirectClient := *client
+	noRedirectClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	return &brokerRegistrar{
 		brokerURL: strings.TrimRight(brokerURL, "/"),
 		token:     token,
-		client:    client,
+		client:    &noRedirectClient,
 	}
 }
 
 func (b *brokerRegistrar) Register(ctx context.Context, req relay.RegisterRequest) (RelayRegistration, error) {
+	if b.legacyRoutes.Load() {
+		return b.registerAt(ctx, "/api/v1/volunteers/register", req)
+	}
+
+	registration, err := b.registerAt(ctx, "/api/v1/relays/register", req)
+	if !isRouteUnsupported(err) {
+		return registration, err
+	}
+
+	b.legacyRoutes.Store(true)
+	return b.registerAt(ctx, "/api/v1/volunteers/register", req)
+}
+
+func (b *brokerRegistrar) registerAt(ctx context.Context, path string, req relay.RegisterRequest) (RelayRegistration, error) {
 	var desc relay.Descriptor
-	if err := b.postJSON(ctx, "/api/v1/volunteers/register", req, &desc); err != nil {
+	if err := b.postJSON(ctx, path, req, &desc); err != nil {
 		return RelayRegistration{}, err
 	}
 	return RelayRegistration{
@@ -68,8 +102,39 @@ func (b *brokerRegistrar) Register(ctx context.Context, req relay.RegisterReques
 }
 
 func (b *brokerRegistrar) Heartbeat(ctx context.Context, relayID string) error {
+	if b.legacyRoutes.Load() {
+		return b.heartbeatAt(ctx, "/api/v1/volunteers/", relayID)
+	}
+
+	err := b.heartbeatAt(ctx, "/api/v1/relays/", relayID)
+	if !isRouteUnsupported(err) {
+		return err
+	}
+
+	b.legacyRoutes.Store(true)
+	return b.heartbeatAt(ctx, "/api/v1/volunteers/", relayID)
+}
+
+func (b *brokerRegistrar) heartbeatAt(ctx context.Context, routeBase, relayID string) error {
 	var resp relay.HeartbeatResponse
-	return b.postJSON(ctx, "/api/v1/volunteers/"+relayID+"/heartbeat", map[string]bool{"ok": true}, &resp)
+	return b.postJSON(ctx, routeBase+relayID+"/heartbeat", map[string]bool{"ok": true}, &resp)
+}
+
+// brokerHTTPError is a non-2xx broker response.
+type brokerHTTPError struct {
+	path             string
+	statusCode       int
+	message          string
+	routeUnsupported bool
+}
+
+func (e *brokerHTTPError) Error() string {
+	return fmt.Sprintf("broker %s: %s", e.path, e.message)
+}
+
+func isRouteUnsupported(err error) bool {
+	var responseErr *brokerHTTPError
+	return errors.As(err, &responseErr) && responseErr.routeUnsupported
 }
 
 func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out any) error {
@@ -91,15 +156,29 @@ func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out a
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errorBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBrokerErrorBodyBytes+1))
+		bodyWithinLimit := len(errorBody) <= maxBrokerErrorBodyBytes
 		var apiErr relay.ErrorResponse
-		_ = json.NewDecoder(resp.Body).Decode(&apiErr)
+		if readErr == nil && bodyWithinLimit {
+			_ = json.Unmarshal(errorBody, &apiErr)
+		}
 		if apiErr.Error == "" {
 			apiErr.Error = resp.Status
 		}
 		if resp.StatusCode == http.StatusNotFound && apiErr.Error == "relay not found" {
 			return fmt.Errorf("broker %s: %w", path, ErrRelayNotFound)
 		}
-		return fmt.Errorf("broker %s: %s", path, apiErr.Error)
+		mediaType, _, _ := strings.Cut(resp.Header.Get("Content-Type"), ";")
+		legacyMux404 := resp.StatusCode == http.StatusNotFound &&
+			readErr == nil && bodyWithinLimit &&
+			strings.EqualFold(strings.TrimSpace(mediaType), "text/plain") &&
+			bytes.Equal(errorBody, []byte(legacyServeMuxNotFoundBody))
+		return &brokerHTTPError{
+			path:             path,
+			statusCode:       resp.StatusCode,
+			message:          apiErr.Error,
+			routeUnsupported: resp.StatusCode == http.StatusMethodNotAllowed || legacyMux404,
+		}
 	}
 	if out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {

--- a/internal/tunnel/registrar_test.go
+++ b/internal/tunnel/registrar_test.go
@@ -1,0 +1,620 @@
+package tunnel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+const (
+	canonicalRegisterPath = "/api/v1/relays/register"
+	legacyRegisterPath    = "/api/v1/volunteers/register"
+)
+
+func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC)
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		if got := r.Header.Get("Authorization"); got != "Bearer relay-token" {
+			http.Error(w, "missing authorization", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{
+				ID:         "relay_canonical",
+				PublicHost: "203.0.113.10",
+				PublicPort: 443,
+				ExpiresAt:  expiresAt,
+			})
+		case "/api/v1/relays/relay_canonical/heartbeat":
+			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true, ExpiresAt: expiresAt})
+		default:
+			writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	registrar := NewBrokerRegistrar(server.URL, "relay-token", server.Client())
+	got, err := registrar.Register(context.Background(), testRegisterRequest())
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	want := RelayRegistration{
+		RelayID:    "relay_canonical",
+		PublicHost: "203.0.113.10",
+		PublicPort: 443,
+		ExpiresAt:  expiresAt,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Register() = %+v, want %+v", got, want)
+	}
+	if err := registrar.Heartbeat(context.Background(), got.RelayID); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	wantPaths := []string{
+		canonicalRegisterPath,
+		"/api/v1/relays/relay_canonical/heartbeat",
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
+	}
+}
+
+func TestBrokerRegistrarRegister404FallbackIsSticky(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			http.NotFound(w, r) // matches an old broker's ServeMux response
+		case legacyRegisterPath:
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_legacy"})
+		case "/api/v1/volunteers/relay_legacy/heartbeat":
+			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
+		case "/api/v1/volunteers/relay_missing/heartbeat":
+			writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
+		default:
+			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+	for i := 0; i < 2; i++ {
+		if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
+			t.Fatalf("Register() call %d error = %v", i+1, err)
+		}
+	}
+	if err := registrar.Heartbeat(context.Background(), "relay_legacy"); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+	if err := registrar.Heartbeat(context.Background(), "relay_missing"); !errors.Is(err, ErrRelayNotFound) {
+		t.Fatalf("Heartbeat() missing relay error = %v, want ErrRelayNotFound", err)
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	wantPaths := []string{
+		canonicalRegisterPath,
+		legacyRegisterPath,
+		legacyRegisterPath,
+		"/api/v1/volunteers/relay_legacy/heartbeat",
+		"/api/v1/volunteers/relay_missing/heartbeat",
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
+	}
+}
+
+func TestBrokerRegistrarHeartbeatFirst405FallbackIsSticky(t *testing.T) {
+	t.Parallel()
+
+	type observedRequest struct {
+		path        string
+		authorize   string
+		contentType string
+		body        []byte
+	}
+	var (
+		mu       sync.Mutex
+		requests []observedRequest
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests = append(requests, observedRequest{
+			path:        r.URL.Path,
+			authorize:   r.Header.Get("Authorization"),
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+		})
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case "/api/v1/relays/relay_existing/heartbeat":
+			writeRegistrarJSON(w, http.StatusMethodNotAllowed, relay.ErrorResponse{Error: "method not allowed"})
+		case "/api/v1/volunteers/relay_existing/heartbeat":
+			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
+		case legacyRegisterPath:
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_existing"})
+		default:
+			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	registrar := NewBrokerRegistrar(server.URL, "relay-token", server.Client())
+	if err := registrar.Heartbeat(context.Background(), "relay_existing"); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	mu.Lock()
+	gotRequests := append([]observedRequest(nil), requests...)
+	mu.Unlock()
+	if len(gotRequests) != 3 {
+		t.Fatalf("request count = %d, want 3: %+v", len(gotRequests), gotRequests)
+	}
+	wantPaths := []string{
+		"/api/v1/relays/relay_existing/heartbeat",
+		"/api/v1/volunteers/relay_existing/heartbeat",
+		legacyRegisterPath,
+	}
+	for i, wantPath := range wantPaths {
+		if gotRequests[i].path != wantPath {
+			t.Errorf("request %d path = %q, want %q", i+1, gotRequests[i].path, wantPath)
+		}
+		if gotRequests[i].authorize != "Bearer relay-token" {
+			t.Errorf("request %d Authorization = %q, want bearer token", i+1, gotRequests[i].authorize)
+		}
+		if gotRequests[i].contentType != "application/json" {
+			t.Errorf("request %d Content-Type = %q, want application/json", i+1, gotRequests[i].contentType)
+		}
+	}
+	if !bytes.Equal(gotRequests[0].body, gotRequests[1].body) {
+		t.Errorf("heartbeat retry body = %q, want canonical body %q", gotRequests[1].body, gotRequests[0].body)
+	}
+	if !bytes.Equal(gotRequests[0].body, []byte(`{"ok":true}`)) {
+		t.Errorf("heartbeat body = %q, want {\"ok\":true}", gotRequests[0].body)
+	}
+}
+
+func TestBrokerRegistrarFallbackPreservesRegisterRequest(t *testing.T) {
+	t.Parallel()
+
+	type observedRequest struct {
+		path        string
+		authorize   string
+		contentType string
+		body        []byte
+	}
+	var (
+		mu       sync.Mutex
+		requests []observedRequest
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests = append(requests, observedRequest{
+			path:        r.URL.Path,
+			authorize:   r.Header.Get("Authorization"),
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+		})
+		mu.Unlock()
+
+		if r.URL.Path == canonicalRegisterPath {
+			writeRegistrarJSON(w, http.StatusMethodNotAllowed, relay.ErrorResponse{Error: "method not allowed"})
+			return
+		}
+		if r.URL.Path == legacyRegisterPath {
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_legacy"})
+			return
+		}
+		writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+	}))
+	t.Cleanup(server.Close)
+
+	req := testRegisterRequest()
+	registrar := NewBrokerRegistrar(server.URL, "relay-token", server.Client())
+	if _, err := registrar.Register(context.Background(), req); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	mu.Lock()
+	gotRequests := append([]observedRequest(nil), requests...)
+	mu.Unlock()
+	if len(gotRequests) != 2 {
+		t.Fatalf("request count = %d, want 2: %+v", len(gotRequests), gotRequests)
+	}
+	if gotRequests[0].path != canonicalRegisterPath || gotRequests[1].path != legacyRegisterPath {
+		t.Fatalf("request paths = [%q %q], want [%q %q]", gotRequests[0].path, gotRequests[1].path, canonicalRegisterPath, legacyRegisterPath)
+	}
+	wantBody, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal(register request) error = %v", err)
+	}
+	for i, got := range gotRequests {
+		if got.authorize != "Bearer relay-token" {
+			t.Errorf("request %d Authorization = %q, want bearer token", i+1, got.authorize)
+		}
+		if got.contentType != "application/json" {
+			t.Errorf("request %d Content-Type = %q, want application/json", i+1, got.contentType)
+		}
+		if !bytes.Equal(got.body, wantBody) {
+			t.Errorf("request %d body = %q, want %q", i+1, got.body, wantBody)
+		}
+	}
+}
+
+func TestBrokerRegistrarRelayNotFoundDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case "/api/v1/relays/relay_missing/heartbeat":
+			writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
+		case canonicalRegisterPath:
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_new"})
+		default:
+			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "legacy route must not be called"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+	err := registrar.Heartbeat(context.Background(), "relay_missing")
+	if !errors.Is(err, ErrRelayNotFound) {
+		t.Fatalf("Heartbeat() error = %v, want ErrRelayNotFound", err)
+	}
+	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
+		t.Fatalf("Register() after relay-not-found error = %v", err)
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	wantPaths := []string{
+		"/api/v1/relays/relay_missing/heartbeat",
+		canonicalRegisterPath,
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
+	}
+}
+
+func TestBrokerRegistrarDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{
+		http.StatusNotFound,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	} {
+		status := status
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			var canonical, legacy atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case canonicalRegisterPath:
+					canonical.Add(1)
+					writeRegistrarJSON(w, status, relay.ErrorResponse{Error: "deliberate failure"})
+				case legacyRegisterPath:
+					legacy.Add(1)
+					writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
+				default:
+					writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+			if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
+				t.Fatal("Register() error = nil, want failure")
+			}
+			if got := canonical.Load(); got != 1 {
+				t.Errorf("canonical request count = %d, want 1", got)
+			}
+			if got := legacy.Load(); got != 0 {
+				t.Errorf("legacy request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBrokerRegistrarDoesNotFallbackOnOther404Shapes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+	}{
+		{name: "empty body", contentType: "text/plain; charset=utf-8"},
+		{name: "HTML body", contentType: "text/html; charset=utf-8", body: "<h1>Not Found</h1>"},
+		{name: "malformed JSON", contentType: "application/json", body: `{"error":`},
+		{name: "other plaintext", contentType: "text/plain; charset=utf-8", body: "route not found\n"},
+		{name: "legacy body with wrong type", contentType: "text/html", body: legacyServeMuxNotFoundBody},
+		{name: "plaintext prefix type", contentType: "text/plain-legacy", body: legacyServeMuxNotFoundBody},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var canonical, legacy atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case canonicalRegisterPath:
+					canonical.Add(1)
+					w.Header().Set("Content-Type", tc.contentType)
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = io.WriteString(w, tc.body)
+				case legacyRegisterPath:
+					legacy.Add(1)
+					writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
+				default:
+					writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+			if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
+				t.Fatal("Register() error = nil, want 404 failure")
+			}
+			if got := canonical.Load(); got != 1 {
+				t.Errorf("canonical request count = %d, want 1", got)
+			}
+			if got := legacy.Load(); got != 0 {
+				t.Errorf("legacy request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBrokerRegistrarRefusesRedirectsWithoutFallback(t *testing.T) {
+	t.Parallel()
+
+	for _, redirectStatus := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		redirectStatus := redirectStatus
+		t.Run(http.StatusText(redirectStatus), func(t *testing.T) {
+			t.Parallel()
+
+			var canonical, redirected, legacy atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case canonicalRegisterPath:
+					canonical.Add(1)
+					http.Redirect(w, r, "/redirect-target", redirectStatus)
+				case "/redirect-target":
+					redirected.Add(1)
+					writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "route not found"})
+				case legacyRegisterPath:
+					legacy.Add(1)
+					writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
+				default:
+					writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+			for i := 0; i < 2; i++ {
+				if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
+					t.Fatalf("Register() call %d error = nil, want redirected failure", i+1)
+				}
+			}
+			if got := canonical.Load(); got != 2 {
+				t.Errorf("canonical request count = %d, want 2", got)
+			}
+			if got := redirected.Load(); got != 0 {
+				t.Errorf("redirect-target request count = %d, want 0", got)
+			}
+			if got := legacy.Load(); got != 0 {
+				t.Errorf("legacy request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBrokerRegistrarDoesNotFallbackOnNetworkError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		if req.URL.Path != canonicalRegisterPath {
+			t.Errorf("request path = %q, want %q", req.URL.Path, canonicalRegisterPath)
+		}
+		return nil, errors.New("network unavailable")
+	})}
+	registrar := NewBrokerRegistrar("http://broker.invalid", "", client)
+	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
+		t.Fatal("Register() error = nil, want network failure")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("HTTP request count = %d, want 1", got)
+	}
+}
+
+func TestBrokerRegistrarDoesNotFallbackOnDecodeError(t *testing.T) {
+	t.Parallel()
+
+	var canonical, legacy atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			canonical.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":`)
+		case legacyRegisterPath:
+			legacy.Add(1)
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
+		default:
+			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
+		t.Fatal("Register() error = nil, want decode failure")
+	}
+	if got := canonical.Load(); got != 1 {
+		t.Errorf("canonical request count = %d, want 1", got)
+	}
+	if got := legacy.Load(); got != 0 {
+		t.Errorf("legacy request count = %d, want 0", got)
+	}
+}
+
+func TestBrokerRegistrarConcurrentLegacyDiscovery(t *testing.T) {
+	t.Parallel()
+
+	const workers = 48
+	var canonical, legacy atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			canonical.Add(1)
+			http.NotFound(w, r)
+		case legacyRegisterPath:
+			legacy.Add(1)
+			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_legacy"})
+		default:
+			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := registrar.Register(context.Background(), testRegisterRequest())
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent Register() error = %v", err)
+		}
+	}
+
+	canonicalAfterDiscovery := canonical.Load()
+	if canonicalAfterDiscovery < 1 || canonicalAfterDiscovery > workers {
+		t.Errorf("canonical discovery request count = %d, want between 1 and %d", canonicalAfterDiscovery, workers)
+	}
+	if got := legacy.Load(); got != workers {
+		t.Errorf("legacy request count = %d, want %d", got, workers)
+	}
+
+	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
+		t.Fatalf("Register() after concurrent discovery error = %v", err)
+	}
+	if got := canonical.Load(); got != canonicalAfterDiscovery {
+		t.Errorf("canonical requests after sticky fallback = %d, want %d", got, canonicalAfterDiscovery)
+	}
+	if got := legacy.Load(); got != workers+1 {
+		t.Errorf("legacy requests after sticky fallback = %d, want %d", got, workers+1)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testRegisterRequest() relay.RegisterRequest {
+	return relay.RegisterRequest{
+		PublicHost:       "198.51.100.20",
+		PublicPort:       8443,
+		Protocol:         relay.ProtocolVLESSRealityVision,
+		ClientID:         "11111111-2222-3333-4444-555555555555",
+		RealityPublicKey: "test-reality-public-key",
+		ShortID:          "0123456789abcdef",
+		ServerName:       "www.example.com",
+		Flow:             relay.FlowVision,
+		ExitMode:         relay.ExitModeDirect,
+		MaxSessions:      32,
+		MaxMbps:          100,
+		RelayVersion:     "test-version",
+		Label:            "test-relay",
+		NodeClass:        relay.NodeClassVolunteer,
+		Transport:        relay.TransportTunnel,
+		PunchCapable:     true,
+		PunchEndpoint:    "https://198.51.100.20:9444",
+		ExitHost:         "192.0.2.30",
+	}
+}
+
+func writeRegistrarJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -263,7 +263,7 @@ func TestHubReregistersWhenBrokerForgetsRelay(t *testing.T) {
 	echoHost, echoPort := startEchoServer(t)
 	registrar := &fakeRegistrar{
 		relayIDs:          []string{"relay_old", "relay_new"},
-		failHeartbeatOnce: fmt.Errorf("broker /api/v1/volunteers/relay_old/heartbeat: %w", ErrRelayNotFound),
+		failHeartbeatOnce: fmt.Errorf("broker /api/v1/relays/relay_old/heartbeat: %w", ErrRelayNotFound),
 		releaseHeartbeat:  make(chan struct{}),
 	}
 	hub, controlAddr, _ := startTestHub(t, registrar, "secret")


### PR DESCRIPTION
## Summary

- make the relay hub prefer the canonical `/api/v1/relays` register and heartbeat routes
- switch the registrar to the legacy `/api/v1/volunteers` route family only after a route-not-supported response
- keep that compatibility decision sticky and race-safe across registrations and heartbeats
- preserve request payloads, bearer authentication, and `ErrRelayNotFound` behavior
- refuse redirects so credentials cannot be forwarded and redirected 404/405 responses cannot trigger fallback
- document the hub's route negotiation behavior

## Fallback boundary

A canonical response activates the legacy route family only when it is:

- `405 Method Not Allowed`; or
- the exact bounded plaintext 404 signature emitted by the old Go ServeMux for an unregistered route

Structured relay-not-found errors, other 404 bodies, redirects, authentication failures, rate limits, server failures, network errors, and decode errors do not trigger fallback.

## Scope and rollout

This changes only the relay hub registrar. Direct relay runtime callers remain on their current routes for a later rollout step. The production broker already accepts the canonical route family; the sticky fallback protects older, private, or rolled-back broker deployments.

## Validation

- `go test -race ./internal/tunnel -run '^TestBrokerRegistrar' -count=1`
- `go test -race ./...`
- `env GOCACHE=/private/tmp/openrung-go-cache go vet ./...`
- `git diff --check`
- independent final code review: no findings
