### PR TITLE
Remove legacy relay write routes

### DIFF
--- a/deploy/broker/origin-tls.md
+++ b/deploy/broker/origin-tls.md
@@ -7,12 +7,7 @@ carried the high-value **Foundation registration token** (the `Authorization`
 header on relay registration requests) in cleartext across the public internet.
 This runbook closes that leg with a TLS-terminating reverse proxy on the broker
 box so the token is encrypted **relay → CloudFront edge → origin**. Current
-relays use `POST /api/v1/relays/register`; older runtimes used the compatibility
-path below.
-
-The legacy `POST /api/v1/volunteers/register` route reaches the same handler and
-is retained as a compatibility alias with no scheduled removal date. New
-operational checks should use the canonical relay route shown here.
+relays use the canonical `POST /api/v1/relays/register` route.
 
 ```
 relay ──HTTPS──► CloudFront edge ──HTTPS(:443)──► Caddy ──HTTP(127.0.0.1:8080)──► broker

--- a/docs/api.md
+++ b/docs/api.md
@@ -210,9 +210,7 @@ Authorization: Bearer <registration-token>
 Content-Type: application/json
 ```
 
-The legacy `POST /api/v1/volunteers/register` path is retained as a
-compatibility alias with identical authentication, rate limiting, validation,
-and response behavior. It has no scheduled removal date. Both paths register
+This is the only supported relay registration route. It registers both
 `volunteer`-class and `foundation`-class relays.
 
 Request:
