### PR TITLE
Migrate direct relays to canonical broker routes

### DIFF
--- a/cmd/volunteer/main.go
+++ b/cmd/volunteer/main.go
@@ -401,7 +401,8 @@ func run(cfg cliConfig) error {
 	// would publish a live foundation lease that a subsequent bind failure
 	// could strand. Any registration failure, including a rejected foundation
 	// attestation, tears the relay down below.
-	desc, err := register(ctx, cfg, prepared)
+	broker := cfg.brokerClient()
+	desc, err := register(ctx, broker, cfg, prepared)
 	if err != nil {
 		if xrayCmd != nil {
 			stopProcess(xrayCmd, errCh)
@@ -437,7 +438,7 @@ func run(cfg cliConfig) error {
 				return fmt.Errorf("connection observer stopped: %w", err)
 			}
 		case <-ticker.C:
-			updatedDesc, reRegistered, err := heartbeatOrRegister(ctx, cfg, prepared, desc)
+			updatedDesc, reRegistered, err := heartbeatOrRegister(ctx, broker, cfg, prepared, desc)
 			if err != nil {
 				slog.Warn("heartbeat failed", "error", err)
 				continue
@@ -584,13 +585,13 @@ func boolEnv(key string) bool {
 	}
 }
 
-func heartbeatOrRegister(ctx context.Context, cfg cliConfig, prepared preparedRuntime, desc relay.Descriptor) (relay.Descriptor, bool, error) {
-	if err := heartbeat(ctx, cfg, desc.ID); err != nil {
+func heartbeatOrRegister(ctx context.Context, broker *volunteer.BrokerClient, cfg cliConfig, prepared preparedRuntime, desc relay.Descriptor) (relay.Descriptor, bool, error) {
+	if err := heartbeat(ctx, broker, desc.ID); err != nil {
 		if !volunteer.IsRelayNotFound(err) {
 			return desc, false, err
 		}
 
-		updatedDesc, registerErr := register(ctx, cfg, prepared)
+		updatedDesc, registerErr := register(ctx, broker, cfg, prepared)
 		if registerErr != nil {
 			return desc, false, fmt.Errorf("re-register relay after broker forgot %s: %w", desc.ID, registerErr)
 		}
@@ -664,7 +665,7 @@ func prepareRuntime(cfg cliConfig) (preparedRuntime, error) {
 	}, nil
 }
 
-func register(ctx context.Context, cfg cliConfig, prepared preparedRuntime) (relay.Descriptor, error) {
+func register(ctx context.Context, broker *volunteer.BrokerClient, cfg cliConfig, prepared preparedRuntime) (relay.Descriptor, error) {
 	// The foundation token's cleartext-transport guard lives in BrokerClient
 	// (RequireSecureTransport, set by brokerClient() for foundation), so it
 	// covers heartbeat as well as registration and also refuses redirects.
@@ -684,7 +685,7 @@ func register(ctx context.Context, cfg cliConfig, prepared preparedRuntime) (rel
 		Label:            cfg.Label,
 		NodeClass:        cfg.NodeClass,
 	}
-	desc, err := cfg.brokerClient().Register(ctx, req)
+	desc, err := broker.Register(ctx, req)
 	if err != nil {
 		return relay.Descriptor{}, err
 	}
@@ -697,11 +698,11 @@ func register(ctx context.Context, cfg cliConfig, prepared preparedRuntime) (rel
 	return desc, nil
 }
 
-func heartbeat(ctx context.Context, cfg cliConfig, id string) error {
-	return cfg.brokerClient().Heartbeat(ctx, id)
+func heartbeat(ctx context.Context, broker *volunteer.BrokerClient, id string) error {
+	return broker.Heartbeat(ctx, id)
 }
 
-func (c cliConfig) brokerClient() volunteer.BrokerClient {
+func (c cliConfig) brokerClient() *volunteer.BrokerClient {
 	// A foundation token is the bearer and, on its own, requires secure
 	// transport (https + redirect refusal), so the guarantee holds even if the
 	// posture normalization above has not run for this config.
@@ -709,7 +710,7 @@ func (c cliConfig) brokerClient() volunteer.BrokerClient {
 	if c.FoundationToken != "" {
 		token = c.FoundationToken
 	}
-	return volunteer.BrokerClient{
+	return &volunteer.BrokerClient{
 		BaseURL:                c.BrokerURL,
 		Token:                  token,
 		HTTPClient:             c.HTTPClient,

--- a/cmd/volunteer/main_test.go
+++ b/cmd/volunteer/main_test.go
@@ -16,9 +16,9 @@ func TestHeartbeatOrRegisterRecoversForgottenRelay(t *testing.T) {
 	var registrations atomic.Int32
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch r.URL.Path {
-		case "/api/v1/volunteers/relay_old/heartbeat":
+		case "/api/v1/relays/relay_old/heartbeat":
 			return jsonResponse(http.StatusNotFound, `{"error":"relay not found"}`), nil
-		case "/api/v1/volunteers/register":
+		case "/api/v1/relays/register":
 			registrations.Add(1)
 			return jsonResponse(http.StatusCreated, `{"id":"relay_new","public_host":"relay.example","public_port":443}`), nil
 		default:
@@ -27,7 +27,8 @@ func TestHeartbeatOrRegisterRecoversForgottenRelay(t *testing.T) {
 	})}
 
 	cfg := cliConfig{BrokerURL: "http://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client}
-	desc, reRegistered, err := heartbeatOrRegister(context.Background(), cfg, preparedRuntime{}, relay.Descriptor{ID: "relay_old"})
+	broker := cfg.brokerClient()
+	desc, reRegistered, err := heartbeatOrRegister(context.Background(), broker, cfg, preparedRuntime{}, relay.Descriptor{ID: "relay_old"})
 	if err != nil {
 		t.Fatalf("heartbeatOrRegister() error = %v", err)
 	}
@@ -45,15 +46,16 @@ func TestHeartbeatOrRegisterRecoversForgottenRelay(t *testing.T) {
 func TestHeartbeatOrRegisterDoesNotRegisterOnOtherErrors(t *testing.T) {
 	var registrations atomic.Int32
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		if r.URL.Path == "/api/v1/volunteers/register" {
+		if r.URL.Path == "/api/v1/relays/register" {
 			registrations.Add(1)
 		}
 		return jsonResponse(http.StatusInternalServerError, `{"error":"temporary failure"}`), nil
 	})}
 
 	cfg := cliConfig{BrokerURL: "http://broker.test", HTTPClient: client}
+	broker := cfg.brokerClient()
 	original := relay.Descriptor{ID: "relay_old"}
-	desc, reRegistered, err := heartbeatOrRegister(context.Background(), cfg, preparedRuntime{}, original)
+	desc, reRegistered, err := heartbeatOrRegister(context.Background(), broker, cfg, preparedRuntime{}, original)
 	if err == nil {
 		t.Fatal("heartbeatOrRegister() error = nil, want an error")
 	}
@@ -177,7 +179,7 @@ func TestRegisterRejectsUnattestedFoundationClass(t *testing.T) {
 	})}
 
 	cfg := cliConfig{BrokerURL: "http://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client, NodeClass: relay.NodeClassFoundation}
-	if _, err := register(context.Background(), cfg, preparedRuntime{}); err == nil {
+	if _, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{}); err == nil {
 		t.Fatal("register() error = nil, want an unattested-node-class error")
 	}
 }
@@ -188,7 +190,7 @@ func TestRegisterAcceptsAttestedFoundationClass(t *testing.T) {
 	})}
 
 	cfg := cliConfig{BrokerURL: "https://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client, NodeClass: relay.NodeClassFoundation}
-	desc, err := register(context.Background(), cfg, preparedRuntime{})
+	desc, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{})
 	if err != nil {
 		t.Fatalf("register() error = %v", err)
 	}
@@ -207,7 +209,7 @@ func TestRegisterRefusesFoundationOverPlaintext(t *testing.T) {
 		return jsonResponse(http.StatusCreated, `{"id":"relay_new","node_class":"foundation"}`), nil
 	})}
 	cfg := cliConfig{BrokerURL: "http://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client, NodeClass: relay.NodeClassFoundation}
-	if _, err := register(context.Background(), cfg, preparedRuntime{}); err == nil {
+	if _, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{}); err == nil {
 		t.Fatal("register() error = nil, want a cleartext-broker error")
 	}
 	if sent.Load() != 0 {
@@ -229,7 +231,7 @@ func TestHeartbeatRefusesFoundationOverPlaintext(t *testing.T) {
 		HTTPClient:        client,
 		NodeClass:         relay.NodeClassFoundation,
 	}
-	if err := heartbeat(context.Background(), cfg, "relay_foundation"); err == nil {
+	if err := heartbeat(context.Background(), cfg.brokerClient(), "relay_foundation"); err == nil {
 		t.Fatal("heartbeat() error = nil, want a cleartext-broker error")
 	}
 	if sent.Load() != 0 {
@@ -266,7 +268,7 @@ func TestFoundationTokenRegistersAsFoundationWithoutNodeClass(t *testing.T) {
 	if cfg.Mode != "direct" {
 		t.Fatalf("mode = %q, want direct (forced by the token)", cfg.Mode)
 	}
-	desc, err := register(context.Background(), cfg, preparedRuntime{})
+	desc, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{})
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -332,7 +334,7 @@ func TestFoundationTokenRefusesPlaintextBroker(t *testing.T) {
 	if err := cfg.ApplyDefaults(); err != nil {
 		t.Fatalf("ApplyDefaults: %v", err)
 	}
-	if _, err := register(context.Background(), cfg, preparedRuntime{}); err == nil {
+	if _, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{}); err == nil {
 		t.Fatal("register() error = nil, want a cleartext-broker refusal")
 	}
 	if sent.Load() != 0 {

--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -3,11 +3,12 @@
 The broker runs plaintext HTTP on `:8080`. Fronts terminate client TLS at the
 edge, but the **edge → origin** leg was HTTP. On the AWS CloudFront front
 (distribution `E2PLKW8FO3JZSA`, `d2r7mdpyevvs1m.cloudfront.net`) that leg
-carried the high-value **Foundation registration token** (`Authorization`
-header on the shipped runtime's `POST /api/v1/volunteers/register` request) in
-cleartext across the public internet. This runbook closes that leg with a
-TLS-terminating reverse proxy on the broker box so the token is encrypted
-**relay → CloudFront edge → origin**.
+carried the high-value **Foundation registration token** (the `Authorization`
+header on relay registration requests) in cleartext across the public internet.
+This runbook closes that leg with a TLS-terminating reverse proxy on the broker
+box so the token is encrypted **relay → CloudFront edge → origin**. Current
+relays use `POST /api/v1/relays/register`; older runtimes used the compatibility
+path below.
 
 The legacy `POST /api/v1/volunteers/register` route reaches the same handler and
 is retained as a compatibility alias with no scheduled removal date. New

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,14 @@ as `node_class: "volunteer"`; relays presenting the Foundation credential
 register as `node_class: "foundation"`. The broker attests this provenance in
 the signed relay directory. It is not a quality score or a trust bypass.
 
+Direct-mode relays, including the desktop relay engine, prefer the canonical
+`POST /api/v1/relays/register` and `/api/v1/relays/{id}/heartbeat` routes. If a
+broker reports either route unsupported with the old ServeMux's exact
+route-missing `404` response or with `405`, that runtime selects the legacy
+`/api/v1/volunteers/...` compatibility route family for all subsequent
+registrations and heartbeats. The selection is sticky across reconnects; other
+broker errors never trigger fallback, and broker redirects are refused.
+
 The CLI produces an Xray server config with:
 
 - VLESS inbound.

--- a/internal/volunteer/broker.go
+++ b/internal/volunteer/broker.go
@@ -6,31 +6,65 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"openrung/internal/relay"
 )
 
+const (
+	canonicalRegisterPath      = "/api/v1/relays/register"
+	legacyRegisterPath         = "/api/v1/volunteers/register"
+	canonicalHeartbeatPathBase = "/api/v1/relays/"
+	legacyHeartbeatPathBase    = "/api/v1/volunteers/"
+	maxBrokerErrorBodyBytes    = 64 << 10
+	legacyServeMuxNotFoundBody = "404 page not found\n"
+)
+
 // BrokerClient speaks the relay side of the broker HTTP API: registration
 // and heartbeats. The zero HTTPClient falls back to http.DefaultClient; Token
-// is optional (anonymous registration when the broker allows it).
+// is optional (anonymous registration when the broker allows it). A
+// BrokerClient must not be copied after first use so its route selection stays
+// shared.
 type BrokerClient struct {
 	BaseURL    string
 	Token      string
 	HTTPClient *http.Client
-	// RequireSecureTransport refuses plaintext non-loopback broker URLs and
-	// all redirects. It is enabled for the high-value foundation credential;
-	// loopback HTTP remains available for local integration tests.
+	// RequireSecureTransport refuses plaintext non-loopback broker URLs. It is
+	// enabled for the high-value foundation credential; loopback HTTP remains
+	// available for local integration tests. All broker requests refuse
+	// redirects regardless of this setting.
 	RequireSecureTransport bool
+
+	// legacyRoutes is broker-wide for this client: once either canonical write
+	// endpoint proves unavailable, registration and heartbeats both stay on the
+	// compatibility route family. Atomic state makes concurrent desktop-engine
+	// requests race-safe and keeps the transition monotonic.
+	legacyRoutes atomic.Bool
 }
 
 // Register announces the relay and returns the broker-minted descriptor.
-func (b BrokerClient) Register(ctx context.Context, req relay.RegisterRequest) (relay.Descriptor, error) {
+func (b *BrokerClient) Register(ctx context.Context, req relay.RegisterRequest) (relay.Descriptor, error) {
+	if b.legacyRoutes.Load() {
+		return b.registerAt(ctx, legacyRegisterPath, req)
+	}
+
+	desc, err := b.registerAt(ctx, canonicalRegisterPath, req)
+	if !isRouteUnsupported(err) {
+		return desc, err
+	}
+
+	b.legacyRoutes.Store(true)
+	return b.registerAt(ctx, legacyRegisterPath, req)
+}
+
+func (b *BrokerClient) registerAt(ctx context.Context, path string, req relay.RegisterRequest) (relay.Descriptor, error) {
 	var desc relay.Descriptor
-	if err := b.postJSON(ctx, "/api/v1/volunteers/register", req, &desc); err != nil {
+	if err := b.postJSON(ctx, path, req, &desc); err != nil {
 		return relay.Descriptor{}, err
 	}
 	return desc, nil
@@ -38,12 +72,26 @@ func (b BrokerClient) Register(ctx context.Context, req relay.RegisterRequest) (
 
 // Heartbeat renews the relay's lease. A pruned relay yields an APIError with
 // status 404 that IsRelayNotFound recognizes.
-func (b BrokerClient) Heartbeat(ctx context.Context, id string) error {
-	var resp relay.HeartbeatResponse
-	return b.postJSON(ctx, "/api/v1/volunteers/"+id+"/heartbeat", map[string]bool{"ok": true}, &resp)
+func (b *BrokerClient) Heartbeat(ctx context.Context, id string) error {
+	if b.legacyRoutes.Load() {
+		return b.heartbeatAt(ctx, legacyHeartbeatPathBase, id)
+	}
+
+	err := b.heartbeatAt(ctx, canonicalHeartbeatPathBase, id)
+	if !isRouteUnsupported(err) {
+		return err
+	}
+
+	b.legacyRoutes.Store(true)
+	return b.heartbeatAt(ctx, legacyHeartbeatPathBase, id)
 }
 
-func (b BrokerClient) postJSON(ctx context.Context, path string, body any, out any) error {
+func (b *BrokerClient) heartbeatAt(ctx context.Context, pathBase, id string) error {
+	var resp relay.HeartbeatResponse
+	return b.postJSON(ctx, pathBase+id+"/heartbeat", map[string]bool{"ok": true}, &resp)
+}
+
+func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out any) error {
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return err
@@ -68,18 +116,15 @@ func (b BrokerClient) postJSON(ctx context.Context, path string, body any, out a
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	if b.RequireSecureTransport {
-		// Clone the caller's client so the security policy neither mutates a
-		// shared client nor depends on its CheckRedirect setting. Broker API
-		// endpoints are canonical and should never need a redirect; rejecting
-		// every redirect also makes an HTTPS-to-HTTP Authorization leak
-		// impossible.
-		secureClient := *httpClient
-		secureClient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
-			return fmt.Errorf("secure broker request refused redirect to %s", req.URL.Redacted())
-		}
-		httpClient = &secureClient
+	// Clone the caller's client so the policy neither mutates a shared client
+	// nor depends on its CheckRedirect setting. Broker write endpoints never
+	// need a redirect; refusing every redirect prevents forwarding the bearer
+	// token and ensures a redirected 404/405 cannot trigger legacy fallback.
+	noRedirectClient := *httpClient
+	noRedirectClient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		return fmt.Errorf("broker request refused redirect to %s", req.URL.Redacted())
 	}
+	httpClient = &noRedirectClient
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
@@ -87,12 +132,27 @@ func (b BrokerClient) postJSON(ctx context.Context, path string, body any, out a
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errorBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBrokerErrorBodyBytes+1))
+		bodyWithinLimit := len(errorBody) <= maxBrokerErrorBodyBytes
 		var apiErr relay.ErrorResponse
-		_ = json.NewDecoder(resp.Body).Decode(&apiErr)
+		if readErr == nil && bodyWithinLimit {
+			_ = json.Unmarshal(errorBody, &apiErr)
+		}
 		if apiErr.Error == "" {
 			apiErr.Error = resp.Status
 		}
-		return &APIError{Path: path, StatusCode: resp.StatusCode, Message: apiErr.Error, RetryAfter: resp.Header.Get("Retry-After")}
+		mediaType, _, _ := strings.Cut(resp.Header.Get("Content-Type"), ";")
+		legacyMux404 := resp.StatusCode == http.StatusNotFound &&
+			readErr == nil && bodyWithinLimit &&
+			strings.EqualFold(strings.TrimSpace(mediaType), "text/plain") &&
+			bytes.Equal(errorBody, []byte(legacyServeMuxNotFoundBody))
+		return &APIError{
+			Path:             path,
+			StatusCode:       resp.StatusCode,
+			Message:          apiErr.Error,
+			RetryAfter:       resp.Header.Get("Retry-After"),
+			routeUnsupported: resp.StatusCode == http.StatusMethodNotAllowed || legacyMux404,
+		}
 	}
 
 	if out != nil {
@@ -134,6 +194,13 @@ type APIError struct {
 	// RetryAfter is the raw Retry-After header (seconds), present on 429s so
 	// callers can honour the broker's backoff request.
 	RetryAfter string
+
+	routeUnsupported bool
+}
+
+func isRouteUnsupported(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.routeUnsupported
 }
 
 func (e *APIError) Error() string {

--- a/internal/volunteer/broker_test.go
+++ b/internal/volunteer/broker_test.go
@@ -1,16 +1,599 @@
 package volunteer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"openrung/internal/relay"
 )
+
+func TestBrokerClientUsesCanonicalRoutes(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC)
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		if got := r.Header.Get("Authorization"); got != "Bearer relay-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			var req relay.RegisterRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode register request: %v", err)
+			}
+			if !reflect.DeepEqual(req, testBrokerRegisterRequest()) {
+				t.Errorf("register request = %+v, want %+v", req, testBrokerRegisterRequest())
+			}
+			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{
+				ID:         "relay_canonical",
+				PublicHost: "203.0.113.10",
+				PublicPort: 443,
+				ExpiresAt:  expiresAt,
+			})
+		case canonicalHeartbeatPathBase + "relay_canonical/heartbeat":
+			var body map[string]bool
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode heartbeat request: %v", err)
+			}
+			if !body["ok"] {
+				t.Errorf("heartbeat body = %v, want ok=true", body)
+			}
+			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true, ExpiresAt: expiresAt})
+		default:
+			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &BrokerClient{BaseURL: server.URL, Token: "relay-token", HTTPClient: server.Client()}
+	desc, err := client.Register(context.Background(), testBrokerRegisterRequest())
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	want := relay.Descriptor{
+		ID:         "relay_canonical",
+		PublicHost: "203.0.113.10",
+		PublicPort: 443,
+		ExpiresAt:  expiresAt,
+	}
+	if !reflect.DeepEqual(desc, want) {
+		t.Fatalf("Register() = %+v, want %+v", desc, want)
+	}
+	if err := client.Heartbeat(context.Background(), desc.ID); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	wantPaths := []string{
+		canonicalRegisterPath,
+		canonicalHeartbeatPathBase + "relay_canonical/heartbeat",
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
+	}
+}
+
+func TestBrokerClientRegister404FallbackIsSticky(t *testing.T) {
+	t.Parallel()
+
+	type observedRequest struct {
+		path        string
+		authorize   string
+		contentType string
+		body        []byte
+	}
+	var (
+		mu       sync.Mutex
+		requests []observedRequest
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests = append(requests, observedRequest{
+			path:        r.URL.Path,
+			authorize:   r.Header.Get("Authorization"),
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+		})
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			http.NotFound(w, r)
+		case legacyRegisterPath:
+			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_legacy"})
+		case legacyHeartbeatPathBase + "relay_legacy/heartbeat":
+			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
+		case legacyHeartbeatPathBase + "relay_missing/heartbeat":
+			writeBrokerJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
+		default:
+			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	req := testBrokerRegisterRequest()
+	client := &BrokerClient{BaseURL: server.URL, Token: "relay-token", HTTPClient: server.Client()}
+	for i := 0; i < 2; i++ {
+		if _, err := client.Register(context.Background(), req); err != nil {
+			t.Fatalf("Register() call %d error = %v", i+1, err)
+		}
+	}
+	if err := client.Heartbeat(context.Background(), "relay_legacy"); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+	if err := client.Heartbeat(context.Background(), "relay_missing"); !IsRelayNotFound(err) {
+		t.Fatalf("Heartbeat() missing relay error = %v, want relay-not-found API error", err)
+	}
+
+	mu.Lock()
+	gotRequests := append([]observedRequest(nil), requests...)
+	mu.Unlock()
+	wantPaths := []string{
+		canonicalRegisterPath,
+		legacyRegisterPath,
+		legacyRegisterPath,
+		legacyHeartbeatPathBase + "relay_legacy/heartbeat",
+		legacyHeartbeatPathBase + "relay_missing/heartbeat",
+	}
+	if len(gotRequests) != len(wantPaths) {
+		t.Fatalf("request count = %d, want %d: %+v", len(gotRequests), len(wantPaths), gotRequests)
+	}
+	for i, wantPath := range wantPaths {
+		if gotRequests[i].path != wantPath {
+			t.Errorf("request %d path = %q, want %q", i+1, gotRequests[i].path, wantPath)
+		}
+		if gotRequests[i].authorize != "Bearer relay-token" {
+			t.Errorf("request %d Authorization = %q, want bearer token", i+1, gotRequests[i].authorize)
+		}
+		if gotRequests[i].contentType != "application/json" {
+			t.Errorf("request %d Content-Type = %q, want application/json", i+1, gotRequests[i].contentType)
+		}
+	}
+	wantBody, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal(register request) error = %v", err)
+	}
+	for _, index := range []int{0, 1, 2} {
+		if !bytes.Equal(gotRequests[index].body, wantBody) {
+			t.Errorf("register request %d body = %q, want %q", index+1, gotRequests[index].body, wantBody)
+		}
+	}
+}
+
+func TestBrokerClientHeartbeatFirst405FallbackIsSticky(t *testing.T) {
+	t.Parallel()
+
+	type observedRequest struct {
+		path        string
+		authorize   string
+		contentType string
+		body        []byte
+	}
+	var (
+		mu       sync.Mutex
+		requests []observedRequest
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests = append(requests, observedRequest{
+			path:        r.URL.Path,
+			authorize:   r.Header.Get("Authorization"),
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+		})
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case canonicalHeartbeatPathBase + "relay_existing/heartbeat":
+			writeBrokerJSON(w, http.StatusMethodNotAllowed, relay.ErrorResponse{Error: "method not allowed"})
+		case legacyHeartbeatPathBase + "relay_existing/heartbeat":
+			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
+		case legacyRegisterPath:
+			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_existing"})
+		default:
+			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &BrokerClient{BaseURL: server.URL, Token: "relay-token", HTTPClient: server.Client()}
+	if err := client.Heartbeat(context.Background(), "relay_existing"); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+	if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	mu.Lock()
+	gotRequests := append([]observedRequest(nil), requests...)
+	mu.Unlock()
+	wantPaths := []string{
+		canonicalHeartbeatPathBase + "relay_existing/heartbeat",
+		legacyHeartbeatPathBase + "relay_existing/heartbeat",
+		legacyRegisterPath,
+	}
+	if len(gotRequests) != len(wantPaths) {
+		t.Fatalf("request count = %d, want %d: %+v", len(gotRequests), len(wantPaths), gotRequests)
+	}
+	for i, wantPath := range wantPaths {
+		if gotRequests[i].path != wantPath {
+			t.Errorf("request %d path = %q, want %q", i+1, gotRequests[i].path, wantPath)
+		}
+		if gotRequests[i].authorize != "Bearer relay-token" {
+			t.Errorf("request %d Authorization = %q, want bearer token", i+1, gotRequests[i].authorize)
+		}
+		if gotRequests[i].contentType != "application/json" {
+			t.Errorf("request %d Content-Type = %q, want application/json", i+1, gotRequests[i].contentType)
+		}
+	}
+	if !bytes.Equal(gotRequests[0].body, gotRequests[1].body) {
+		t.Errorf("heartbeat retry body = %q, want canonical body %q", gotRequests[1].body, gotRequests[0].body)
+	}
+	if !bytes.Equal(gotRequests[0].body, []byte(`{"ok":true}`)) {
+		t.Errorf("heartbeat body = %q, want {\"ok\":true}", gotRequests[0].body)
+	}
+}
+
+func TestBrokerClientRelayNotFoundDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case canonicalHeartbeatPathBase + "relay_missing/heartbeat":
+			writeBrokerJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
+		case canonicalRegisterPath:
+			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_new"})
+		default:
+			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "legacy route must not be called"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
+	err := client.Heartbeat(context.Background(), "relay_missing")
+	if !IsRelayNotFound(err) {
+		t.Fatalf("Heartbeat() error = %v, want relay-not-found API error", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Heartbeat() error type = %T, want *APIError", err)
+	}
+	if apiErr.Path != canonicalHeartbeatPathBase+"relay_missing/heartbeat" || apiErr.StatusCode != http.StatusNotFound || apiErr.Message != "relay not found" {
+		t.Errorf("APIError = %+v, want canonical 404 relay not found", apiErr)
+	}
+	if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err != nil {
+		t.Fatalf("Register() after relay-not-found error = %v", err)
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	wantPaths := []string{
+		canonicalHeartbeatPathBase + "relay_missing/heartbeat",
+		canonicalRegisterPath,
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
+	}
+}
+
+func TestBrokerClientDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{
+		http.StatusNotFound,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	} {
+		status := status
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			var canonical, legacy atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case canonicalRegisterPath:
+					canonical.Add(1)
+					if status == http.StatusTooManyRequests {
+						w.Header().Set("Retry-After", "17")
+					}
+					writeBrokerJSON(w, status, relay.ErrorResponse{Error: "deliberate failure"})
+				case legacyRegisterPath:
+					legacy.Add(1)
+					writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
+				default:
+					writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
+			for i := 0; i < 2; i++ {
+				_, err := client.Register(context.Background(), testBrokerRegisterRequest())
+				if err == nil {
+					t.Fatalf("Register() call %d error = nil, want failure", i+1)
+				}
+				var apiErr *APIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("Register() call %d error type = %T, want *APIError", i+1, err)
+				}
+				if apiErr.Path != canonicalRegisterPath || apiErr.StatusCode != status || apiErr.Message != "deliberate failure" {
+					t.Errorf("APIError = %+v, want canonical status %d", apiErr, status)
+				}
+				if status == http.StatusTooManyRequests && apiErr.RetryAfter != "17" {
+					t.Errorf("RetryAfter = %q, want 17", apiErr.RetryAfter)
+				}
+			}
+			if got := canonical.Load(); got != 2 {
+				t.Errorf("canonical request count = %d, want 2", got)
+			}
+			if got := legacy.Load(); got != 0 {
+				t.Errorf("legacy request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBrokerClientDoesNotFallbackOnOther404Shapes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+	}{
+		{name: "empty body", contentType: "text/plain; charset=utf-8"},
+		{name: "HTML body", contentType: "text/html; charset=utf-8", body: "<h1>Not Found</h1>"},
+		{name: "malformed JSON", contentType: "application/json", body: `{"error":`},
+		{name: "other plaintext", contentType: "text/plain; charset=utf-8", body: "route not found\n"},
+		{name: "legacy body with wrong type", contentType: "text/html", body: legacyServeMuxNotFoundBody},
+		{name: "plaintext prefix type", contentType: "text/plain-legacy", body: legacyServeMuxNotFoundBody},
+		{name: "oversized body", contentType: "text/plain; charset=utf-8", body: legacyServeMuxNotFoundBody + strings.Repeat("x", maxBrokerErrorBodyBytes)},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var canonical, legacy atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case canonicalRegisterPath:
+					canonical.Add(1)
+					w.Header().Set("Content-Type", tc.contentType)
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = io.WriteString(w, tc.body)
+				case legacyRegisterPath:
+					legacy.Add(1)
+					writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
+				default:
+					writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
+			for i := 0; i < 2; i++ {
+				if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err == nil {
+					t.Fatalf("Register() call %d error = nil, want 404 failure", i+1)
+				}
+			}
+			if got := canonical.Load(); got != 2 {
+				t.Errorf("canonical request count = %d, want 2", got)
+			}
+			if got := legacy.Load(); got != 0 {
+				t.Errorf("legacy request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBrokerClientRefusesRedirectsWithoutFallback(t *testing.T) {
+	t.Parallel()
+
+	for _, redirectStatus := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		redirectStatus := redirectStatus
+		t.Run(http.StatusText(redirectStatus), func(t *testing.T) {
+			t.Parallel()
+
+			var canonical, redirected, legacy atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case canonicalRegisterPath:
+					canonical.Add(1)
+					http.Redirect(w, r, "/redirect-target", redirectStatus)
+				case "/redirect-target":
+					redirected.Add(1)
+					writeBrokerJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "route not found"})
+				case legacyRegisterPath:
+					legacy.Add(1)
+					writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
+				default:
+					writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client := &BrokerClient{BaseURL: server.URL, Token: "relay-token", HTTPClient: server.Client()}
+			for i := 0; i < 2; i++ {
+				_, err := client.Register(context.Background(), testBrokerRegisterRequest())
+				if err == nil || !strings.Contains(err.Error(), "refused redirect") {
+					t.Fatalf("Register() call %d error = %v, want redirect refusal", i+1, err)
+				}
+			}
+			if got := canonical.Load(); got != 2 {
+				t.Errorf("canonical request count = %d, want 2", got)
+			}
+			if got := redirected.Load(); got != 0 {
+				t.Errorf("redirect-target request count = %d, want 0", got)
+			}
+			if got := legacy.Load(); got != 0 {
+				t.Errorf("legacy request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBrokerClientDoesNotFallbackOnNetworkOrDecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("network", func(t *testing.T) {
+		var calls atomic.Int64
+		httpClient := &http.Client{Transport: brokerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			if req.URL.Path != canonicalRegisterPath {
+				t.Errorf("request path = %q, want %q", req.URL.Path, canonicalRegisterPath)
+			}
+			return nil, errors.New("network unavailable")
+		})}
+		client := &BrokerClient{BaseURL: "http://broker.invalid", HTTPClient: httpClient}
+		for i := 0; i < 2; i++ {
+			if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err == nil {
+				t.Fatalf("Register() call %d error = nil, want network failure", i+1)
+			}
+		}
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("HTTP request count = %d, want 2", got)
+		}
+	})
+
+	t.Run("decode", func(t *testing.T) {
+		var canonical, legacy atomic.Int64
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case canonicalRegisterPath:
+				canonical.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{"id":`)
+			case legacyRegisterPath:
+				legacy.Add(1)
+				writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
+			default:
+				writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
+		for i := 0; i < 2; i++ {
+			if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err == nil {
+				t.Fatalf("Register() call %d error = nil, want decode failure", i+1)
+			}
+		}
+		if got := canonical.Load(); got != 2 {
+			t.Errorf("canonical request count = %d, want 2", got)
+		}
+		if got := legacy.Load(); got != 0 {
+			t.Errorf("legacy request count = %d, want 0", got)
+		}
+	})
+}
+
+func TestBrokerClientConcurrentLegacyDiscovery(t *testing.T) {
+	t.Parallel()
+
+	const workers = 48
+	var canonical, legacy atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case canonicalRegisterPath:
+			canonical.Add(1)
+			http.NotFound(w, r)
+		case legacyRegisterPath:
+			legacy.Add(1)
+			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_legacy"})
+		case legacyHeartbeatPathBase + "relay_legacy/heartbeat":
+			legacy.Add(1)
+			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
+		default:
+			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := client.Register(context.Background(), testBrokerRegisterRequest())
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent Register() error = %v", err)
+		}
+	}
+
+	canonicalAfterDiscovery := canonical.Load()
+	if canonicalAfterDiscovery < 1 || canonicalAfterDiscovery > workers {
+		t.Errorf("canonical discovery request count = %d, want between 1 and %d", canonicalAfterDiscovery, workers)
+	}
+	if got := legacy.Load(); got != workers {
+		t.Errorf("legacy request count = %d, want %d", got, workers)
+	}
+
+	if err := client.Heartbeat(context.Background(), "relay_legacy"); err != nil {
+		t.Fatalf("Heartbeat() after concurrent discovery error = %v", err)
+	}
+	if got := canonical.Load(); got != canonicalAfterDiscovery {
+		t.Errorf("canonical requests after sticky fallback = %d, want %d", got, canonicalAfterDiscovery)
+	}
+	if got := legacy.Load(); got != workers+1 {
+		t.Errorf("legacy requests after sticky fallback = %d, want %d", got, workers+1)
+	}
+}
 
 func TestBrokerClientSecureTransportAllowsLoopbackHTTP(t *testing.T) {
 	httpClient := &http.Client{Transport: brokerRoundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -18,20 +601,20 @@ func TestBrokerClientSecureTransportAllowsLoopbackHTTP(t *testing.T) {
 			t.Errorf("Authorization = %q, want foundation bearer", got)
 		}
 		switch r.URL.Path {
-		case "/api/v1/volunteers/register":
+		case canonicalRegisterPath:
 			body, err := json.Marshal(relay.Descriptor{ID: "relay_foundation"})
 			if err != nil {
 				return nil, err
 			}
 			return brokerJSONResponse(r, http.StatusCreated, string(body)), nil
-		case "/api/v1/volunteers/relay_foundation/heartbeat":
+		case canonicalHeartbeatPathBase + "relay_foundation/heartbeat":
 			return brokerJSONResponse(r, http.StatusOK, `{}`), nil
 		default:
 			return brokerJSONResponse(r, http.StatusNotFound, `{"error":"not found"}`), nil
 		}
 	})}
 
-	client := BrokerClient{
+	client := &BrokerClient{
 		BaseURL:                "http://127.0.0.1:8080",
 		Token:                  "foundation-secret",
 		HTTPClient:             httpClient,
@@ -52,18 +635,18 @@ func TestBrokerClientSecureTransportAllowsLoopbackHTTP(t *testing.T) {
 func TestBrokerClientSecureTransportRejectsRedirectsBeforeCredentialLeak(t *testing.T) {
 	operations := []struct {
 		name string
-		do   func(BrokerClient) error
+		do   func(*BrokerClient) error
 	}{
 		{
 			name: "register",
-			do: func(client BrokerClient) error {
+			do: func(client *BrokerClient) error {
 				_, err := client.Register(context.Background(), relay.RegisterRequest{})
 				return err
 			},
 		},
 		{
 			name: "heartbeat",
-			do: func(client BrokerClient) error {
+			do: func(client *BrokerClient) error {
 				return client.Heartbeat(context.Background(), "relay_foundation")
 			},
 		},
@@ -81,7 +664,7 @@ func TestBrokerClientSecureTransportRejectsRedirectsBeforeCredentialLeak(t *test
 				resp.Header.Set("Location", "http://broker.test"+req.URL.Path)
 				return resp, nil
 			})}
-			client := BrokerClient{
+			client := &BrokerClient{
 				BaseURL:                "https://broker.test",
 				Token:                  "foundation-secret",
 				HTTPClient:             httpClient,
@@ -103,7 +686,7 @@ func TestBrokerClientSecureTransportRejectsRedirectsBeforeCredentialLeak(t *test
 
 func TestBrokerClientSecureTransportRejectsRemotePlaintextBeforeSending(t *testing.T) {
 	var requests atomic.Int32
-	client := BrokerClient{
+	client := &BrokerClient{
 		BaseURL: "http://broker.example",
 		Token:   "foundation-secret",
 		HTTPClient: &http.Client{Transport: brokerRoundTripFunc(func(*http.Request) (*http.Response, error) {
@@ -127,11 +710,39 @@ func (f brokerRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error
 	return f(req)
 }
 
+func testBrokerRegisterRequest() relay.RegisterRequest {
+	return relay.RegisterRequest{
+		PublicHost:       "198.51.100.20",
+		PublicPort:       8443,
+		Protocol:         relay.ProtocolVLESSRealityVision,
+		ClientID:         "11111111-2222-3333-4444-555555555555",
+		RealityPublicKey: "test-reality-public-key",
+		ShortID:          "0123456789abcdef",
+		ServerName:       "www.example.com",
+		Flow:             relay.FlowVision,
+		ExitMode:         relay.ExitModeDirect,
+		MaxSessions:      32,
+		MaxMbps:          100,
+		RelayVersion:     "test-version",
+		Label:            "test-relay",
+		NodeClass:        relay.NodeClassVolunteer,
+		Transport:        relay.TransportDirect,
+	}
+}
+
+func writeBrokerJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
 func brokerJSONResponse(req *http.Request, status int, body string) *http.Response {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
 	return &http.Response{
 		StatusCode: status,
 		Status:     http.StatusText(status),
-		Header:     make(http.Header),
+		Header:     header,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Request:    req,
 	}

--- a/internal/volunteer/engine/engine.go
+++ b/internal/volunteer/engine/engine.go
@@ -371,10 +371,16 @@ func (e *Engine) run(ctx context.Context, done chan struct{}) {
 	}()
 
 	const backoffMin, backoffMax = 2 * time.Second, time.Minute
+	brokerConfig := e.currentConfig()
+	broker := &volunteer.BrokerClient{
+		BaseURL:    brokerConfig.BrokerURL,
+		Token:      brokerConfig.Token,
+		HTTPClient: brokerConfig.HTTPClient,
+	}
 	backoff := backoffMin
 	for {
 		sessionStart := time.Now()
-		err := e.runSession(ctx)
+		err := e.runSession(ctx, broker)
 		if ctx.Err() != nil {
 			return
 		}
@@ -485,7 +491,7 @@ func (e *Engine) watchForModeChange(ctx context.Context, cfg Config, current str
 	}
 }
 
-func (e *Engine) runSession(ctx context.Context) error {
+func (e *Engine) runSession(ctx context.Context, broker *volunteer.BrokerClient) error {
 	cfg := e.currentConfig()
 
 	e.setStatus(func() {
@@ -533,7 +539,7 @@ func (e *Engine) runSession(ctx context.Context) error {
 	if mode == ModeTunnel {
 		return e.runTunnelSession(ctx, cfg, label, identity)
 	}
-	return e.runDirectSession(ctx, cfg, label, identity, publicHost)
+	return e.runDirectSession(ctx, broker, cfg, label, identity, publicHost)
 }
 
 func (e *Engine) currentConfig() Config {
@@ -641,7 +647,7 @@ func (e *Engine) startXray(ctx context.Context, cfg Config, identity Identity, l
 	return cmd, waitCh, nil
 }
 
-func (e *Engine) runDirectSession(ctx context.Context, cfg Config, label string, identity Identity, publicHost string) error {
+func (e *Engine) runDirectSession(ctx context.Context, broker *volunteer.BrokerClient, cfg Config, label string, identity Identity, publicHost string) error {
 	if publicHost == "" {
 		detected, err := detectPublicIPv6()
 		if err != nil {
@@ -692,7 +698,6 @@ func (e *Engine) runDirectSession(ctx context.Context, cfg Config, label string,
 
 	e.setStatus(func() { e.phase = PhaseRegistering })
 
-	broker := volunteer.BrokerClient{BaseURL: cfg.BrokerURL, Token: cfg.Token, HTTPClient: cfg.HTTPClient}
 	req := relay.RegisterRequest{
 		PublicHost:       publicHost,
 		PublicPort:       cfg.ListenPort,
@@ -782,7 +787,7 @@ func (e *Engine) runDirectSession(ctx context.Context, cfg Config, label string,
 
 // registerWithRetry gives startup registration a few tries with short backoff
 // (honouring 429 Retry-After) before failing the session to the supervisor.
-func registerWithRetry(ctx context.Context, broker volunteer.BrokerClient, req relay.RegisterRequest) (relay.Descriptor, error) {
+func registerWithRetry(ctx context.Context, broker *volunteer.BrokerClient, req relay.RegisterRequest) (relay.Descriptor, error) {
 	const attempts = 3
 	backoff := 2 * time.Second
 	var lastErr error

--- a/internal/volunteer/engine/engine_test.go
+++ b/internal/volunteer/engine/engine_test.go
@@ -16,6 +16,7 @@ import (
 
 	"openrung/internal/relay"
 	"openrung/internal/tunnel"
+	"openrung/internal/volunteer"
 )
 
 var testIdentity = Identity{
@@ -36,12 +37,14 @@ func freePort(t *testing.T) int {
 	return port
 }
 
-// fakeBroker implements the two legacy-named relay endpoints with configurable
-// heartbeat failures.
+// fakeBroker implements only the canonical relay endpoints with configurable
+// heartbeat failures. Legacy requests are recorded so the integration test can
+// prove the desktop engine does not need compatibility routing on a new broker.
 type fakeBroker struct {
 	mu           sync.Mutex
 	registers    int
 	heartbeats   int
+	legacyCalls  int
 	nextRelayID  int
 	lastRegister relay.RegisterRequest
 	// notFoundOnce makes the next heartbeat return the broker's pruned-relay
@@ -51,7 +54,7 @@ type fakeBroker struct {
 
 func (f *fakeBroker) handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/volunteers/register", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/relays/register", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		f.registers++
 		f.nextRelayID++
@@ -63,7 +66,7 @@ func (f *fakeBroker) handler() http.Handler {
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(relay.Descriptor{ID: id, Label: req.Label, PublicHost: req.PublicHost, PublicPort: req.PublicPort})
 	})
-	mux.HandleFunc("/api/v1/volunteers/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/relays/", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		f.heartbeats++
 		notFound := f.notFoundOnce
@@ -76,6 +79,12 @@ func (f *fakeBroker) handler() http.Handler {
 		}
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	})
+	mux.HandleFunc("/api/v1/volunteers/", func(w http.ResponseWriter, _ *http.Request) {
+		f.mu.Lock()
+		f.legacyCalls++
+		f.mu.Unlock()
+		http.Error(w, "legacy route used", http.StatusInternalServerError)
+	})
 	return mux
 }
 
@@ -83,6 +92,12 @@ func (f *fakeBroker) stats() (registers, heartbeats int, last relay.RegisterRequ
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.registers, f.heartbeats, f.lastRegister
+}
+
+func (f *fakeBroker) legacyCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.legacyCalls
 }
 
 func eventually(t *testing.T, timeout time.Duration, what string, cond func() bool) {
@@ -125,9 +140,10 @@ func TestDirectSessionRegistersAndRecovers(t *testing.T) {
 	// session's public host through the auto-mode "observed" path instead by
 	// injecting a fast heartbeat and running the exported surface only.
 	eng.cfg.HeartbeatInterval = 50 * time.Millisecond
+	brokerClient := &volunteer.BrokerClient{BaseURL: ts.URL}
 	// Bypass IPv6 detection: pretend probing already resolved us.
 	go func() {
-		_ = eng.runDirectSession(context.Background(), eng.cfg, "test-relay", testIdentity, "127.0.0.1")
+		_ = eng.runDirectSession(context.Background(), brokerClient, eng.cfg, "test-relay", testIdentity, "127.0.0.1")
 	}()
 
 	eventually(t, 5*time.Second, "online status", func() bool {
@@ -160,6 +176,9 @@ func TestDirectSessionRegistersAndRecovers(t *testing.T) {
 	}
 	if last.Label != "test-relay" {
 		t.Fatalf("registered label = %q", last.Label)
+	}
+	if legacyCalls := broker.legacyCallCount(); legacyCalls != 0 {
+		t.Fatalf("legacy broker calls = %d, want 0", legacyCalls)
 	}
 
 	mu.Lock()


### PR DESCRIPTION
## Summary

- prefer the canonical `/api/v1/relays/register` and `/api/v1/relays/{id}/heartbeat` routes in `internal/volunteer.BrokerClient`
- downgrade both operations to the legacy route family only after a `405` or the exact old Go ServeMux route-missing `404`, and keep that choice sticky
- retain one broker client for the full CLI process and desktop engine run, including desktop reconnects
- refuse broker redirects for every relay credential and preserve request body, headers, API errors, and `Retry-After` behavior
- document the direct-relay route policy and update the origin-TLS route wording

## Why

The broker now exposes canonical relay write routes, but the direct relay client still used the legacy volunteer-named aliases exclusively. This moves the CLI and desktop relay engine to the canonical API while keeping compatibility with brokers that predate those routes.

## Compatibility and safety

- legacy fallback is broker-wide and monotonic for the client lifetime
- structured `404 relay not found` remains a lease-expiry signal and does not trigger route fallback
- `400`, `401`, `403`, `429`, `5xx`, network errors, decode errors, redirects, and other `404` shapes do not trigger fallback
- canonical-to-legacy retries preserve bearer authentication, JSON content type, and request bodies

## Checks

- `GOCACHE=/tmp/openrung-go-cache go vet ./...`
- `GOCACHE=/tmp/openrung-go-cache go test ./...`
- `GOCACHE=/tmp/openrung-go-cache go test -race ./internal/volunteer -run '^TestBrokerClient' -count=1`
- `GOCACHE=/tmp/openrung-go-cache go test -race ./cmd/volunteer ./internal/volunteer/engine -run '^(TestHeartbeatOrRegister.*|TestDirectSessionRegistersAndRecovers)$' -count=1`
