### PR TITLE
Retire openrung-volunteer image

### DIFF
--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -1,9 +1,7 @@
 name: relay-image
 
-# Build and publish the relay runtime image to GHCR. During the fleet cutover,
-# publish the same manifest under the legacy openrung-volunteer package name.
-# Remove that second image after every controlled relay uses openrung-relay.
-# Multi-arch (amd64 + arm64) so it runs on x86 and Graviton/ARM VPSes.
+# Build and publish the relay runtime image to GHCR. Multi-arch (amd64 + arm64)
+# so it runs on x86 and Graviton/ARM VPSes.
 
 on:
   push:
@@ -46,9 +44,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/openrung-relay
-            ghcr.io/${{ github.repository_owner }}/openrung-volunteer
+          images: ghcr.io/${{ github.repository_owner }}/openrung-relay
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -66,7 +62,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Verify canonical and compatibility tags
+      - name: Verify published tags
         env:
           EXPECTED_DIGEST: ${{ steps.build.outputs.digest }}
           PUBLISHED_TAGS: ${{ steps.meta.outputs.tags }}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,8 +9,6 @@ must surface it:
 
 - **`openrung-relay` / `openrung-relayhub` Docker images** — the file is
   copied to `/usr/local/share/openrung/THIRD_PARTY_NOTICES.md` in each image.
-  During the relay artifact cutover, the identical `openrung-relay` image is
-  also published under the temporary `openrung-volunteer` package name.
 - **Server binaries on the host** — ship this file alongside the binary.
 - **Desktop app (Wails GUI)** — the in-app "Open-source licenses" screen
   renders these notices (`desktop/frontend/src/licenses/notices.ts` mirrors
@@ -73,8 +71,7 @@ recipients of the MPL-2.0 terms and where to obtain the source.
 ### Xray-core (VLESS + REALITY + Vision)
 
 - **Component:** `github.com/XTLS/Xray-core` — the `xray` binary, plus
-  `geoip.dat` / `geosite.dat`, bundled into the `openrung-relay` image (also
-  temporarily published as `openrung-volunteer`).
+  `geoip.dat` / `geosite.dat`, bundled into the `openrung-relay` image.
   The OpenRung Volunteer desktop app (`desktop-volunteer/`) bundles the
   `xray` binary **only** — no geo data files — so section 4 does not apply
   to that channel.
@@ -107,9 +104,8 @@ recipients of the MPL-2.0 terms and where to obtain the source.
 
 ## 3. Strong copyleft in the base image (GPL-2.0) — written source offer
 
-The `alpine:3.21` base of the `openrung-relay` (also temporarily published as
-`openrung-volunteer`) and `openrung-relayhub` images includes GPL-2.0-only
-userland. These are aggregated with — and do not
+The `alpine:3.21` base of the `openrung-relay` and `openrung-relayhub` images
+includes GPL-2.0-only userland. These are aggregated with — and do not
 relicense — OpenRung's own binaries, but conveying the images still requires a
 source offer for the GPL components themselves.
 
@@ -130,8 +126,7 @@ source offer for the GPL components themselves.
 ## 4. Bundled data files (license differs from the code that ships them)
 
 Both files are extracted from the Xray-core release zip and bundled, unmodified,
-into the `openrung-relay` image (also temporarily published as
-`openrung-volunteer`). They are **not** bundled in the OpenRung
+into the `openrung-relay` image. They are **not** bundled in the OpenRung
 Volunteer desktop app (which ships the `xray` binary only), so these notices
 apply to the Docker image channel only.
 

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -138,9 +138,6 @@ docker pull ghcr.io/openrung/openrung-relay:main
 ```
 
 The cloud provisioning helpers pull this public canonical package by default.
-During the compatibility window, CI also publishes the same manifest under the
-legacy `openrung-volunteer` package name and verifies that both names resolve to
-the same digest.
 
 ## Networking notes
 

--- a/deploy/relay/hetzner-up.sh
+++ b/deploy/relay/hetzner-up.sh
@@ -111,9 +111,7 @@ systemctl enable --now docker
 # Public IPv4 from the Hetzner metadata service; clients reach the relay here.
 PUBLIC_IP="\$(curl -fsS http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
 docker pull ${IMAGE}
-# Remove both names during the artifact migration so a stale host-network relay
-# cannot retain port 443 or keep a duplicate broker registration.
-docker rm -f openrung-relay openrung-volunteer 2>/dev/null || true
+docker rm -f openrung-relay 2>/dev/null || true
 docker run -d --name openrung-relay --restart unless-stopped \\
   --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\
   -e OPENRUNG_BROKER_URL=${BROKER_URL} \\

--- a/deploy/relay/lightsail-up.sh
+++ b/deploy/relay/lightsail-up.sh
@@ -75,9 +75,7 @@ apt-get -o DPkg::Lock::Timeout=300 update
 apt-get -o DPkg::Lock::Timeout=300 install -y docker.io
 systemctl enable --now docker
 docker pull ${IMAGE}
-# Remove both names during the artifact migration so a stale host-network relay
-# cannot retain port 443 or keep a duplicate broker registration.
-docker rm -f openrung-relay openrung-volunteer 2>/dev/null || true
+docker rm -f openrung-relay 2>/dev/null || true
 docker run -d --name openrung-relay --restart unless-stopped \\
   --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\
   -e OPENRUNG_BROKER_URL=${BROKER_URL} \\


### PR DESCRIPTION
## Summary
- stop publishing `ghcr.io/openrung/openrung-volunteer` from the relay image workflow
- keep `openrung-relay` as the only published relay package and continue verifying all emitted tags against the build digest
- remove legacy-container cleanup from the Hetzner and Lightsail provisioning scripts
- remove compatibility-package wording from deployment documentation and third-party notices

The historical `.env`/container migration guide remains so operators can
preserve credentials and stable relay identity. Semantic volunteer-class
identifiers, the Volunteer desktop app identity, and the existing shared
Hetzner firewall name also remain; none are image aliases.

## Registry deletion sequence

The public `openrung-volunteer` package currently contains 115 versions,
including `main`, `latest`, release tags, SHA tags, and untagged platform or
attestation manifests. Delete the entire package rather than individual tags,
but only after this PR merges and the resulting canonical-only `relay-image`
workflow succeeds. This avoids the current main-branch workflow recreating the
package.

Post-merge verification:

1. Confirm no older dual-publish workflow run is queued or running.
2. Anonymously pull `ghcr.io/openrung/openrung-relay:main`.
3. Delete the complete `openrung-volunteer` GHCR package.
4. Confirm the legacy pull fails and the canonical pull still succeeds.

## Validation
- workflow YAML parses successfully
- `bash -n` passes for both relay provisioning scripts
- extracted Hetzner and Lightsail cloud-init payloads pass shell syntax checks
- relay Compose configuration validates
- `git diff --check`
- repository audit finds no active legacy GHCR, image, binary, or workflow reference
- two independent read-only reviews approve the final diff