@@ -334,10 +332,6 @@ resolves.
 POST /api/v1/relays/{id}/heartbeat
 Authorization: Bearer <registration-token>
 ```
-
-The legacy `POST /api/v1/volunteers/{id}/heartbeat` path is retained as a
-compatibility alias with identical authentication, rate limiting, validation,
-and response behavior. It has no scheduled removal date.
 
 Response:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,13 +51,10 @@ as `node_class: "volunteer"`; relays presenting the Foundation credential
 register as `node_class: "foundation"`. The broker attests this provenance in
 the signed relay directory. It is not a quality score or a trust bypass.
 
-Direct-mode relays, including the desktop relay engine, prefer the canonical
-`POST /api/v1/relays/register` and `/api/v1/relays/{id}/heartbeat` routes. If a
-broker reports either route unsupported with the old ServeMux's exact
-route-missing `404` response or with `405`, that runtime selects the legacy
-`/api/v1/volunteers/...` compatibility route family for all subsequent
-registrations and heartbeats. The selection is sticky across reconnects; other
-broker errors never trigger fallback, and broker redirects are refused.
+Direct-mode relays, including the desktop relay engine, use only the canonical
+`POST /api/v1/relays/register` and `/api/v1/relays/{id}/heartbeat` routes.
+Broker errors are returned directly to the runtime, and broker redirects are
+refused.
 
 The CLI produces an Xray server config with:
 
@@ -95,12 +92,9 @@ volunteer-run relays online:
 - The hub allocates one public TCP port per relay, registers the relay with
   the broker (with `transport: "tunnel"` and `public_host`/`public_port` pointing
   at the hub), and multiplexes inbound client connections to the relay over the
-  tunnel using yamux. The hub prefers the canonical
-  `POST /api/v1/relays/register` route. If a broker reports that route unsupported
-  with the old ServeMux's route-missing `404` response or with `405`, the hub
-  selects the legacy `POST /api/v1/volunteers/register` compatibility alias for
-  subsequent registrations and heartbeats. Other broker errors never trigger
-  fallback.
+  tunnel using yamux. The hub uses only the canonical
+  `POST /api/v1/relays/register` and `/api/v1/relays/{id}/heartbeat` routes;
+  broker errors are returned directly.
   Clients connect to `hub:port` exactly as they would any direct relay — no client
   changes.
 - Descriptor liveness is tied to the tunnel: the hub heartbeats while the tunnel

--- a/internal/broker/auth_hardening_test.go
+++ b/internal/broker/auth_hardening_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAuthorizedRejectsInvalidTokens(t *testing.T) {
 	withAuth := func(v string) *http.Request {
-		r := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil)
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", nil)
 		if v != "" {
 			r.Header.Set("Authorization", v)
 		}
@@ -38,7 +38,7 @@ func TestServerRateLimitsRegister(t *testing.T) {
 	status := 0
 	for i := 0; i < relayRegistrationBurst+1; i++ {
 		recorder := httptest.NewRecorder()
-		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil))
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", nil))
 		status = recorder.Code
 		if i < relayRegistrationBurst && status == http.StatusTooManyRequests {
 			t.Fatalf("request %d inside burst unexpectedly limited", i+1)

--- a/internal/broker/nodeclass_test.go
+++ b/internal/broker/nodeclass_test.go
@@ -15,16 +15,11 @@ import (
 
 func postRegister(t *testing.T, server http.Handler, req relay.RegisterRequest, bearer string) *httptest.ResponseRecorder {
 	t.Helper()
-	return postRegisterAt(t, server, "/api/v1/volunteers/register", req, bearer)
-}
-
-func postRegisterAt(t *testing.T, server http.Handler, path string, req relay.RegisterRequest, bearer string) *httptest.ResponseRecorder {
-	t.Helper()
 	body, err := json.Marshal(req)
 	if err != nil {
 		t.Fatalf("marshal register request: %v", err)
 	}
-	httpReq := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body))
 	if bearer != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+bearer)
 	}
@@ -60,14 +55,7 @@ func TestRegisterDefaultsNodeClassVolunteer(t *testing.T) {
 	}
 }
 
-func TestRegisterRouteAliasesPreserveNodeClassAuthorization(t *testing.T) {
-	routes := []struct {
-		name string
-		path string
-	}{
-		{name: "canonical", path: "/api/v1/relays/register"},
-		{name: "legacy", path: "/api/v1/volunteers/register"},
-	}
+func TestRegisterPreservesNodeClassAuthorization(t *testing.T) {
 	tests := []struct {
 		name          string
 		bearer        string
@@ -101,27 +89,25 @@ func TestRegisterRouteAliasesPreserveNodeClassAuthorization(t *testing.T) {
 		},
 	}
 
-	for _, route := range routes {
-		for _, test := range tests {
-			t.Run(route.name+"/"+test.name, func(t *testing.T) {
-				server := NewServer(NewStore(), Config{
-					SigningSeed:       testSigningSeed(),
-					RegistrationToken: "volunteer-token",
-					FoundationToken:   "foundation-token",
-				})
-				req := validRegisterRequest()
-				req.NodeClass = test.claimClass
-				recorder := postRegisterAt(t, server, route.path, req, test.bearer)
-				if recorder.Code != test.wantStatus {
-					t.Fatalf("expected %d, got %d: %s", test.wantStatus, recorder.Code, recorder.Body.String())
-				}
-				if test.wantStatus == http.StatusCreated {
-					if desc := decodeDescriptor(t, recorder); desc.NodeClass != test.wantNodeClass {
-						t.Fatalf("node_class = %q, want %q", desc.NodeClass, test.wantNodeClass)
-					}
-				}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := NewServer(NewStore(), Config{
+				SigningSeed:       testSigningSeed(),
+				RegistrationToken: "volunteer-token",
+				FoundationToken:   "foundation-token",
 			})
-		}
+			req := validRegisterRequest()
+			req.NodeClass = test.claimClass
+			recorder := postRegister(t, server, req, test.bearer)
+			if recorder.Code != test.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", test.wantStatus, recorder.Code, recorder.Body.String())
+			}
+			if test.wantStatus == http.StatusCreated {
+				if desc := decodeDescriptor(t, recorder); desc.NodeClass != test.wantNodeClass {
+					t.Fatalf("node_class = %q, want %q", desc.NodeClass, test.wantNodeClass)
+				}
+			}
+		})
 	}
 }
 
@@ -239,7 +225,7 @@ func TestHeartbeatAcceptsFoundationToken(t *testing.T) {
 	}
 	desc := decodeDescriptor(t, recorder)
 
-	heartbeat := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/"+desc.ID+"/heartbeat", nil)
+	heartbeat := httptest.NewRequest(http.MethodPost, "/api/v1/relays/"+desc.ID+"/heartbeat", nil)
 	heartbeat.Header.Set("Authorization", "Bearer foundation-token")
 	heartbeatRecorder := httptest.NewRecorder()
 	server.ServeHTTP(heartbeatRecorder, heartbeat)
@@ -248,7 +234,7 @@ func TestHeartbeatAcceptsFoundationToken(t *testing.T) {
 	}
 }
 
-func TestCanonicalHeartbeatEnforcesFoundationToken(t *testing.T) {
+func TestHeartbeatEnforcesFoundationToken(t *testing.T) {
 	server := NewServer(NewStore(), Config{
 		SigningSeed:       testSigningSeed(),
 		RegistrationToken: "volunteer-token",
@@ -257,7 +243,7 @@ func TestCanonicalHeartbeatEnforcesFoundationToken(t *testing.T) {
 
 	req := validRegisterRequest()
 	req.NodeClass = relay.NodeClassFoundation
-	recorder := postRegisterAt(t, server, "/api/v1/relays/register", req, "foundation-token")
+	recorder := postRegister(t, server, req, "foundation-token")
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("register: expected 201, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -283,7 +269,7 @@ func TestCanonicalHeartbeatEnforcesFoundationToken(t *testing.T) {
 
 func TestCredentialNodeClass(t *testing.T) {
 	withAuth := func(v string) *http.Request {
-		r := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil)
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", nil)
 		if v != "" {
 			r.Header.Set("Authorization", v)
 		}
@@ -376,14 +362,14 @@ func TestHeartbeatForbiddenForFoundationRelayWithoutFoundationCredential(t *test
 
 	// Anonymous heartbeat (valid volunteer-class credential on this open broker)
 	// must not extend a foundation relay's lease.
-	anonymous := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/"+desc.ID+"/heartbeat", nil)
+	anonymous := httptest.NewRequest(http.MethodPost, "/api/v1/relays/"+desc.ID+"/heartbeat", nil)
 	anonymousRecorder := httptest.NewRecorder()
 	server.ServeHTTP(anonymousRecorder, anonymous)
 	if anonymousRecorder.Code != http.StatusForbidden {
 		t.Fatalf("anonymous heartbeat: expected 403, got %d: %s", anonymousRecorder.Code, anonymousRecorder.Body.String())
 	}
 
-	authorized := httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/"+desc.ID+"/heartbeat", nil)
+	authorized := httptest.NewRequest(http.MethodPost, "/api/v1/relays/"+desc.ID+"/heartbeat", nil)
 	authorized.Header.Set("Authorization", "Bearer foundation-token")
 	authorizedRecorder := httptest.NewRecorder()
 	server.ServeHTTP(authorizedRecorder, authorized)

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -79,12 +79,6 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	})
 	mux.HandleFunc("POST /api/v1/relays/register", registerRelay)
 	mux.HandleFunc("POST /api/v1/relays/", heartbeatRelay)
-	// Keep the original volunteer-named routes as compatibility aliases for
-	// deployed relays. Both route families intentionally share the same handler
-	// closures and rate limiter so aliases cannot change behavior or double a
-	// client's registration budget.
-	mux.HandleFunc("POST /api/v1/volunteers/register", registerRelay)
-	mux.HandleFunc("POST /api/v1/volunteers/", heartbeatRelay)
 	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen, relaySigner)))
 	mux.HandleFunc("GET /api/v1/relays.mirror", rateLimited(relayListLimiter, clientIP, 10, listRelaysMirrorHandler(store, relaySigner)))
 	mux.HandleFunc("POST /api/v1/telemetry/events", rateLimited(telemetryLimiter, clientIP, 10, telemetryHandler(cfg.TelemetrySink, store, clientIP)))
@@ -342,20 +336,14 @@ func validateRegisterRequest(req relay.RegisterRequest) error {
 
 func heartbeatRelayID(path string) (string, bool) {
 	const (
-		relayPrefix     = "/api/v1/relays/"
-		volunteerPrefix = "/api/v1/volunteers/"
-		suffix          = "/heartbeat"
+		relayPrefix = "/api/v1/relays/"
+		suffix      = "/heartbeat"
 	)
 
-	var remainder string
-	switch {
-	case strings.HasPrefix(path, relayPrefix):
-		remainder = strings.TrimPrefix(path, relayPrefix)
-	case strings.HasPrefix(path, volunteerPrefix):
-		remainder = strings.TrimPrefix(path, volunteerPrefix)
-	default:
+	if !strings.HasPrefix(path, relayPrefix) {
 		return "", false
 	}
+	remainder := strings.TrimPrefix(path, relayPrefix)
 
 	id, ok := strings.CutSuffix(remainder, suffix)
 	if !ok || id == "" || strings.ContainsRune(id, '/') {

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -34,7 +34,7 @@ func TestHeartbeatRelayID(t *testing.T) {
 		wantOK bool
 	}{
 		{name: "canonical relay route", path: "/api/v1/relays/relay_abc/heartbeat", wantID: "relay_abc", wantOK: true},
-		{name: "legacy volunteer route", path: "/api/v1/volunteers/relay_abc/heartbeat", wantID: "relay_abc", wantOK: true},
+		{name: "retired legacy prefix", path: "/api/v1/volunteers/relay_abc/heartbeat"},
 		{name: "missing relay ID", path: "/api/v1/relays//heartbeat"},
 		{name: "nested relay ID", path: "/api/v1/relays/group/relay_abc/heartbeat"},
 		{name: "wrong suffix", path: "/api/v1/relays/relay_abc/pulse"},
@@ -51,65 +51,51 @@ func TestHeartbeatRelayID(t *testing.T) {
 	}
 }
 
-func TestRelayRouteAliasesRegisterAndHeartbeat(t *testing.T) {
-	tests := []struct {
-		name          string
-		registerPath  string
-		heartbeatBase string
-	}{
-		{name: "canonical routes", registerPath: "/api/v1/relays/register", heartbeatBase: "/api/v1/relays/"},
-		{name: "canonical register legacy heartbeat", registerPath: "/api/v1/relays/register", heartbeatBase: "/api/v1/volunteers/"},
-		{name: "legacy register canonical heartbeat", registerPath: "/api/v1/volunteers/register", heartbeatBase: "/api/v1/relays/"},
+func TestCanonicalRelayRoutesRegisterAndHeartbeat(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+	body, err := json.Marshal(validRegisterRequest())
+	if err != nil {
+		t.Fatalf("marshal register request: %v", err)
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
-			body, err := json.Marshal(validRegisterRequest())
-			if err != nil {
-				t.Fatalf("marshal register request: %v", err)
-			}
+	registerRecorder := httptest.NewRecorder()
+	server.ServeHTTP(registerRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
+	if registerRecorder.Code != http.StatusCreated {
+		t.Fatalf("register: expected 201, got %d: %s", registerRecorder.Code, registerRecorder.Body.String())
+	}
 
-			registerRecorder := httptest.NewRecorder()
-			server.ServeHTTP(registerRecorder, httptest.NewRequest(http.MethodPost, test.registerPath, bytes.NewReader(body)))
-			if registerRecorder.Code != http.StatusCreated {
-				t.Fatalf("register: expected 201, got %d: %s", registerRecorder.Code, registerRecorder.Body.String())
-			}
-
-			var desc relay.Descriptor
-			if err := json.Unmarshal(registerRecorder.Body.Bytes(), &desc); err != nil {
-				t.Fatalf("decode descriptor: %v", err)
-			}
-			heartbeatRecorder := httptest.NewRecorder()
-			heartbeatPath := test.heartbeatBase + desc.ID + "/heartbeat"
-			server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, heartbeatPath, nil))
-			if heartbeatRecorder.Code != http.StatusOK {
-				t.Fatalf("heartbeat: expected 200, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
-			}
-		})
+	var desc relay.Descriptor
+	if err := json.Unmarshal(registerRecorder.Body.Bytes(), &desc); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+	heartbeatRecorder := httptest.NewRecorder()
+	heartbeatPath := "/api/v1/relays/" + desc.ID + "/heartbeat"
+	server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, heartbeatPath, nil))
+	if heartbeatRecorder.Code != http.StatusOK {
+		t.Fatalf("heartbeat: expected 200, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
 	}
 }
 
-func TestRegisterRouteAliasesRejectMalformedJSONIdentically(t *testing.T) {
+func TestRegisterRouteRejectsMalformedJSON(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", strings.NewReader("{")))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRetiredVolunteerWriteRoutesReturnNotFound(t *testing.T) {
 	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
 	paths := []string{
-		"/api/v1/relays/register",
 		"/api/v1/volunteers/register",
+		"/api/v1/volunteers/relay_abc/heartbeat",
 	}
-
-	var wantBody string
 	for _, path := range paths {
 		recorder := httptest.NewRecorder()
-		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, path, strings.NewReader("{")))
-		if recorder.Code != http.StatusBadRequest {
-			t.Fatalf("%s: expected 400, got %d: %s", path, recorder.Code, recorder.Body.String())
-		}
-		if wantBody == "" {
-			wantBody = recorder.Body.String()
-			continue
-		}
-		if recorder.Body.String() != wantBody {
-			t.Fatalf("%s: body = %q, want %q", path, recorder.Body.String(), wantBody)
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, path, nil))
+		if recorder.Code != http.StatusNotFound {
+			t.Errorf("POST %s: expected 404, got %d: %s", path, recorder.Code, recorder.Body.String())
 		}
 	}
 }
@@ -172,7 +158,7 @@ func TestRegisterStoresAndReturnsLabel(t *testing.T) {
 	req.Label = "happy-hippo"
 	body, _ := json.Marshal(req)
 	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -198,7 +184,7 @@ func TestRegisterRejectsUnsafeLabel(t *testing.T) {
 	req.Label = "<script>alert(1)</script>"
 	body, _ := json.Marshal(req)
 	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for unsafe label, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -209,7 +195,7 @@ func TestRegisterRejectsOversizedBody(t *testing.T) {
 
 	oversized := []byte(`{"public_host":"` + strings.Repeat("a", maxRegisterBodyBytes) + `"}`)
 	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(oversized)))
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(oversized)))
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for oversized register body, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -221,7 +207,7 @@ func TestRegisterResolvesRelayLocation(t *testing.T) {
 
 	body, _ := json.Marshal(validRegisterRequest())
 	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -253,7 +239,7 @@ func TestRegisterGeolocatesTunnelRelayByExitHostWithoutExposingIt(t *testing.T) 
 	req.ExitHost = "198.51.100.7" // relay's observed exit IP
 	body, _ := json.Marshal(req)
 	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -281,7 +267,7 @@ func TestHeartbeatBackfillsRelayLocation(t *testing.T) {
 
 	body, _ := json.Marshal(validRegisterRequest())
 	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", bytes.NewReader(body)))
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
 	}
@@ -298,7 +284,7 @@ func TestHeartbeatBackfillsRelayLocation(t *testing.T) {
 	heartbeat := func() {
 		t.Helper()
 		heartbeatRecorder := httptest.NewRecorder()
-		server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/"+desc.ID+"/heartbeat", nil))
+		server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/"+desc.ID+"/heartbeat", nil))
 		if heartbeatRecorder.Code != http.StatusOK {
 			t.Fatalf("expected 200 heartbeat, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
 		}
@@ -359,15 +345,13 @@ func TestListRelaysIsNeverCacheable(t *testing.T) {
 	}
 }
 
-func TestHeartbeatRoutesRejectMissingOrMalformedRelays(t *testing.T) {
+func TestHeartbeatRouteRejectsMissingOrMalformedRelays(t *testing.T) {
 	tests := []struct {
 		name string
 		path string
 	}{
-		{name: "canonical missing relay", path: "/api/v1/relays/relay_missing/heartbeat"},
-		{name: "legacy missing relay", path: "/api/v1/volunteers/relay_missing/heartbeat"},
-		{name: "canonical malformed endpoint", path: "/api/v1/relays/relay_missing/pulse"},
-		{name: "legacy malformed endpoint", path: "/api/v1/volunteers/relay_missing/pulse"},
+		{name: "missing relay", path: "/api/v1/relays/relay_missing/heartbeat"},
+		{name: "malformed endpoint", path: "/api/v1/relays/relay_missing/pulse"},
 	}
 
 	for _, test := range tests {
@@ -379,35 +363,6 @@ func TestHeartbeatRoutesRejectMissingOrMalformedRelays(t *testing.T) {
 				t.Fatalf("expected 404, got %d: %s", recorder.Code, recorder.Body.String())
 			}
 		})
-	}
-}
-
-func TestRelayRouteAliasesShareRegistrationRateLimit(t *testing.T) {
-	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
-
-	// Exhaust the registration budget through the legacy alias. Invalid JSON
-	// still consumes a token because limiting deliberately happens before body
-	// parsing and authentication.
-	exhausted := false
-	for i := 0; i < relayRegistrationBurst+32; i++ {
-		recorder := httptest.NewRecorder()
-		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/volunteers/register", nil))
-		if recorder.Code == http.StatusTooManyRequests {
-			exhausted = true
-			break
-		}
-	}
-	if !exhausted {
-		t.Fatal("expected legacy route to exhaust the shared budget")
-	}
-
-	// The canonical alias must immediately see that exhausted bucket. Separate
-	// limiters would let callers double the effective registration budget by
-	// alternating route names.
-	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", nil))
-	if recorder.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected canonical route to share exhausted budget, got %d: %s", recorder.Code, recorder.Body.String())
 	}
 }
 

--- a/internal/relayruntime/broker.go
+++ b/internal/relayruntime/broker.go
@@ -11,25 +11,19 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync/atomic"
 
 	"openrung/internal/relay"
 )
 
 const (
-	canonicalRegisterPath      = "/api/v1/relays/register"
-	legacyRegisterPath         = "/api/v1/volunteers/register"
-	canonicalHeartbeatPathBase = "/api/v1/relays/"
-	legacyHeartbeatPathBase    = "/api/v1/volunteers/"
-	maxBrokerErrorBodyBytes    = 64 << 10
-	legacyServeMuxNotFoundBody = "404 page not found\n"
+	relayRegisterPath       = "/api/v1/relays/register"
+	relayHeartbeatPathBase  = "/api/v1/relays/"
+	maxBrokerErrorBodyBytes = 64 << 10
 )
 
 // BrokerClient speaks the relay side of the broker HTTP API: registration
 // and heartbeats. The zero HTTPClient falls back to http.DefaultClient; Token
-// is optional (anonymous registration when the broker allows it). A
-// BrokerClient must not be copied after first use so its route selection stays
-// shared.
+// is optional (anonymous registration when the broker allows it).
 type BrokerClient struct {
 	BaseURL    string
 	Token      string
@@ -39,32 +33,12 @@ type BrokerClient struct {
 	// available for local integration tests. All broker requests refuse
 	// redirects regardless of this setting.
 	RequireSecureTransport bool
-
-	// legacyRoutes is broker-wide for this client: once either canonical write
-	// endpoint proves unavailable, registration and heartbeats both stay on the
-	// compatibility route family. Atomic state makes concurrent desktop-engine
-	// requests race-safe and keeps the transition monotonic.
-	legacyRoutes atomic.Bool
 }
 
 // Register announces the relay and returns the broker-minted descriptor.
 func (b *BrokerClient) Register(ctx context.Context, req relay.RegisterRequest) (relay.Descriptor, error) {
-	if b.legacyRoutes.Load() {
-		return b.registerAt(ctx, legacyRegisterPath, req)
-	}
-
-	desc, err := b.registerAt(ctx, canonicalRegisterPath, req)
-	if !isRouteUnsupported(err) {
-		return desc, err
-	}
-
-	b.legacyRoutes.Store(true)
-	return b.registerAt(ctx, legacyRegisterPath, req)
-}
-
-func (b *BrokerClient) registerAt(ctx context.Context, path string, req relay.RegisterRequest) (relay.Descriptor, error) {
 	var desc relay.Descriptor
-	if err := b.postJSON(ctx, path, req, &desc); err != nil {
+	if err := b.postJSON(ctx, relayRegisterPath, req, &desc); err != nil {
 		return relay.Descriptor{}, err
 	}
 	return desc, nil
@@ -73,22 +47,8 @@ func (b *BrokerClient) registerAt(ctx context.Context, path string, req relay.Re
 // Heartbeat renews the relay's lease. A pruned relay yields an APIError with
 // status 404 that IsRelayNotFound recognizes.
 func (b *BrokerClient) Heartbeat(ctx context.Context, id string) error {
-	if b.legacyRoutes.Load() {
-		return b.heartbeatAt(ctx, legacyHeartbeatPathBase, id)
-	}
-
-	err := b.heartbeatAt(ctx, canonicalHeartbeatPathBase, id)
-	if !isRouteUnsupported(err) {
-		return err
-	}
-
-	b.legacyRoutes.Store(true)
-	return b.heartbeatAt(ctx, legacyHeartbeatPathBase, id)
-}
-
-func (b *BrokerClient) heartbeatAt(ctx context.Context, pathBase, id string) error {
 	var resp relay.HeartbeatResponse
-	return b.postJSON(ctx, pathBase+id+"/heartbeat", map[string]bool{"ok": true}, &resp)
+	return b.postJSON(ctx, relayHeartbeatPathBase+id+"/heartbeat", map[string]bool{"ok": true}, &resp)
 }
 
 func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out any) error {
@@ -119,7 +79,7 @@ func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out 
 	// Clone the caller's client so the policy neither mutates a shared client
 	// nor depends on its CheckRedirect setting. Broker write endpoints never
 	// need a redirect; refusing every redirect prevents forwarding the bearer
-	// token and ensures a redirected 404/405 cannot trigger legacy fallback.
+	// token to another location.
 	noRedirectClient := *httpClient
 	noRedirectClient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
 		return fmt.Errorf("broker request refused redirect to %s", req.URL.Redacted())
@@ -141,17 +101,11 @@ func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out 
 		if apiErr.Error == "" {
 			apiErr.Error = resp.Status
 		}
-		mediaType, _, _ := strings.Cut(resp.Header.Get("Content-Type"), ";")
-		legacyMux404 := resp.StatusCode == http.StatusNotFound &&
-			readErr == nil && bodyWithinLimit &&
-			strings.EqualFold(strings.TrimSpace(mediaType), "text/plain") &&
-			bytes.Equal(errorBody, []byte(legacyServeMuxNotFoundBody))
 		return &APIError{
-			Path:             path,
-			StatusCode:       resp.StatusCode,
-			Message:          apiErr.Error,
-			RetryAfter:       resp.Header.Get("Retry-After"),
-			routeUnsupported: resp.StatusCode == http.StatusMethodNotAllowed || legacyMux404,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Message:    apiErr.Error,
+			RetryAfter: resp.Header.Get("Retry-After"),
 		}
 	}
 
@@ -194,13 +148,6 @@ type APIError struct {
 	// RetryAfter is the raw Retry-After header (seconds), present on 429s so
 	// callers can honour the broker's backoff request.
 	RetryAfter string
-
-	routeUnsupported bool
-}
-
-func isRouteUnsupported(err error) bool {
-	var apiErr *APIError
-	return errors.As(err, &apiErr) && apiErr.routeUnsupported
 }
 
 func (e *APIError) Error() string {

--- a/internal/relayruntime/broker_test.go
+++ b/internal/relayruntime/broker_test.go
@@ -1,7 +1,6 @@
 package relayruntime
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -38,7 +37,7 @@ func TestBrokerClientUsesCanonicalRoutes(t *testing.T) {
 			t.Errorf("Content-Type = %q, want application/json", got)
 		}
 		switch r.URL.Path {
-		case canonicalRegisterPath:
+		case relayRegisterPath:
 			var req relay.RegisterRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Errorf("decode register request: %v", err)
@@ -52,7 +51,7 @@ func TestBrokerClientUsesCanonicalRoutes(t *testing.T) {
 				PublicPort: 443,
 				ExpiresAt:  expiresAt,
 			})
-		case canonicalHeartbeatPathBase + "relay_canonical/heartbeat":
+		case relayHeartbeatPathBase + "relay_canonical/heartbeat":
 			var body map[string]bool
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Errorf("decode heartbeat request: %v", err)
@@ -89,178 +88,15 @@ func TestBrokerClientUsesCanonicalRoutes(t *testing.T) {
 	gotPaths := append([]string(nil), paths...)
 	mu.Unlock()
 	wantPaths := []string{
-		canonicalRegisterPath,
-		canonicalHeartbeatPathBase + "relay_canonical/heartbeat",
+		relayRegisterPath,
+		relayHeartbeatPathBase + "relay_canonical/heartbeat",
 	}
 	if !reflect.DeepEqual(gotPaths, wantPaths) {
 		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
 	}
 }
 
-func TestBrokerClientRegister404FallbackIsSticky(t *testing.T) {
-	t.Parallel()
-
-	type observedRequest struct {
-		path        string
-		authorize   string
-		contentType string
-		body        []byte
-	}
-	var (
-		mu       sync.Mutex
-		requests []observedRequest
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		requests = append(requests, observedRequest{
-			path:        r.URL.Path,
-			authorize:   r.Header.Get("Authorization"),
-			contentType: r.Header.Get("Content-Type"),
-			body:        body,
-		})
-		mu.Unlock()
-
-		switch r.URL.Path {
-		case canonicalRegisterPath:
-			http.NotFound(w, r)
-		case legacyRegisterPath:
-			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_legacy"})
-		case legacyHeartbeatPathBase + "relay_legacy/heartbeat":
-			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
-		case legacyHeartbeatPathBase + "relay_missing/heartbeat":
-			writeBrokerJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
-		default:
-			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	req := testBrokerRegisterRequest()
-	client := &BrokerClient{BaseURL: server.URL, Token: "relay-token", HTTPClient: server.Client()}
-	for i := 0; i < 2; i++ {
-		if _, err := client.Register(context.Background(), req); err != nil {
-			t.Fatalf("Register() call %d error = %v", i+1, err)
-		}
-	}
-	if err := client.Heartbeat(context.Background(), "relay_legacy"); err != nil {
-		t.Fatalf("Heartbeat() error = %v", err)
-	}
-	if err := client.Heartbeat(context.Background(), "relay_missing"); !IsRelayNotFound(err) {
-		t.Fatalf("Heartbeat() missing relay error = %v, want relay-not-found API error", err)
-	}
-
-	mu.Lock()
-	gotRequests := append([]observedRequest(nil), requests...)
-	mu.Unlock()
-	wantPaths := []string{
-		canonicalRegisterPath,
-		legacyRegisterPath,
-		legacyRegisterPath,
-		legacyHeartbeatPathBase + "relay_legacy/heartbeat",
-		legacyHeartbeatPathBase + "relay_missing/heartbeat",
-	}
-	if len(gotRequests) != len(wantPaths) {
-		t.Fatalf("request count = %d, want %d: %+v", len(gotRequests), len(wantPaths), gotRequests)
-	}
-	for i, wantPath := range wantPaths {
-		if gotRequests[i].path != wantPath {
-			t.Errorf("request %d path = %q, want %q", i+1, gotRequests[i].path, wantPath)
-		}
-		if gotRequests[i].authorize != "Bearer relay-token" {
-			t.Errorf("request %d Authorization = %q, want bearer token", i+1, gotRequests[i].authorize)
-		}
-		if gotRequests[i].contentType != "application/json" {
-			t.Errorf("request %d Content-Type = %q, want application/json", i+1, gotRequests[i].contentType)
-		}
-	}
-	wantBody, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("Marshal(register request) error = %v", err)
-	}
-	for _, index := range []int{0, 1, 2} {
-		if !bytes.Equal(gotRequests[index].body, wantBody) {
-			t.Errorf("register request %d body = %q, want %q", index+1, gotRequests[index].body, wantBody)
-		}
-	}
-}
-
-func TestBrokerClientHeartbeatFirst405FallbackIsSticky(t *testing.T) {
-	t.Parallel()
-
-	type observedRequest struct {
-		path        string
-		authorize   string
-		contentType string
-		body        []byte
-	}
-	var (
-		mu       sync.Mutex
-		requests []observedRequest
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		requests = append(requests, observedRequest{
-			path:        r.URL.Path,
-			authorize:   r.Header.Get("Authorization"),
-			contentType: r.Header.Get("Content-Type"),
-			body:        body,
-		})
-		mu.Unlock()
-
-		switch r.URL.Path {
-		case canonicalHeartbeatPathBase + "relay_existing/heartbeat":
-			writeBrokerJSON(w, http.StatusMethodNotAllowed, relay.ErrorResponse{Error: "method not allowed"})
-		case legacyHeartbeatPathBase + "relay_existing/heartbeat":
-			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
-		case legacyRegisterPath:
-			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_existing"})
-		default:
-			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := &BrokerClient{BaseURL: server.URL, Token: "relay-token", HTTPClient: server.Client()}
-	if err := client.Heartbeat(context.Background(), "relay_existing"); err != nil {
-		t.Fatalf("Heartbeat() error = %v", err)
-	}
-	if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err != nil {
-		t.Fatalf("Register() error = %v", err)
-	}
-
-	mu.Lock()
-	gotRequests := append([]observedRequest(nil), requests...)
-	mu.Unlock()
-	wantPaths := []string{
-		canonicalHeartbeatPathBase + "relay_existing/heartbeat",
-		legacyHeartbeatPathBase + "relay_existing/heartbeat",
-		legacyRegisterPath,
-	}
-	if len(gotRequests) != len(wantPaths) {
-		t.Fatalf("request count = %d, want %d: %+v", len(gotRequests), len(wantPaths), gotRequests)
-	}
-	for i, wantPath := range wantPaths {
-		if gotRequests[i].path != wantPath {
-			t.Errorf("request %d path = %q, want %q", i+1, gotRequests[i].path, wantPath)
-		}
-		if gotRequests[i].authorize != "Bearer relay-token" {
-			t.Errorf("request %d Authorization = %q, want bearer token", i+1, gotRequests[i].authorize)
-		}
-		if gotRequests[i].contentType != "application/json" {
-			t.Errorf("request %d Content-Type = %q, want application/json", i+1, gotRequests[i].contentType)
-		}
-	}
-	if !bytes.Equal(gotRequests[0].body, gotRequests[1].body) {
-		t.Errorf("heartbeat retry body = %q, want canonical body %q", gotRequests[1].body, gotRequests[0].body)
-	}
-	if !bytes.Equal(gotRequests[0].body, []byte(`{"ok":true}`)) {
-		t.Errorf("heartbeat body = %q, want {\"ok\":true}", gotRequests[0].body)
-	}
-}
-
-func TestBrokerClientRelayNotFoundDoesNotFallback(t *testing.T) {
+func TestBrokerClientRelayNotFoundUsesCanonicalRoute(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -273,12 +109,12 @@ func TestBrokerClientRelayNotFoundDoesNotFallback(t *testing.T) {
 		mu.Unlock()
 
 		switch r.URL.Path {
-		case canonicalHeartbeatPathBase + "relay_missing/heartbeat":
+		case relayHeartbeatPathBase + "relay_missing/heartbeat":
 			writeBrokerJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
-		case canonicalRegisterPath:
+		case relayRegisterPath:
 			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_new"})
 		default:
-			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "legacy route must not be called"})
+			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -292,7 +128,7 @@ func TestBrokerClientRelayNotFoundDoesNotFallback(t *testing.T) {
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("Heartbeat() error type = %T, want *APIError", err)
 	}
-	if apiErr.Path != canonicalHeartbeatPathBase+"relay_missing/heartbeat" || apiErr.StatusCode != http.StatusNotFound || apiErr.Message != "relay not found" {
+	if apiErr.Path != relayHeartbeatPathBase+"relay_missing/heartbeat" || apiErr.StatusCode != http.StatusNotFound || apiErr.Message != "relay not found" {
 		t.Errorf("APIError = %+v, want canonical 404 relay not found", apiErr)
 	}
 	if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err != nil {
@@ -303,19 +139,20 @@ func TestBrokerClientRelayNotFoundDoesNotFallback(t *testing.T) {
 	gotPaths := append([]string(nil), paths...)
 	mu.Unlock()
 	wantPaths := []string{
-		canonicalHeartbeatPathBase + "relay_missing/heartbeat",
-		canonicalRegisterPath,
+		relayHeartbeatPathBase + "relay_missing/heartbeat",
+		relayRegisterPath,
 	}
 	if !reflect.DeepEqual(gotPaths, wantPaths) {
 		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
 	}
 }
 
-func TestBrokerClientDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
+func TestBrokerClientReturnsCanonicalHTTPFailures(t *testing.T) {
 	t.Parallel()
 
 	for _, status := range []int{
 		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 		http.StatusForbidden,
@@ -327,21 +164,17 @@ func TestBrokerClientDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			t.Parallel()
 
-			var canonical, legacy atomic.Int64
+			var requests atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case canonicalRegisterPath:
-					canonical.Add(1)
-					if status == http.StatusTooManyRequests {
-						w.Header().Set("Retry-After", "17")
-					}
-					writeBrokerJSON(w, status, relay.ErrorResponse{Error: "deliberate failure"})
-				case legacyRegisterPath:
-					legacy.Add(1)
-					writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
-				default:
+				if r.URL.Path != relayRegisterPath {
 					writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+					return
 				}
+				requests.Add(1)
+				if status == http.StatusTooManyRequests {
+					w.Header().Set("Retry-After", "17")
+				}
+				writeBrokerJSON(w, status, relay.ErrorResponse{Error: "deliberate failure"})
 			}))
 			t.Cleanup(server.Close)
 
@@ -355,24 +188,21 @@ func TestBrokerClientDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
 				if !errors.As(err, &apiErr) {
 					t.Fatalf("Register() call %d error type = %T, want *APIError", i+1, err)
 				}
-				if apiErr.Path != canonicalRegisterPath || apiErr.StatusCode != status || apiErr.Message != "deliberate failure" {
+				if apiErr.Path != relayRegisterPath || apiErr.StatusCode != status || apiErr.Message != "deliberate failure" {
 					t.Errorf("APIError = %+v, want canonical status %d", apiErr, status)
 				}
 				if status == http.StatusTooManyRequests && apiErr.RetryAfter != "17" {
 					t.Errorf("RetryAfter = %q, want 17", apiErr.RetryAfter)
 				}
 			}
-			if got := canonical.Load(); got != 2 {
-				t.Errorf("canonical request count = %d, want 2", got)
-			}
-			if got := legacy.Load(); got != 0 {
-				t.Errorf("legacy request count = %d, want 0", got)
+			if got := requests.Load(); got != 2 {
+				t.Errorf("request count = %d, want 2", got)
 			}
 		})
 	}
 }
 
-func TestBrokerClientDoesNotFallbackOnOther404Shapes(t *testing.T) {
+func TestBrokerClientReturnsCanonical404Shapes(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -383,49 +213,48 @@ func TestBrokerClientDoesNotFallbackOnOther404Shapes(t *testing.T) {
 		{name: "empty body", contentType: "text/plain; charset=utf-8"},
 		{name: "HTML body", contentType: "text/html; charset=utf-8", body: "<h1>Not Found</h1>"},
 		{name: "malformed JSON", contentType: "application/json", body: `{"error":`},
-		{name: "other plaintext", contentType: "text/plain; charset=utf-8", body: "route not found\n"},
-		{name: "legacy body with wrong type", contentType: "text/html", body: legacyServeMuxNotFoundBody},
-		{name: "plaintext prefix type", contentType: "text/plain-legacy", body: legacyServeMuxNotFoundBody},
-		{name: "oversized body", contentType: "text/plain; charset=utf-8", body: legacyServeMuxNotFoundBody + strings.Repeat("x", maxBrokerErrorBodyBytes)},
+		{name: "plaintext", contentType: "text/plain; charset=utf-8", body: "404 page not found\n"},
+		{name: "oversized body", contentType: "application/json", body: `{"error":"` + strings.Repeat("x", maxBrokerErrorBodyBytes)},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var canonical, legacy atomic.Int64
+			var requests atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case canonicalRegisterPath:
-					canonical.Add(1)
-					w.Header().Set("Content-Type", tc.contentType)
-					w.WriteHeader(http.StatusNotFound)
-					_, _ = io.WriteString(w, tc.body)
-				case legacyRegisterPath:
-					legacy.Add(1)
-					writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
-				default:
+				if r.URL.Path != relayRegisterPath {
 					writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+					return
 				}
+				requests.Add(1)
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, tc.body)
 			}))
 			t.Cleanup(server.Close)
 
 			client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
 			for i := 0; i < 2; i++ {
-				if _, err := client.Register(context.Background(), testBrokerRegisterRequest()); err == nil {
+				_, err := client.Register(context.Background(), testBrokerRegisterRequest())
+				if err == nil {
 					t.Fatalf("Register() call %d error = nil, want 404 failure", i+1)
 				}
+				var apiErr *APIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("Register() call %d error type = %T, want *APIError", i+1, err)
+				}
+				if apiErr.Path != relayRegisterPath || apiErr.StatusCode != http.StatusNotFound || apiErr.Message != "404 Not Found" {
+					t.Errorf("APIError = %+v, want canonical 404 with status-derived message", apiErr)
+				}
 			}
