### PR TITLE
Make relay_version canonical in broker API

### DIFF
--- a/desktop-volunteer/volunteerservice/service.go
+++ b/desktop-volunteer/volunteerservice/service.go
@@ -19,7 +19,7 @@ import (
 	"openrung/internal/relayruntime/engine"
 )
 
-// Version is reported to the broker/hub as the volunteer version.
+// Version is reported to the broker/hub as the relay runtime version.
 const Version = "desktop-volunteer/0.1.0"
 
 // DefaultBrokerURL matches the desktop client's primary broker endpoint.

--- a/desktop/frontend/src/core/model/relay.test.ts
+++ b/desktop/frontend/src/core/model/relay.test.ts
@@ -25,7 +25,7 @@ function usableRelay(overrides: Partial<RelayDescriptor> = {}): RelayDescriptor 
     exit_mode: 'direct',
     max_sessions: 8,
     max_mbps: 100,
-    volunteer_version: '1',
+    relay_version: '1',
     registered_at: '2026-07-05T00:00:00Z',
     last_heartbeat_at: '2026-07-06T00:00:00Z',
     expires_at: '2026-07-06T01:00:00Z',

--- a/desktop/frontend/src/core/model/relay.ts
+++ b/desktop/frontend/src/core/model/relay.ts
@@ -1,8 +1,7 @@
 /**
- * PORTED VERBATIM from openrung-mobile-app/src/model/relay.ts (no changes).
- * This module is pure TypeScript with no react-native imports, so it is shared
- * as-is between the mobile app and this desktop client. Keep the two copies in
- * sync until they are extracted into a shared @openrung/core package.
+ * Ported from openrung-mobile-app/src/model/relay.ts. This module is pure
+ * TypeScript with no react-native imports, so keep the shared fields aligned
+ * until they are extracted into a shared @openrung/core package.
  *
  * Relay descriptor model, ported from the production `model/RelayDescriptor.kt` /
  * `model/RelaySelector.kt`. JSON field names are kept snake_case, exactly as the broker sends them.
@@ -28,8 +27,9 @@ export interface RelayDescriptor {
   exit_mode: string;
   max_sessions: number;
   max_mbps: number;
-  // Legacy broker wire name; this reports the software version for every relay class.
-  volunteer_version: string;
+  relay_version: string;
+  // Deprecated v1 response alias for released clients; new code must use relay_version.
+  volunteer_version?: string;
   registered_at: string; // ISO instant
   last_heartbeat_at: string;
   expires_at: string;

--- a/desktop/frontend/src/core/net/exitNodeDirectory.test.ts
+++ b/desktop/frontend/src/core/net/exitNodeDirectory.test.ts
@@ -19,7 +19,7 @@ function relay(overrides: Partial<RelayDescriptor>): RelayDescriptor {
     exit_mode: 'direct',
     max_sessions: 8,
     max_mbps: 100,
-    volunteer_version: '1',
+    relay_version: '1',
     registered_at: '2026-07-05T00:00:00Z',
     last_heartbeat_at: '2026-07-06T00:00:00Z',
     expires_at: '2026-07-06T01:00:00Z',

--- a/desktop/frontend/src/native/mock.ts
+++ b/desktop/frontend/src/native/mock.ts
@@ -38,7 +38,7 @@ function sampleRelay(loc: Located, index: number): RelayDescriptor {
     exit_mode: 'direct',
     max_sessions: 32,
     max_mbps: 100,
-    volunteer_version: '0.0.0-mock',
+    relay_version: '0.0.0-mock',
     registered_at: new Date(Date.now() - 3_600_000).toISOString(),
     last_heartbeat_at: new Date().toISOString(),
     expires_at: new Date(Date.now() + 3_600_000).toISOString(),

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,15 +228,17 @@ Request:
   "exit_mode": "direct",
   "max_sessions": 8,
   "max_mbps": 20,
-  "volunteer_version": "dev",
+  "relay_version": "dev",
   "transport": "direct",
   "node_class": "volunteer"
 }
 ```
 
-`volunteer_version` is a frozen legacy wire name retained for compatibility. It
-reports the relay runtime version for both `volunteer`-class and
-`foundation`-class relays.
+`relay_version` reports the runtime version for both `volunteer`-class and
+`foundation`-class relays. During the v1 migration, registration also accepts
+the old `volunteer_version` name, and descriptor responses include it as a
+deprecated alias for released clients that still require it. New integrations
+must use `relay_version`; the compatibility alias is omitted from the examples.
 
 `transport` is optional and defaults to `direct`. The relay hub registers CGNAT
 volunteer-run relays with `transport: "tunnel"` and a
@@ -311,7 +313,7 @@ Response:
   "exit_mode": "direct",
   "max_sessions": 8,
   "max_mbps": 20,
-  "volunteer_version": "dev",
+  "relay_version": "dev",
   "registered_at": "2026-06-09T07:00:00Z",
   "last_heartbeat_at": "2026-06-09T07:00:00Z",
   "expires_at": "2026-06-09T07:03:00Z"
@@ -427,7 +429,7 @@ Response:
       "exit_mode": "direct",
       "max_sessions": 8,
       "max_mbps": 20,
-      "volunteer_version": "dev",
+      "relay_version": "dev",
       "registered_at": "2026-06-09T07:00:00Z",
       "last_heartbeat_at": "2026-06-09T07:00:00Z",
       "expires_at": "2026-06-09T07:03:00Z"

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -76,6 +76,75 @@ func TestCanonicalRelayRoutesRegisterAndHeartbeat(t *testing.T) {
 	}
 }
 
+func TestRelayVersionAPIMigration(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+	requestBody, err := json.Marshal(validRegisterRequest())
+	if err != nil {
+		t.Fatalf("marshal canonical request: %v", err)
+	}
+
+	registerRecorder := httptest.NewRecorder()
+	server.ServeHTTP(registerRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(requestBody)))
+	if registerRecorder.Code != http.StatusCreated {
+		t.Fatalf("register canonical request: expected 201, got %d: %s", registerRecorder.Code, registerRecorder.Body.String())
+	}
+	var registered map[string]any
+	if err := json.Unmarshal(registerRecorder.Body.Bytes(), &registered); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	assertRelayVersionFields(t, registered, "test")
+
+	listRecorder := httptest.NewRecorder()
+	server.ServeHTTP(listRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("list relays: expected 200, got %d: %s", listRecorder.Code, listRecorder.Body.String())
+	}
+	var list struct {
+		Relays []map[string]any `json:"relays"`
+	}
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(list.Relays) != 1 {
+		t.Fatalf("listed relays = %d, want 1", len(list.Relays))
+	}
+	assertRelayVersionFields(t, list.Relays[0], "test")
+
+	var legacyRequest map[string]any
+	if err := json.Unmarshal(requestBody, &legacyRequest); err != nil {
+		t.Fatalf("decode canonical request: %v", err)
+	}
+	delete(legacyRequest, "relay_version")
+	legacyRequest["volunteer_version"] = "legacy-version"
+	legacyBody, err := json.Marshal(legacyRequest)
+	if err != nil {
+		t.Fatalf("marshal legacy request: %v", err)
+	}
+	legacyRecorder := httptest.NewRecorder()
+	NewServer(NewStore(), Config{SigningSeed: testSigningSeed()}).ServeHTTP(
+		legacyRecorder,
+		httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(legacyBody)),
+	)
+	if legacyRecorder.Code != http.StatusCreated {
+		t.Fatalf("register legacy request: expected 201, got %d: %s", legacyRecorder.Code, legacyRecorder.Body.String())
+	}
+	var legacyRegistered map[string]any
+	if err := json.Unmarshal(legacyRecorder.Body.Bytes(), &legacyRegistered); err != nil {
+		t.Fatalf("decode legacy register response: %v", err)
+	}
+	assertRelayVersionFields(t, legacyRegistered, "legacy-version")
+}
+
+func assertRelayVersionFields(t *testing.T, fields map[string]any, want string) {
+	t.Helper()
+	if fields["relay_version"] != want {
+		t.Fatalf("relay_version = %#v, want %q", fields["relay_version"], want)
+	}
+	if fields["volunteer_version"] != want {
+		t.Fatalf("volunteer_version compatibility alias = %#v, want %q", fields["volunteer_version"], want)
+	}
+}
+
 func TestRegisterRouteRejectsMalformedJSON(t *testing.T) {
 	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
 	recorder := httptest.NewRecorder()

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -52,10 +53,8 @@ type RegisterRequest struct {
 	ExitMode         string `json:"exit_mode"`
 	MaxSessions      int    `json:"max_sessions"`
 	MaxMbps          int    `json:"max_mbps"`
-	// RelayVersion retains the legacy volunteer_version JSON name for wire
-	// compatibility with deployed brokers, relays, and clients.
-	RelayVersion string `json:"volunteer_version"`
-	Label        string `json:"label,omitempty"`
+	RelayVersion     string `json:"relay_version"`
+	Label            string `json:"label,omitempty"`
 	// NodeClass declares who operates this relay: NodeClassVolunteer (the
 	// default when empty) or NodeClassFoundation. A foundation claim is only
 	// honored when the request presents the broker's foundation token;
@@ -80,6 +79,46 @@ type RegisterRequest struct {
 	// never serves it to clients. Rejected for direct transport, where
 	// PublicHost already is the exit.
 	ExitHost string `json:"exit_host,omitempty"`
+}
+
+// MarshalJSON emits the canonical key plus the deprecated v1 alias so upgraded
+// relays and hubs can still register their version with an older broker during
+// a rolling deployment.
+func (r RegisterRequest) MarshalJSON() ([]byte, error) {
+	type registerRequestAlias RegisterRequest
+	return json.Marshal(struct {
+		registerRequestAlias
+		VolunteerVersion string `json:"volunteer_version"`
+	}{
+		registerRequestAlias: registerRequestAlias(r),
+		VolunteerVersion:     r.RelayVersion,
+	})
+}
+
+// UnmarshalJSON accepts the pre-relay-terminology volunteer_version key so
+// deployed relays can continue registering during the v1 migration. When both
+// keys are present, the canonical relay_version value wins.
+func (r *RegisterRequest) UnmarshalJSON(data []byte) error {
+	type registerRequestAlias RegisterRequest
+	var decoded registerRequestAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var versions struct {
+		RelayVersion     *string `json:"relay_version"`
+		VolunteerVersion *string `json:"volunteer_version"`
+	}
+	if err := json.Unmarshal(data, &versions); err != nil {
+		return err
+	}
+	switch {
+	case versions.RelayVersion != nil:
+		decoded.RelayVersion = *versions.RelayVersion
+	case versions.VolunteerVersion != nil:
+		decoded.RelayVersion = *versions.VolunteerVersion
+	}
+	*r = RegisterRequest(decoded)
+	return nil
 }
 
 // GeoLocation is the broker-resolved physical location of the relay's exit:
@@ -112,25 +151,63 @@ type Descriptor struct {
 	// NodeClassVolunteer). Always serialized, and covered by the relay-list
 	// signature like every other descriptor field; clients that predate it
 	// ignore it, clients that read it treat a missing value as the volunteer class.
-	NodeClass        string `json:"node_class"`
-	Protocol         string `json:"protocol"`
-	ClientID         string `json:"client_id"`
-	RealityPublicKey string `json:"reality_public_key"`
-	ShortID          string `json:"short_id"`
-	ServerName       string `json:"server_name"`
-	Flow             string `json:"flow"`
-	ExitMode         string `json:"exit_mode"`
-	MaxSessions      int    `json:"max_sessions"`
-	MaxMbps          int    `json:"max_mbps"`
-	// RelayVersion retains the legacy volunteer_version JSON name for wire
-	// compatibility with deployed brokers, relays, and clients.
-	RelayVersion    string    `json:"volunteer_version"`
-	Transport       string    `json:"transport,omitempty"`
-	PunchCapable    bool      `json:"punch_capable,omitempty"`
-	PunchEndpoint   string    `json:"punch_endpoint,omitempty"`
-	RegisteredAt    time.Time `json:"registered_at"`
-	LastHeartbeatAt time.Time `json:"last_heartbeat_at"`
-	ExpiresAt       time.Time `json:"expires_at"`
+	NodeClass        string    `json:"node_class"`
+	Protocol         string    `json:"protocol"`
+	ClientID         string    `json:"client_id"`
+	RealityPublicKey string    `json:"reality_public_key"`
+	ShortID          string    `json:"short_id"`
+	ServerName       string    `json:"server_name"`
+	Flow             string    `json:"flow"`
+	ExitMode         string    `json:"exit_mode"`
+	MaxSessions      int       `json:"max_sessions"`
+	MaxMbps          int       `json:"max_mbps"`
+	RelayVersion     string    `json:"relay_version"`
+	Transport        string    `json:"transport,omitempty"`
+	PunchCapable     bool      `json:"punch_capable,omitempty"`
+	PunchEndpoint    string    `json:"punch_endpoint,omitempty"`
+	RegisteredAt     time.Time `json:"registered_at"`
+	LastHeartbeatAt  time.Time `json:"last_heartbeat_at"`
+	ExpiresAt        time.Time `json:"expires_at"`
+}
+
+// MarshalJSON keeps volunteer_version as a deprecated v1 response alias while
+// released native clients still require it. New clients should read
+// relay_version; both keys carry the same value and are covered by the relay-list
+// signature.
+func (d Descriptor) MarshalJSON() ([]byte, error) {
+	type descriptorAlias Descriptor
+	return json.Marshal(struct {
+		descriptorAlias
+		VolunteerVersion string `json:"volunteer_version"`
+	}{
+		descriptorAlias:  descriptorAlias(d),
+		VolunteerVersion: d.RelayVersion,
+	})
+}
+
+// UnmarshalJSON lets current clients read both canonical broker responses and
+// older v1 responses. When both keys are present, relay_version wins.
+func (d *Descriptor) UnmarshalJSON(data []byte) error {
+	type descriptorAlias Descriptor
+	var decoded descriptorAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var versions struct {
+		RelayVersion     *string `json:"relay_version"`
+		VolunteerVersion *string `json:"volunteer_version"`
+	}
+	if err := json.Unmarshal(data, &versions); err != nil {
+		return err
+	}
+	switch {
+	case versions.RelayVersion != nil:
+		decoded.RelayVersion = *versions.RelayVersion
+	case versions.VolunteerVersion != nil:
+		decoded.RelayVersion = *versions.VolunteerVersion
+	}
+	*d = Descriptor(decoded)
+	return nil
 }
 
 // ListResponse is the signed relay directory. The whole marshaled body is

--- a/internal/relay/types_test.go
+++ b/internal/relay/types_test.go
@@ -1,36 +1,80 @@
 package relay
 
 import (
-	"bytes"
 	"encoding/json"
 	"testing"
 )
 
-func TestRelayVersionKeepsLegacyJSONField(t *testing.T) {
-	values := map[string]any{
-		"register request": RegisterRequest{RelayVersion: "1.2.3"},
-		"descriptor":       Descriptor{RelayVersion: "1.2.3"},
+func TestRegisterRequestRelayVersionJSONMigration(t *testing.T) {
+	encoded, err := json.Marshal(RegisterRequest{RelayVersion: "1.2.3"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
 	}
-	for name, value := range values {
-		t.Run(name, func(t *testing.T) {
-			encoded, err := json.Marshal(value)
-			if err != nil {
-				t.Fatalf("marshal: %v", err)
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["relay_version"] != "1.2.3" {
+		t.Fatalf("relay_version = %#v, want %q", fields["relay_version"], "1.2.3")
+	}
+	if fields["volunteer_version"] != "1.2.3" {
+		t.Fatalf("volunteer_version compatibility alias = %#v, want %q", fields["volunteer_version"], "1.2.3")
+	}
+
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "canonical", body: `{"relay_version":"2.3.4"}`, want: "2.3.4"},
+		{name: "legacy", body: `{"volunteer_version":"3.4.5"}`, want: "3.4.5"},
+		{name: "canonical wins", body: `{"relay_version":"4.5.6","volunteer_version":"legacy"}`, want: "4.5.6"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var request RegisterRequest
+			if err := json.Unmarshal([]byte(test.body), &request); err != nil {
+				t.Fatalf("unmarshal: %v", err)
 			}
-			if !bytes.Contains(encoded, []byte(`"volunteer_version":"1.2.3"`)) {
-				t.Fatalf("legacy volunteer_version field missing from %s", encoded)
-			}
-			if bytes.Contains(encoded, []byte(`"relay_version"`)) {
-				t.Fatalf("unexpected relay_version wire field in %s", encoded)
+			if request.RelayVersion != test.want {
+				t.Fatalf("RelayVersion = %q, want %q", request.RelayVersion, test.want)
 			}
 		})
 	}
+}
 
-	var request RegisterRequest
-	if err := json.Unmarshal([]byte(`{"volunteer_version":"4.5.6"}`), &request); err != nil {
-		t.Fatalf("unmarshal register request: %v", err)
+func TestDescriptorRelayVersionJSONMigration(t *testing.T) {
+	encoded, err := json.Marshal(Descriptor{RelayVersion: "1.2.3"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
 	}
-	if request.RelayVersion != "4.5.6" {
-		t.Fatalf("RelayVersion = %q, want %q", request.RelayVersion, "4.5.6")
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["relay_version"] != "1.2.3" {
+		t.Fatalf("relay_version = %#v, want %q", fields["relay_version"], "1.2.3")
+	}
+	if fields["volunteer_version"] != "1.2.3" {
+		t.Fatalf("volunteer_version compatibility alias = %#v, want %q", fields["volunteer_version"], "1.2.3")
+	}
+
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "canonical", body: `{"relay_version":"2.3.4"}`, want: "2.3.4"},
+		{name: "legacy", body: `{"volunteer_version":"3.4.5"}`, want: "3.4.5"},
+		{name: "canonical wins", body: `{"relay_version":"4.5.6","volunteer_version":"legacy"}`, want: "4.5.6"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var descriptor Descriptor
+			if err := json.Unmarshal([]byte(test.body), &descriptor); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if descriptor.RelayVersion != test.want {
+				t.Fatalf("RelayVersion = %q, want %q", descriptor.RelayVersion, test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- make `relay_version` the canonical registration and relay-descriptor field
- accept and emit the deprecated `volunteer_version` alias during the v1 migration
- update the desktop model, fixtures, API documentation, and broker boundary tests
- leave the private relay-hub wire key and physical PostgreSQL column unchanged for rollback safety

## Why

The relay directory now includes both Foundation-operated and volunteer-run relays, so `volunteer_version` is no longer an accurate generic API name. A hard rename would make the currently released native mobile clients reject the signed relay list because they still require the legacy field. This staged migration establishes the correct canonical name without breaking existing clients or mixed-version broker and relay deployments.

## Impact

New integrations should read and send `relay_version`. Existing v1 clients continue to receive `volunteer_version` with the same value, and older registration payloads remain accepted. When both input fields are present, `relay_version` wins.

The deprecated alias can be removed after native mobile clients have shipped dual-read support, or as part of a versioned API cutover.

## Validation

- `GOCACHE=/tmp/openrung-relay-version-gocache go test ./...`
- `GOCACHE=/tmp/openrung-relay-version-gocache go test -race ./internal/relay ./internal/broker ./internal/client ./internal/relayruntime ./internal/tunnel`
- `GOCACHE=/tmp/openrung-relay-version-gocache go vet ./...`
- `npm test` in `desktop/frontend` (17 tests)
- `npm run build` in `desktop/frontend`
