### PR TITLE
Use canonical relay image for provisioning

### DIFF
--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -137,12 +137,10 @@ If you publish via the CI workflow, pull instead of building:
 docker pull ghcr.io/openrung/openrung-relay:main
 ```
 
-The `openrung-relay` GHCR package must be **public** before unauthenticated relay
-hosts can pull it. After its first workflow publication, verify the package
-visibility under the OpenRung organization’s **Packages** settings, then verify
-an unauthenticated pull. Until that gate passes, the cloud provisioning helpers
-default to the public `openrung-volunteer` compatibility package; CI publishes
-it from the same build and verifies that both package names have the same digest.
+The cloud provisioning helpers pull this public canonical package by default.
+During the compatibility window, CI also publishes the same manifest under the
+legacy `openrung-volunteer` package name and verifies that both names resolve to
+the same digest.
 
 ## Networking notes
 

--- a/deploy/relay/hetzner-up.sh
+++ b/deploy/relay/hetzner-up.sh
@@ -26,10 +26,7 @@ set -euo pipefail
 LOCATION="${OPENRUNG_LOCATION:-hel1}"          # Helsinki (EU: 20TB included traffic)
 SERVER_TYPE="${OPENRUNG_SERVER_TYPE:-cax11}"   # ARM Ampere, 2 vCPU / 4GB / 40GB
 OS_IMAGE="${OPENRUNG_OS_IMAGE:-ubuntu-24.04}"
-# Keep anonymous bootstrap on the existing public package until openrung-relay
-# has been published, made public, and anonymously verified. CI publishes both
-# package names from one build, so they resolve to the same multi-arch manifest.
-IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-volunteer:main}"  # multi-arch: pulls arm64 on CAX
+IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"  # multi-arch: pulls arm64 on CAX
 # Register against the broker ORIGIN, not the Cloudflare front (broker.openrung.org).
 # That hostname is a Worker front for *client* discovery; its edge serves a Managed
 # Challenge to datacenter IP ranges (incl. Hetzner), which a relay's HTTP client

--- a/deploy/relay/lightsail-up.sh
+++ b/deploy/relay/lightsail-up.sh
@@ -23,10 +23,7 @@ REGION="${OPENRUNG_REGION:-ap-northeast-1}"
 AZ="${OPENRUNG_AZ:-${REGION}a}"
 BUNDLE="${OPENRUNG_BUNDLE:-micro_3_0}"          # 1GB RAM / 2 vCPU / 40GB / 2TB
 BLUEPRINT="${OPENRUNG_BLUEPRINT:-ubuntu_24_04}"
-# Keep anonymous bootstrap on the existing public package until openrung-relay
-# has been published, made public, and anonymously verified. CI publishes both
-# package names from one build, so they resolve to the same multi-arch manifest.
-IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-volunteer:main}"
+IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
 BROKER_URL="${OPENRUNG_BROKER_URL:-http://54.238.185.205:8080}"
 
 if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_FOUNDATION_TOKEN+x}" = x ] || [ "${OPENRUNG_NODE_CLASS+x}" = x ]; then


### PR DESCRIPTION
## Summary
- switch the Hetzner and Lightsail provisioning defaults to `ghcr.io/openrung/openrung-relay:main`
- update the deployment guide to describe the canonical package as the default
- retain `openrung-volunteer` only as the temporary compatibility package published from the same build

## Why
The canonical package is now published, public, and anonymously pullable. Its
multi-architecture manifest matches the compatibility package, so the visibility
gate established in PR #64 has passed.

## Validation
- anonymous `docker pull ghcr.io/openrung/openrung-relay:main` succeeded at `sha256:1eb2c8e7858001f8276913cf830d8704b220f966fd70bc6f7e445ddff8d84190`
- anonymous manifest inspection confirms Linux amd64 and arm64 variants
- normalized canonical and compatibility manifest indexes have identical SHA-256 hashes
- pulled-image smoke test confirms `relay` and Xray are executable and `/usr/local/bin/volunteer` is absent
- `bash -n deploy/relay/hetzner-up.sh deploy/relay/lightsail-up.sh`
- `git diff --check`