-			if got := canonical.Load(); got != 2 {
-				t.Errorf("canonical request count = %d, want 2", got)
-			}
-			if got := legacy.Load(); got != 0 {
-				t.Errorf("legacy request count = %d, want 0", got)
+			if got := requests.Load(); got != 2 {
+				t.Errorf("request count = %d, want 2", got)
 			}
 		})
 	}
 }
 
-func TestBrokerClientRefusesRedirectsWithoutFallback(t *testing.T) {
+func TestBrokerClientRefusesRedirects(t *testing.T) {
 	t.Parallel()
 
 	for _, redirectStatus := range []int{
@@ -438,18 +267,15 @@ func TestBrokerClientRefusesRedirectsWithoutFallback(t *testing.T) {
 		t.Run(http.StatusText(redirectStatus), func(t *testing.T) {
 			t.Parallel()
 
-			var canonical, redirected, legacy atomic.Int64
+			var requests, redirected atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
-				case canonicalRegisterPath:
-					canonical.Add(1)
+				case relayRegisterPath:
+					requests.Add(1)
 					http.Redirect(w, r, "/redirect-target", redirectStatus)
 				case "/redirect-target":
 					redirected.Add(1)
 					writeBrokerJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "route not found"})
-				case legacyRegisterPath:
-					legacy.Add(1)
-					writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
 				default:
 					writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
 				}
@@ -463,28 +289,25 @@ func TestBrokerClientRefusesRedirectsWithoutFallback(t *testing.T) {
 					t.Fatalf("Register() call %d error = %v, want redirect refusal", i+1, err)
 				}
 			}
-			if got := canonical.Load(); got != 2 {
-				t.Errorf("canonical request count = %d, want 2", got)
+			if got := requests.Load(); got != 2 {
+				t.Errorf("request count = %d, want 2", got)
 			}
 			if got := redirected.Load(); got != 0 {
 				t.Errorf("redirect-target request count = %d, want 0", got)
-			}
-			if got := legacy.Load(); got != 0 {
-				t.Errorf("legacy request count = %d, want 0", got)
 			}
 		})
 	}
 }
 
-func TestBrokerClientDoesNotFallbackOnNetworkOrDecodeErrors(t *testing.T) {
+func TestBrokerClientReturnsNetworkOrDecodeErrors(t *testing.T) {
 	t.Parallel()
 
 	t.Run("network", func(t *testing.T) {
 		var calls atomic.Int64
 		httpClient := &http.Client{Transport: brokerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			calls.Add(1)
-			if req.URL.Path != canonicalRegisterPath {
-				t.Errorf("request path = %q, want %q", req.URL.Path, canonicalRegisterPath)
+			if req.URL.Path != relayRegisterPath {
+				t.Errorf("request path = %q, want %q", req.URL.Path, relayRegisterPath)
 			}
 			return nil, errors.New("network unavailable")
 		})}
@@ -500,20 +323,16 @@ func TestBrokerClientDoesNotFallbackOnNetworkOrDecodeErrors(t *testing.T) {
 	})
 
 	t.Run("decode", func(t *testing.T) {
-		var canonical, legacy atomic.Int64
+		var requests atomic.Int64
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case canonicalRegisterPath:
-				canonical.Add(1)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = io.WriteString(w, `{"id":`)
-			case legacyRegisterPath:
-				legacy.Add(1)
-				writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "must_not_register"})
-			default:
+			if r.URL.Path != relayRegisterPath {
 				writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				return
 			}
+			requests.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":`)
 		}))
 		t.Cleanup(server.Close)
 
@@ -523,76 +342,10 @@ func TestBrokerClientDoesNotFallbackOnNetworkOrDecodeErrors(t *testing.T) {
 				t.Fatalf("Register() call %d error = nil, want decode failure", i+1)
 			}
 		}
-		if got := canonical.Load(); got != 2 {
-			t.Errorf("canonical request count = %d, want 2", got)
-		}
-		if got := legacy.Load(); got != 0 {
-			t.Errorf("legacy request count = %d, want 0", got)
+		if got := requests.Load(); got != 2 {
+			t.Errorf("request count = %d, want 2", got)
 		}
 	})
-}
-
-func TestBrokerClientConcurrentLegacyDiscovery(t *testing.T) {
-	t.Parallel()
-
-	const workers = 48
-	var canonical, legacy atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case canonicalRegisterPath:
-			canonical.Add(1)
-			http.NotFound(w, r)
-		case legacyRegisterPath:
-			legacy.Add(1)
-			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{ID: "relay_legacy"})
-		case legacyHeartbeatPathBase + "relay_legacy/heartbeat":
-			legacy.Add(1)
-			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
-		default:
-			writeBrokerJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
-	start := make(chan struct{})
-	errs := make(chan error, workers)
-	var wg sync.WaitGroup
-	wg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			defer wg.Done()
-			<-start
-			_, err := client.Register(context.Background(), testBrokerRegisterRequest())
-			errs <- err
-		}()
-	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Errorf("concurrent Register() error = %v", err)
-		}
-	}
-
-	canonicalAfterDiscovery := canonical.Load()
-	if canonicalAfterDiscovery < 1 || canonicalAfterDiscovery > workers {
-		t.Errorf("canonical discovery request count = %d, want between 1 and %d", canonicalAfterDiscovery, workers)
-	}
-	if got := legacy.Load(); got != workers {
-		t.Errorf("legacy request count = %d, want %d", got, workers)
-	}
-
-	if err := client.Heartbeat(context.Background(), "relay_legacy"); err != nil {
-		t.Fatalf("Heartbeat() after concurrent discovery error = %v", err)
-	}
-	if got := canonical.Load(); got != canonicalAfterDiscovery {
-		t.Errorf("canonical requests after sticky fallback = %d, want %d", got, canonicalAfterDiscovery)
-	}
-	if got := legacy.Load(); got != workers+1 {
-		t.Errorf("legacy requests after sticky fallback = %d, want %d", got, workers+1)
-	}
 }
 
 func TestBrokerClientSecureTransportAllowsLoopbackHTTP(t *testing.T) {
@@ -601,13 +354,13 @@ func TestBrokerClientSecureTransportAllowsLoopbackHTTP(t *testing.T) {
 			t.Errorf("Authorization = %q, want foundation bearer", got)
 		}
 		switch r.URL.Path {
-		case canonicalRegisterPath:
+		case relayRegisterPath:
 			body, err := json.Marshal(relay.Descriptor{ID: "relay_foundation"})
 			if err != nil {
 				return nil, err
 			}
 			return brokerJSONResponse(r, http.StatusCreated, string(body)), nil
-		case canonicalHeartbeatPathBase + "relay_foundation/heartbeat":
+		case relayHeartbeatPathBase + "relay_foundation/heartbeat":
 			return brokerJSONResponse(r, http.StatusOK, `{}`), nil
 		default:
 			return brokerJSONResponse(r, http.StatusNotFound, `{"error":"not found"}`), nil

--- a/internal/relayruntime/engine/engine_test.go
+++ b/internal/relayruntime/engine/engine_test.go
@@ -37,14 +37,11 @@ func freePort(t *testing.T) int {
 	return port
 }
 
-// fakeBroker implements only the canonical relay endpoints with configurable
-// heartbeat failures. Legacy requests are recorded so the integration test can
-// prove the desktop engine does not need compatibility routing on a new broker.
+// fakeBroker implements the relay endpoints with configurable heartbeat failures.
 type fakeBroker struct {
 	mu           sync.Mutex
 	registers    int
 	heartbeats   int
-	legacyCalls  int
 	nextRelayID  int
 	lastRegister relay.RegisterRequest
 	// notFoundOnce makes the next heartbeat return the broker's pruned-relay
@@ -79,12 +76,6 @@ func (f *fakeBroker) handler() http.Handler {
 		}
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	})
-	mux.HandleFunc("/api/v1/volunteers/", func(w http.ResponseWriter, _ *http.Request) {
-		f.mu.Lock()
-		f.legacyCalls++
-		f.mu.Unlock()
-		http.Error(w, "legacy route used", http.StatusInternalServerError)
-	})
 	return mux
 }
 
@@ -92,12 +83,6 @@ func (f *fakeBroker) stats() (registers, heartbeats int, last relay.RegisterRequ
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.registers, f.heartbeats, f.lastRegister
-}
-
-func (f *fakeBroker) legacyCallCount() int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.legacyCalls
 }
 
 func eventually(t *testing.T, timeout time.Duration, what string, cond func() bool) {
@@ -177,10 +162,6 @@ func TestDirectSessionRegistersAndRecovers(t *testing.T) {
 	if last.Label != "test-relay" {
 		t.Fatalf("registered label = %q", last.Label)
 	}
-	if legacyCalls := broker.legacyCallCount(); legacyCalls != 0 {
-		t.Fatalf("legacy broker calls = %d, want 0", legacyCalls)
-	}
-
 	mu.Lock()
 	sawRegistering := false
 	for _, s := range statuses {

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -82,9 +82,8 @@ func (b *brokerRegistrar) Heartbeat(ctx context.Context, relayID string) error {
 
 // brokerHTTPError is a non-2xx broker response.
 type brokerHTTPError struct {
-	path       string
-	statusCode int
-	message    string
+	path    string
+	message string
 }
 
 func (e *brokerHTTPError) Error() string {
@@ -123,9 +122,8 @@ func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out a
 			return fmt.Errorf("broker %s: %w", path, ErrRelayNotFound)
 		}
 		return &brokerHTTPError{
-			path:       path,
-			statusCode: resp.StatusCode,
-			message:    apiErr.Error,
+			path:    path,
+			message: apiErr.Error,
 		}
 	}
 	if out != nil {

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"openrung/internal/relay"
@@ -20,10 +19,7 @@ import (
 // restart. The caller should re-register rather than keep heartbeating.
 var ErrRelayNotFound = errors.New("relay not found")
 
-const (
-	maxBrokerErrorBodyBytes    = 64 << 10
-	legacyServeMuxNotFoundBody = "404 page not found\n"
-)
+const maxBrokerErrorBodyBytes = 64 << 10
 
 // RelayRegistration is the result of registering a tunneled relay with the broker.
 type RelayRegistration struct {
@@ -41,18 +37,11 @@ type Registrar interface {
 }
 
 // brokerRegistrar registers relays over the broker's canonical HTTP API using
-// the same bearer token volunteer-class relays use. It keeps the legacy route
-// family available for brokers that predate the canonical write endpoints.
+// the same bearer token volunteer-class relays use.
 type brokerRegistrar struct {
 	brokerURL string
 	token     string
 	client    *http.Client
-
-	// legacyRoutes is broker-wide for this registrar: once either canonical
-	// write endpoint proves unavailable, registration and heartbeats both stay
-	// on the compatibility route family. Atomic state keeps concurrent hub
-	// registrations race-safe and the transition monotonic.
-	legacyRoutes atomic.Bool
 }
 
 // NewBrokerRegistrar builds a Registrar backed by the broker HTTP API.
@@ -61,8 +50,7 @@ func NewBrokerRegistrar(brokerURL, token string, client *http.Client) Registrar 
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
 	// Broker write endpoints are canonical and must never redirect. Refusing
-	// redirects prevents forwarding the bearer token to another URL and ensures
-	// a redirected 404/405 cannot be mistaken for an unsupported route.
+	// redirects prevents forwarding the bearer token to another URL.
 	noRedirectClient := *client
 	noRedirectClient.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
@@ -75,22 +63,8 @@ func NewBrokerRegistrar(brokerURL, token string, client *http.Client) Registrar 
 }
 
 func (b *brokerRegistrar) Register(ctx context.Context, req relay.RegisterRequest) (RelayRegistration, error) {
-	if b.legacyRoutes.Load() {
-		return b.registerAt(ctx, "/api/v1/volunteers/register", req)
-	}
-
-	registration, err := b.registerAt(ctx, "/api/v1/relays/register", req)
-	if !isRouteUnsupported(err) {
-		return registration, err
-	}
-
-	b.legacyRoutes.Store(true)
-	return b.registerAt(ctx, "/api/v1/volunteers/register", req)
-}
-
-func (b *brokerRegistrar) registerAt(ctx context.Context, path string, req relay.RegisterRequest) (RelayRegistration, error) {
 	var desc relay.Descriptor
-	if err := b.postJSON(ctx, path, req, &desc); err != nil {
+	if err := b.postJSON(ctx, "/api/v1/relays/register", req, &desc); err != nil {
 		return RelayRegistration{}, err
 	}
 	return RelayRegistration{
@@ -102,39 +76,19 @@ func (b *brokerRegistrar) registerAt(ctx context.Context, path string, req relay
 }
 
 func (b *brokerRegistrar) Heartbeat(ctx context.Context, relayID string) error {
-	if b.legacyRoutes.Load() {
-		return b.heartbeatAt(ctx, "/api/v1/volunteers/", relayID)
-	}
-
-	err := b.heartbeatAt(ctx, "/api/v1/relays/", relayID)
-	if !isRouteUnsupported(err) {
-		return err
-	}
-
-	b.legacyRoutes.Store(true)
-	return b.heartbeatAt(ctx, "/api/v1/volunteers/", relayID)
-}
-
-func (b *brokerRegistrar) heartbeatAt(ctx context.Context, routeBase, relayID string) error {
 	var resp relay.HeartbeatResponse
-	return b.postJSON(ctx, routeBase+relayID+"/heartbeat", map[string]bool{"ok": true}, &resp)
+	return b.postJSON(ctx, "/api/v1/relays/"+relayID+"/heartbeat", map[string]bool{"ok": true}, &resp)
 }
 
 // brokerHTTPError is a non-2xx broker response.
 type brokerHTTPError struct {
-	path             string
-	statusCode       int
-	message          string
-	routeUnsupported bool
+	path       string
+	statusCode int
+	message    string
 }
 
 func (e *brokerHTTPError) Error() string {
 	return fmt.Sprintf("broker %s: %s", e.path, e.message)
-}
-
-func isRouteUnsupported(err error) bool {
-	var responseErr *brokerHTTPError
-	return errors.As(err, &responseErr) && responseErr.routeUnsupported
 }
 
 func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out any) error {
@@ -168,16 +122,10 @@ func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out a
 		if resp.StatusCode == http.StatusNotFound && apiErr.Error == "relay not found" {
 			return fmt.Errorf("broker %s: %w", path, ErrRelayNotFound)
 		}
-		mediaType, _, _ := strings.Cut(resp.Header.Get("Content-Type"), ";")
-		legacyMux404 := resp.StatusCode == http.StatusNotFound &&
-			readErr == nil && bodyWithinLimit &&
-			strings.EqualFold(strings.TrimSpace(mediaType), "text/plain") &&
-			bytes.Equal(errorBody, []byte(legacyServeMuxNotFoundBody))
 		return &brokerHTTPError{
-			path:             path,
-			statusCode:       resp.StatusCode,
-			message:          apiErr.Error,
-			routeUnsupported: resp.StatusCode == http.StatusMethodNotAllowed || legacyMux404,
+			path:       path,
+			statusCode: resp.StatusCode,
+			message:    apiErr.Error,
 		}
 	}
 	if out != nil {

--- a/internal/tunnel/registrar_test.go
+++ b/internal/tunnel/registrar_test.go
@@ -179,8 +179,8 @@ func TestBrokerRegistrarReturnsCanonicalHTTPFailures(t *testing.T) {
 			if !errors.As(err, &responseErr) {
 				t.Fatalf("Register() error type = %T, want *brokerHTTPError", err)
 			}
-			if responseErr.path != canonicalRegisterPath || responseErr.statusCode != status || responseErr.message != "deliberate failure" {
-				t.Errorf("brokerHTTPError = %+v, want canonical status %d", responseErr, status)
+			if responseErr.path != canonicalRegisterPath || responseErr.message != "deliberate failure" {
+				t.Errorf("brokerHTTPError = %+v, want canonical failure for status %d", responseErr, status)
 			}
 			if got := calls.Load(); got != 1 {
 				t.Errorf("request count = %d, want 1", got)

--- a/internal/tunnel/registrar_test.go
+++ b/internal/tunnel/registrar_test.go
@@ -1,7 +1,6 @@
 package tunnel
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,10 +17,7 @@ import (
 	"openrung/internal/relay"
 )
 
-const (
-	canonicalRegisterPath = "/api/v1/relays/register"
-	legacyRegisterPath    = "/api/v1/volunteers/register"
-)
+const canonicalRegisterPath = "/api/v1/relays/register"
 
 func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 	t.Parallel()
@@ -39,8 +36,18 @@ func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 			http.Error(w, "missing authorization", http.StatusUnauthorized)
 			return
 		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
 		switch r.URL.Path {
 		case canonicalRegisterPath:
+			var req relay.RegisterRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode register request: %v", err)
+			}
+			if !reflect.DeepEqual(req, testRegisterRequest()) {
+				t.Errorf("register request = %+v, want %+v", req, testRegisterRequest())
+			}
 			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{
 				ID:         "relay_canonical",
 				PublicHost: "203.0.113.10",
@@ -48,6 +55,13 @@ func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 				ExpiresAt:  expiresAt,
 			})
 		case "/api/v1/relays/relay_canonical/heartbeat":
+			var body map[string]bool
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode heartbeat request: %v", err)
+			}
+			if !body["ok"] {
+				t.Errorf("heartbeat body = %v, want ok=true", body)
+			}
 			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true, ExpiresAt: expiresAt})
 		default:
 			writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "unexpected path"})
@@ -85,205 +99,7 @@ func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 	}
 }
 
-func TestBrokerRegistrarRegister404FallbackIsSticky(t *testing.T) {
-	t.Parallel()
-
-	var (
-		mu    sync.Mutex
-		paths []string
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		paths = append(paths, r.URL.Path)
-		mu.Unlock()
-
-		switch r.URL.Path {
-		case canonicalRegisterPath:
-			http.NotFound(w, r) // matches an old broker's ServeMux response
-		case legacyRegisterPath:
-			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_legacy"})
-		case "/api/v1/volunteers/relay_legacy/heartbeat":
-			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
-		case "/api/v1/volunteers/relay_missing/heartbeat":
-			writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "relay not found"})
-		default:
-			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
-	for i := 0; i < 2; i++ {
-		if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
-			t.Fatalf("Register() call %d error = %v", i+1, err)
-		}
-	}
-	if err := registrar.Heartbeat(context.Background(), "relay_legacy"); err != nil {
-		t.Fatalf("Heartbeat() error = %v", err)
-	}
-	if err := registrar.Heartbeat(context.Background(), "relay_missing"); !errors.Is(err, ErrRelayNotFound) {
-		t.Fatalf("Heartbeat() missing relay error = %v, want ErrRelayNotFound", err)
-	}
-
-	mu.Lock()
-	gotPaths := append([]string(nil), paths...)
-	mu.Unlock()
-	wantPaths := []string{
-		canonicalRegisterPath,
-		legacyRegisterPath,
-		legacyRegisterPath,
-		"/api/v1/volunteers/relay_legacy/heartbeat",
-		"/api/v1/volunteers/relay_missing/heartbeat",
-	}
-	if !reflect.DeepEqual(gotPaths, wantPaths) {
-		t.Fatalf("request paths = %q, want %q", gotPaths, wantPaths)
-	}
-}
-
-func TestBrokerRegistrarHeartbeatFirst405FallbackIsSticky(t *testing.T) {
-	t.Parallel()
-
-	type observedRequest struct {
-		path        string
-		authorize   string
-		contentType string
-		body        []byte
-	}
-	var (
-		mu       sync.Mutex
-		requests []observedRequest
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		requests = append(requests, observedRequest{
-			path:        r.URL.Path,
-			authorize:   r.Header.Get("Authorization"),
-			contentType: r.Header.Get("Content-Type"),
-			body:        body,
-		})
-		mu.Unlock()
-
-		switch r.URL.Path {
-		case "/api/v1/relays/relay_existing/heartbeat":
-			writeRegistrarJSON(w, http.StatusMethodNotAllowed, relay.ErrorResponse{Error: "method not allowed"})
-		case "/api/v1/volunteers/relay_existing/heartbeat":
-			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true})
-		case legacyRegisterPath:
-			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_existing"})
-		default:
-			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	registrar := NewBrokerRegistrar(server.URL, "relay-token", server.Client())
-	if err := registrar.Heartbeat(context.Background(), "relay_existing"); err != nil {
-		t.Fatalf("Heartbeat() error = %v", err)
-	}
-	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
-		t.Fatalf("Register() error = %v", err)
-	}
-
-	mu.Lock()
-	gotRequests := append([]observedRequest(nil), requests...)
-	mu.Unlock()
-	if len(gotRequests) != 3 {
-		t.Fatalf("request count = %d, want 3: %+v", len(gotRequests), gotRequests)
-	}
-	wantPaths := []string{
-		"/api/v1/relays/relay_existing/heartbeat",
-		"/api/v1/volunteers/relay_existing/heartbeat",
-		legacyRegisterPath,
-	}
-	for i, wantPath := range wantPaths {
-		if gotRequests[i].path != wantPath {
-			t.Errorf("request %d path = %q, want %q", i+1, gotRequests[i].path, wantPath)
-		}
-		if gotRequests[i].authorize != "Bearer relay-token" {
-			t.Errorf("request %d Authorization = %q, want bearer token", i+1, gotRequests[i].authorize)
-		}
-		if gotRequests[i].contentType != "application/json" {
-			t.Errorf("request %d Content-Type = %q, want application/json", i+1, gotRequests[i].contentType)
-		}
-	}
-	if !bytes.Equal(gotRequests[0].body, gotRequests[1].body) {
-		t.Errorf("heartbeat retry body = %q, want canonical body %q", gotRequests[1].body, gotRequests[0].body)
-	}
-	if !bytes.Equal(gotRequests[0].body, []byte(`{"ok":true}`)) {
-		t.Errorf("heartbeat body = %q, want {\"ok\":true}", gotRequests[0].body)
-	}
-}
-
-func TestBrokerRegistrarFallbackPreservesRegisterRequest(t *testing.T) {
-	t.Parallel()
-
-	type observedRequest struct {
-		path        string
-		authorize   string
-		contentType string
-		body        []byte
-	}
-	var (
-		mu       sync.Mutex
-		requests []observedRequest
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		requests = append(requests, observedRequest{
-			path:        r.URL.Path,
-			authorize:   r.Header.Get("Authorization"),
-			contentType: r.Header.Get("Content-Type"),
-			body:        body,
-		})
-		mu.Unlock()
-
-		if r.URL.Path == canonicalRegisterPath {
-			writeRegistrarJSON(w, http.StatusMethodNotAllowed, relay.ErrorResponse{Error: "method not allowed"})
-			return
-		}
-		if r.URL.Path == legacyRegisterPath {
-			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_legacy"})
-			return
-		}
-		writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-	}))
-	t.Cleanup(server.Close)
-
-	req := testRegisterRequest()
-	registrar := NewBrokerRegistrar(server.URL, "relay-token", server.Client())
-	if _, err := registrar.Register(context.Background(), req); err != nil {
-		t.Fatalf("Register() error = %v", err)
-	}
-
-	mu.Lock()
-	gotRequests := append([]observedRequest(nil), requests...)
-	mu.Unlock()
-	if len(gotRequests) != 2 {
-		t.Fatalf("request count = %d, want 2: %+v", len(gotRequests), gotRequests)
-	}
-	if gotRequests[0].path != canonicalRegisterPath || gotRequests[1].path != legacyRegisterPath {
-		t.Fatalf("request paths = [%q %q], want [%q %q]", gotRequests[0].path, gotRequests[1].path, canonicalRegisterPath, legacyRegisterPath)
-	}
-	wantBody, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("Marshal(register request) error = %v", err)
-	}
-	for i, got := range gotRequests {
-		if got.authorize != "Bearer relay-token" {
-			t.Errorf("request %d Authorization = %q, want bearer token", i+1, got.authorize)
-		}
-		if got.contentType != "application/json" {
-			t.Errorf("request %d Content-Type = %q, want application/json", i+1, got.contentType)
-		}
-		if !bytes.Equal(got.body, wantBody) {
-			t.Errorf("request %d body = %q, want %q", i+1, got.body, wantBody)
-		}
-	}
-}
-
-func TestBrokerRegistrarRelayNotFoundDoesNotFallback(t *testing.T) {
+func TestBrokerRegistrarMapsRelayNotFound(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -301,7 +117,7 @@ func TestBrokerRegistrarRelayNotFoundDoesNotFallback(t *testing.T) {
 		case canonicalRegisterPath:
 			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_new"})
 		default:
-			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "legacy route must not be called"})
+			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -327,11 +143,12 @@ func TestBrokerRegistrarRelayNotFoundDoesNotFallback(t *testing.T) {
 	}
 }
 
-func TestBrokerRegistrarDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
+func TestBrokerRegistrarReturnsCanonicalHTTPFailures(t *testing.T) {
 	t.Parallel()
 
 	for _, status := range []int{
 		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 		http.StatusForbidden,
@@ -343,86 +160,57 @@ func TestBrokerRegistrarDoesNotFallbackOnOtherHTTPFailures(t *testing.T) {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			t.Parallel()
 
-			var canonical, legacy atomic.Int64
+			var calls atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case canonicalRegisterPath:
-					canonical.Add(1)
-					writeRegistrarJSON(w, status, relay.ErrorResponse{Error: "deliberate failure"})
-				case legacyRegisterPath:
-					legacy.Add(1)
-					writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
-				default:
-					writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
+				calls.Add(1)
+				if r.URL.Path != canonicalRegisterPath {
+					t.Errorf("request path = %q, want %q", r.URL.Path, canonicalRegisterPath)
 				}
+				writeRegistrarJSON(w, status, relay.ErrorResponse{Error: "deliberate failure"})
 			}))
 			t.Cleanup(server.Close)
 
 			registrar := NewBrokerRegistrar(server.URL, "", server.Client())
-			if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
+			_, err := registrar.Register(context.Background(), testRegisterRequest())
+			if err == nil {
 				t.Fatal("Register() error = nil, want failure")
 			}
-			if got := canonical.Load(); got != 1 {
-				t.Errorf("canonical request count = %d, want 1", got)
+			var responseErr *brokerHTTPError
+			if !errors.As(err, &responseErr) {
+				t.Fatalf("Register() error type = %T, want *brokerHTTPError", err)
 			}
-			if got := legacy.Load(); got != 0 {
-				t.Errorf("legacy request count = %d, want 0", got)
+			if responseErr.path != canonicalRegisterPath || responseErr.statusCode != status || responseErr.message != "deliberate failure" {
+				t.Errorf("brokerHTTPError = %+v, want canonical status %d", responseErr, status)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Errorf("request count = %d, want 1", got)
 			}
 		})
 	}
 }
 
-func TestBrokerRegistrarDoesNotFallbackOnOther404Shapes(t *testing.T) {
+func TestBrokerRegistrarBoundsErrorBody(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		name        string
-		contentType string
-		body        string
-	}{
-		{name: "empty body", contentType: "text/plain; charset=utf-8"},
-		{name: "HTML body", contentType: "text/html; charset=utf-8", body: "<h1>Not Found</h1>"},
-		{name: "malformed JSON", contentType: "application/json", body: `{"error":`},
-		{name: "other plaintext", contentType: "text/plain; charset=utf-8", body: "route not found\n"},
-		{name: "legacy body with wrong type", contentType: "text/html", body: legacyServeMuxNotFoundBody},
-		{name: "plaintext prefix type", contentType: "text/plain-legacy", body: legacyServeMuxNotFoundBody},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, `{"error":"`+strings.Repeat("x", maxBrokerErrorBodyBytes)+`"}`)
+	}))
+	t.Cleanup(server.Close)
 
-			var canonical, legacy atomic.Int64
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case canonicalRegisterPath:
-					canonical.Add(1)
-					w.Header().Set("Content-Type", tc.contentType)
-					w.WriteHeader(http.StatusNotFound)
-					_, _ = io.WriteString(w, tc.body)
-				case legacyRegisterPath:
-					legacy.Add(1)
-					writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
-				default:
-					writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-				}
-			}))
-			t.Cleanup(server.Close)
-
-			registrar := NewBrokerRegistrar(server.URL, "", server.Client())
-			if _, err := registrar.Register(context.Background(), testRegisterRequest()); err == nil {
-				t.Fatal("Register() error = nil, want 404 failure")
-			}
-			if got := canonical.Load(); got != 1 {
-				t.Errorf("canonical request count = %d, want 1", got)
-			}
-			if got := legacy.Load(); got != 0 {
-				t.Errorf("legacy request count = %d, want 0", got)
-			}
-		})
+	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+	_, err := registrar.Register(context.Background(), testRegisterRequest())
+	var responseErr *brokerHTTPError
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("Register() error = %v, want *brokerHTTPError", err)
+	}
+	if responseErr.message != "502 Bad Gateway" {
+		t.Fatalf("error message = %q, want bounded status fallback", responseErr.message)
 	}
 }
 
-func TestBrokerRegistrarRefusesRedirectsWithoutFallback(t *testing.T) {
+func TestBrokerRegistrarRefusesRedirects(t *testing.T) {
 	t.Parallel()
 
 	for _, redirectStatus := range []int{
@@ -435,7 +223,7 @@ func TestBrokerRegistrarRefusesRedirectsWithoutFallback(t *testing.T) {
 		t.Run(http.StatusText(redirectStatus), func(t *testing.T) {
 			t.Parallel()
 
-			var canonical, redirected, legacy atomic.Int64
+			var canonical, redirected atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case canonicalRegisterPath:
@@ -444,9 +232,6 @@ func TestBrokerRegistrarRefusesRedirectsWithoutFallback(t *testing.T) {
 				case "/redirect-target":
 					redirected.Add(1)
 					writeRegistrarJSON(w, http.StatusNotFound, relay.ErrorResponse{Error: "route not found"})
-				case legacyRegisterPath:
-					legacy.Add(1)
-					writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
 				default:
 					writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
 				}
@@ -465,14 +250,11 @@ func TestBrokerRegistrarRefusesRedirectsWithoutFallback(t *testing.T) {
 			if got := redirected.Load(); got != 0 {
 				t.Errorf("redirect-target request count = %d, want 0", got)
 			}
-			if got := legacy.Load(); got != 0 {
-				t.Errorf("legacy request count = %d, want 0", got)
-			}
 		})
 	}
 }
 
-func TestBrokerRegistrarDoesNotFallbackOnNetworkError(t *testing.T) {
+func TestBrokerRegistrarReturnsNetworkError(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int64
@@ -492,10 +274,10 @@ func TestBrokerRegistrarDoesNotFallbackOnNetworkError(t *testing.T) {
 	}
 }
 
-func TestBrokerRegistrarDoesNotFallbackOnDecodeError(t *testing.T) {
+func TestBrokerRegistrarReturnsDecodeError(t *testing.T) {
 	t.Parallel()
 
-	var canonical, legacy atomic.Int64
+	var canonical atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case canonicalRegisterPath:
@@ -503,9 +285,6 @@ func TestBrokerRegistrarDoesNotFallbackOnDecodeError(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = io.WriteString(w, `{"id":`)
-		case legacyRegisterPath:
-			legacy.Add(1)
-			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "must_not_register"})
 		default:
 			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
 		}
@@ -518,69 +297,6 @@ func TestBrokerRegistrarDoesNotFallbackOnDecodeError(t *testing.T) {
 	}
 	if got := canonical.Load(); got != 1 {
 		t.Errorf("canonical request count = %d, want 1", got)
-	}
-	if got := legacy.Load(); got != 0 {
-		t.Errorf("legacy request count = %d, want 0", got)
-	}
-}
-
-func TestBrokerRegistrarConcurrentLegacyDiscovery(t *testing.T) {
-	t.Parallel()
-
-	const workers = 48
-	var canonical, legacy atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case canonicalRegisterPath:
-			canonical.Add(1)
-			http.NotFound(w, r)
-		case legacyRegisterPath:
-			legacy.Add(1)
-			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{ID: "relay_legacy"})
-		default:
-			writeRegistrarJSON(w, http.StatusInternalServerError, relay.ErrorResponse{Error: "unexpected path"})
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
-	start := make(chan struct{})
-	errs := make(chan error, workers)
-	var wg sync.WaitGroup
-	wg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			defer wg.Done()
-			<-start
-			_, err := registrar.Register(context.Background(), testRegisterRequest())
-			errs <- err
-		}()
-	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Errorf("concurrent Register() error = %v", err)
-		}
-	}
-
-	canonicalAfterDiscovery := canonical.Load()
-	if canonicalAfterDiscovery < 1 || canonicalAfterDiscovery > workers {
-		t.Errorf("canonical discovery request count = %d, want between 1 and %d", canonicalAfterDiscovery, workers)
-	}
-	if got := legacy.Load(); got != workers {
-		t.Errorf("legacy request count = %d, want %d", got, workers)
-	}
-
-	if _, err := registrar.Register(context.Background(), testRegisterRequest()); err != nil {
-		t.Fatalf("Register() after concurrent discovery error = %v", err)
-	}
-	if got := canonical.Load(); got != canonicalAfterDiscovery {
-		t.Errorf("canonical requests after sticky fallback = %d, want %d", got, canonicalAfterDiscovery)
-	}
-	if got := legacy.Load(); got != workers+1 {
-		t.Errorf("legacy requests after sticky fallback = %d, want %d", got, workers+1)
 	}
 }
 


### PR DESCRIPTION
## Summary

- remove the legacy `POST /api/v1/volunteers/register` and `/api/v1/volunteers/{id}/heartbeat` broker aliases
- remove sticky canonical-to-legacy fallback from the direct relay/desktop runtime and relayhub registrar
- update broker, runtime, and integration tests for canonical-only behavior and document the retired routes

## Why

All deployed relays are controlled and already use the canonical relay write API. Keeping the volunteer-named compatibility routes and fallback state now adds dead code and makes the supported control-plane contract ambiguous.

## Impact

Canonical registration and heartbeat behavior, authentication, rate limiting, relay-not-found recovery, redirect refusal, secure Foundation transport, bounded error parsing, and `Retry-After` handling are preserved. The retired write routes now return `404` by design.

Merging this PR triggers fresh broker, relayhub, and relay images. Wait for all three `:main` publication workflows before deployment; deploy relayhub and a relay canary first, then the broker, then the remaining relays.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go vet ./... && go test -race ./...` in `punchcore/`
- desktop and desktop-volunteer CI-equivalent vet/build checks
- focused broker, relayruntime, engine, and tunnel integration tests
- local Docker smoke builds for broker, relayhub, and relay
- `git diff --check`
