### PR TITLE
Fix credential-safety defects in foundation-up.sh

### DIFF
--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -94,13 +94,16 @@ volunteer-run relays tunneled through it Foundation-operated.
 host only over SSH, after boot, and never through user-data.
 
 ```sh
-# Provision a new Lightsail host and install credentials on it.
+# Provision a new Lightsail host and install credentials on it. The host key is
+# pinned from the AWS API automatically, before the token is sent.
 OPENRUNG_FOUNDATION_TOKEN_CMD='pass show openrung/foundation-token' \
   deploy/relay/foundation-up.sh create
 
-# Promote hosts that are already serving as volunteer-class relays.
+# Promote a host already serving as a volunteer-class relay. Pin its key first:
+# an unknown host key is a hard failure, never trust-on-first-use.
+deploy/relay/foundation-up.sh trust eu-north-1 noble-pebble
 OPENRUNG_FOUNDATION_TOKEN_CMD='pass show openrung/foundation-token' \
-  deploy/relay/foundation-up.sh convert 203.0.113.10 203.0.113.11
+  deploy/relay/foundation-up.sh convert 203.0.113.10
 
 # Roll a new image across the fleet. Needs no token: the credentials already on
 # each host are reused as-is.
@@ -114,21 +117,48 @@ OPENRUNG_IMAGE=ghcr.io/openrung/openrung-relay:sha-abc1234 \
 | `OPENRUNG_FOUNDATION_TOKEN` | — | The token itself. Fallback for CI; prefer the command form so the secret is not sitting in your environment. |
 | `OPENRUNG_IMAGE` | `…/openrung-relay:main` | Image to run. Pin a `sha-…` tag for reproducible rolls. |
 | `OPENRUNG_BROKER_URL` | CloudFront front | Must be HTTPS; the script fails fast otherwise. |
+| `OPENRUNG_VERIFY_BROKER_URL` | plaintext origin | Read-only endpoint used to read back the broker's attestation. Carries no credential. |
 | `OPENRUNG_ENV_FILE` | `/etc/openrung/relay.env` | Where credentials live. An env file already present on the host wins, so a `convert` overwrites in place instead of leaving a second copy of the token on disk. |
 | `OPENRUNG_SSH_KEY` / `OPENRUNG_SSH_USER` | `~/.ssh/id_ed25519_openrung` / `ubuntu` | SSH access to the host. |
 
 Notes on the design:
 
+- **The host key must be verified before the token is sent.** This connection
+  carries the fleet-wide Foundation credential, so trust-on-first-use is not good
+  enough: it would hand the token to whichever host key answered first. The script
+  runs `StrictHostKeyChecking=yes` and treats an unknown host as a hard failure.
+  `trust <region> <name>` pins the key using AWS as the out-of-band channel —
+  Lightsail witnesses each instance's host keys from its console output at first
+  boot, so a fingerprint from the authenticated API is trustworthy in a way TOFU
+  is not. `create` does this automatically. A presented key that matches none of
+  the witnessed fingerprints aborts rather than connecting.
 - **The token is never a command-line argument.** `argv` is world-readable via
   `/proc` and is retained in shell history, so it is read from the environment or
   a command and streamed to the host over stdin.
+- **Existing configuration is preserved.** `convert` merges: every setting already
+  on the host is carried over and only `OPENRUNG_BROKER_URL` /
+  `OPENRUNG_FOUNDATION_TOKEN` are replaced. Truncating the file would drop stable
+  identity (`OPENRUNG_CLIENT_ID`, the Reality keys, `OPENRUNG_SHORT_ID`), capacity
+  limits, and camouflage — silently rotating relay credentials and breaking
+  clients that hold a cached descriptor. `OPENRUNG_NODE_CLASS` and
+  `OPENRUNG_VOLUNTEER_TOKEN` are dropped, since the Foundation token forces the
+  class and a stale value there is a startup error. Config implying the hub path
+  (`OPENRUNG_MODE`, `OPENRUNG_TUNNEL`, `OPENRUNG_HUB_ADDR`) aborts the convert
+  rather than being silently stripped: Foundation requires direct mode. The file
+  is written atomically via a temp file and `mv`.
 - **`update` needs no token**, because it reuses whatever env file the host
-  already has. Only `create` and `convert` require one.
+  already has — but it *does* verify one is present. An env file alone proves
+  nothing: without a token the relay legitimately registers as `volunteer` and
+  logs the same line a Foundation relay does, so skipping that check would let a
+  roll certify a volunteer relay as Foundation.
 - **`update` is sequential and fails fast.** A bad image stops the roll at the
   first host rather than taking down every relay.
-- **Verification is self-contained.** A relay whose class the broker does not
-  attest as `foundation` exits during startup, so a container that is still
-  running and has logged a registration *is* the proof — no broker query needed.
+- **Verification uses two independent signals.** The relay's own guard (with a
+  token present it claims Foundation and *exits* if the broker attests otherwise),
+  plus the broker's attestation read back from the signed directory. A mismatch is
+  a hard failure. Because that directory caps at 20 relays, a large fleet can push
+  a relay out of the response; that is reported explicitly as unconfirmed rather
+  than assumed to be success.
 - Legacy `openrung-volunteer` container and `volunteer.env` names are detected,
   so hosts predating the rename are handled without manual cleanup.
 

--- a/deploy/relay/foundation-up.sh
+++ b/deploy/relay/foundation-up.sh
@@ -2,9 +2,10 @@
 #
 # Provision, convert, and update OpenRung Foundation-operated relays.
 #
-#   deploy/relay/foundation-up.sh create [name]        # new Lightsail host, then install credentials
-#   deploy/relay/foundation-up.sh convert <host>...    # install credentials on an existing host
-#   deploy/relay/foundation-up.sh update  <host>...    # pull the image and recreate, reusing credentials
+#   deploy/relay/foundation-up.sh create [name]           # new Lightsail host, then install credentials
+#   deploy/relay/foundation-up.sh convert <host>...       # install credentials on an existing host
+#   deploy/relay/foundation-up.sh update  <host>...       # pull the image and recreate, reusing credentials
+#   deploy/relay/foundation-up.sh trust <region> <name>   # pin a Lightsail host key from the AWS API
 #
 # This wraps — and never replaces — lightsail-up.sh. That helper deliberately
 # refuses registration tokens because Lightsail retains user-data, so a Foundation
@@ -14,8 +15,8 @@
 # reaches the host only over SSH, after boot, and never through user-data.
 #
 # Overridable via env: OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_ENV_FILE,
-# OPENRUNG_SSH_KEY, OPENRUNG_SSH_USER. `create` also forwards OPENRUNG_REGION,
-# OPENRUNG_BUNDLE, and the rest of lightsail-up.sh's own knobs.
+# OPENRUNG_SSH_KEY, OPENRUNG_SSH_USER, OPENRUNG_VERIFY_BROKER_URL. `create` also
+# forwards OPENRUNG_REGION, OPENRUNG_BUNDLE, and lightsail-up.sh's other knobs.
 #
 # The token is read from OPENRUNG_FOUNDATION_TOKEN_CMD (preferred) or
 # OPENRUNG_FOUNDATION_TOKEN. It is never accepted as a command-line argument:
@@ -27,19 +28,35 @@ BROKER_URL="${OPENRUNG_BROKER_URL:-https://d2r7mdpyevvs1m.cloudfront.net}"
 ENV_FILE="${OPENRUNG_ENV_FILE:-/etc/openrung/relay.env}"
 SSH_KEY="${OPENRUNG_SSH_KEY:-$HOME/.ssh/id_ed25519_openrung}"
 SSH_USER="${OPENRUNG_SSH_USER:-ubuntu}"
+# Read-only endpoint used to confirm the broker's node_class attestation. The
+# plaintext origin is fine here: this reads a signed public directory and carries
+# no credential.
+VERIFY_BROKER_URL="${OPENRUNG_VERIFY_BROKER_URL:-http://54.238.185.205:8080}"
 
 CONTAINER="openrung-relay"
 LEGACY_CONTAINER="openrung-volunteer"      # pre-rename fleets still run this name
 LEGACY_ENV_FILE="/etc/openrung/volunteer.env"
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
+
+# StrictHostKeyChecking=yes, never accept-new: this connection carries the
+# fleet-wide Foundation token, and trust-on-first-use would hand that credential
+# to whichever host key answers first. An unknown host is a hard failure; use the
+# `trust` subcommand to pin the key from the authenticated AWS API first.
+SSH_OPTS=(-o StrictHostKeyChecking=yes -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
+
+# Env keys this script owns. Everything else already on the host is preserved.
+CONTROLLED_KEYS='OPENRUNG_BROKER_URL|OPENRUNG_FOUNDATION_TOKEN'
+# Dropped on convert: the token alone forces Foundation class, and a stale
+# node-class or a volunteer bearer alongside it is a startup error.
+DROPPED_KEYS='OPENRUNG_NODE_CLASS|OPENRUNG_VOLUNTEER_TOKEN'
 
 die() { echo "error: $*" >&2; exit 1; }
 log() { echo "  $*"; }
+warn() { echo "  warning: $*" >&2; }
 
 usage() {
-  sed -n '3,8p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '3,9p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
   exit 2
 }
 
@@ -53,6 +70,15 @@ require_https_broker() {
     https://*) ;;
     *) die "OPENRUNG_BROKER_URL must be https for a Foundation relay (got '${BROKER_URL}'); the relay refuses to send the token over cleartext" ;;
   esac
+}
+
+# Fail before the token is transmitted if the host key is not already trusted.
+require_known_host() {
+  local host="$1"
+  ssh-keygen -F "$host" >/dev/null 2>&1 \
+    || die "${host}: host key is not in known_hosts. This connection carries the Foundation token, so it will not trust an unverified key. Pin it from the AWS API first:
+    ${0##*/} trust <region> <instance-name>
+  or verify the key out-of-band and add it to known_hosts yourself."
 }
 
 # Print the Foundation token on stdout. Never echoed, never passed as an argument.
@@ -81,31 +107,81 @@ detect_env_file() {
   done"
 }
 
-# Read one non-secret OPENRUNG_* value out of the running container.
-container_env_value() {
-  local host="$1" container="$2" key="$3"
-  ssh_run "$host" "sudo docker inspect ${container} --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null" \
-    | sed -n "s/^${key}=//p" | head -1
+# True when the env file holds a non-empty Foundation token.
+env_file_has_token() {
+  ssh_run "$1" "sudo grep -qE '^OPENRUNG_FOUNDATION_TOKEN=.+' '$2'"
 }
 
-# Write the root-owned mode-0600 env file. The token arrives on stdin so it never
-# appears in argv on either side of the connection.
+# Pin a Lightsail host key using AWS as the out-of-band channel. AWS witnesses the
+# host keys from the instance's own console output at first boot, so a fingerprint
+# from the authenticated API is trustworthy in a way trust-on-first-use is not.
+cmd_trust() {
+  [ "$#" -eq 2 ] || usage
+  local region="$1" name="$2" ip expected scanned fp line tmp
+  ip="$(aws lightsail get-instance --instance-name "$name" --region "$region" \
+        --query 'instance.publicIpAddress' --output text 2>/dev/null)" \
+    || die "could not look up ${name} in ${region}"
+  [ -n "$ip" ] && [ "$ip" != "None" ] || die "${name} in ${region} has no public IP"
+
+  expected="$(aws lightsail get-instance-access-details --instance-name "$name" --region "$region" \
+              --protocol ssh --query 'accessDetails.hostKeys[].fingerprintSHA256' --output text)" \
+    || die "could not fetch host keys for ${name} from the Lightsail API"
+  [ -n "$expected" ] || die "Lightsail returned no host keys for ${name}"
+
+  echo "==> trust ${name} (${ip})"
+  scanned="$(ssh-keyscan -T 15 "$ip" 2>/dev/null)" || true
+  [ -n "$scanned" ] || die "${ip}: ssh-keyscan returned nothing (is the host up and 22 reachable?)"
+
+  tmp="$(mktemp)"; trap 'rm -f "$tmp"' RETURN
+  local matched=0
+  # Drop any existing entries first, then pin every key that AWS witnessed. Pinning
+  # all of them (not just the first) means SSH cannot negotiate a host key
+  # algorithm we left unpinned and fail against StrictHostKeyChecking=yes.
+  ssh-keygen -R "$ip" >/dev/null 2>&1 || true
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    printf '%s\n' "$line" > "$tmp"
+    fp="$(ssh-keygen -lf "$tmp" 2>/dev/null | awk '{print $2}')" || continue
+    # Compare against the AWS-witnessed set (tab-separated).
+    if printf '%s' "$expected" | tr '\t' '\n' | grep -qxF "$fp"; then
+      printf '%s\n' "$line" >> "${HOME}/.ssh/known_hosts"
+      log "pinned $(printf '%s' "$line" | awk '{print $2}') ${fp}"
+      matched=$((matched + 1))
+    fi
+  done <<< "$scanned"
+
+  [ "$matched" -gt 0 ] \
+    || die "${ip}: NO presented host key matched the AWS-witnessed fingerprints. Do not connect — this may be a machine-in-the-middle. Expected one of:
+$(printf '%s' "$expected" | tr '\t' '\n' | sed 's/^/    /')"
+  log "known_hosts updated; ${ip} is now safe to send credentials to"
+}
+
+# Merge: keep every key already configured on the host, drop the ones a Foundation
+# token makes invalid, and set the ones this script owns. Written atomically via a
+# temp file so a failure cannot leave a half-written credential file behind.
 #
-# target is the path to write. Callers pass an already-present env file when the
-# host has one, so a convert overwrites in place rather than leaving a second,
-# stale copy of the token on disk under the other name.
+# The token arrives on stdin so it never appears in argv on either side.
 install_env_file() {
-  local host="$1" public_host="$2" label="$3" token="$4" target="$5"
+  local host="$1" token="$2" target="$3" seed="$4"
   {
+    printf '%s\n' "$seed" | grep -vE "^(${CONTROLLED_KEYS}|${DROPPED_KEYS})=" || true
     printf 'OPENRUNG_BROKER_URL=%s\n' "$BROKER_URL"
-    printf 'OPENRUNG_PUBLIC_HOST=%s\n' "$public_host"
-    printf 'OPENRUNG_LISTEN_HOST=0.0.0.0\n'
-    printf 'OPENRUNG_LABEL=%s\n' "$label"
     printf 'OPENRUNG_FOUNDATION_TOKEN=%s\n' "$token"
   } | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" \
       "sudo install -d -m 700 -o root -g root /etc/openrung \
-       && sudo sh -c 'umask 077 && cat > ${target}' \
-       && sudo chown root:root ${target} && sudo chmod 600 ${target}"
+       && sudo sh -c 'umask 077 && cat > ${target}.tmp' \
+       && sudo chown root:root ${target}.tmp && sudo chmod 600 ${target}.tmp \
+       && sudo mv -f ${target}.tmp ${target}"
+}
+
+# Foundation requires direct mode; auto and tunnel would route the bearer through
+# the hub. Fail loudly rather than silently stripping settings the operator chose.
+assert_no_conflicting_mode() {
+  local host="$1" seed="$2" bad
+  bad="$(printf '%s\n' "$seed" | grep -E '^(OPENRUNG_MODE|OPENRUNG_TUNNEL|OPENRUNG_HUB_ADDR)=' || true)"
+  [ -z "$bad" ] || die "${host}: existing config conflicts with a Foundation relay (which forces direct mode):
+$(printf '%s' "$bad" | sed 's/^/    /')
+  A Foundation relay must not use the hub path. Remove these before converting."
 }
 
 # Recreate the relay container against env_file. Keeps the previous container,
@@ -130,18 +206,52 @@ recreate_container() {
       ${IMAGE} >/dev/null"
 }
 
-# A relay that registers as anything other than Foundation exits during startup
-# (the binary rejects a broker's node_class attestation that does not match what
-# it claimed). So a container still running, having logged a registration, is
-# proof the broker attested Foundation — no separate broker query needed.
+# Ask the broker what class it actually attested for this relay.
+#   foundation | volunteer | <other> : the attested class
+#   unknown                          : relay absent from the response
+#
+# Both the API list and the mirror cap at 20 relays, so a large fleet can push a
+# relay out of the response. That is reported as unknown rather than guessed at.
+broker_attested_class() {
+  local public_host="$1"
+  curl -fsS --max-time 10 "${VERIFY_BROKER_URL}/api/v1/relays.mirror" 2>/dev/null \
+    | python3 -c "
+import json,sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print('unknown'); sys.exit()
+for r in d.get('relays', []):
+    if r.get('public_host') == '$public_host':
+        print(r.get('node_class') or 'unknown'); sys.exit()
+print('unknown')
+" 2>/dev/null || echo unknown
+}
+
+# Confirm the relay came back as Foundation.
+#
+# Two independent signals, because neither alone is sufficient:
+#   1. The relay's own guard. With a token present the binary claims Foundation,
+#      and it exits if the broker attests anything else. So token-present plus a
+#      running, registered container rules out a silent volunteer downgrade. The
+#      token check is enforced before recreate; the generic "registered relay" log
+#      means nothing without it.
+#   2. The broker's attestation, read back from the signed directory. Authoritative
+#      when the relay appears; a mismatch is a hard failure.
 verify_foundation() {
-  local host="$1" i=0
+  local host="$1" public_host="$2" i=0 class
   while [ "$i" -lt 15 ]; do
     if ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep -q 'registered relay'"; then
       ssh_run "$host" "sudo docker ps --format '{{.Names}}' | grep -qx ${CONTAINER}" \
         || die "${host}: container exited after registering; check: docker logs ${CONTAINER}"
-      log "registered and running: $(ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep 'registered relay' | tail -1")"
-      return 0
+
+      class="$(broker_attested_class "$public_host")"
+      case "$class" in
+        foundation) log "broker attested node_class=foundation for ${public_host}"; return 0 ;;
+        unknown)    warn "${host}: broker did not list ${public_host} (the directory caps at 20 relays), so its attestation could not be read back. The relay is running and registered with a Foundation token, which its own startup guard requires the broker to have attested — but this run did not confirm it independently."
+                    return 0 ;;
+        *)          die "${host}: broker attested node_class='${class}', not 'foundation'. The relay is NOT Foundation-operated. Roll back: docker rm -f ${CONTAINER} && docker rename ${CONTAINER}-old ${CONTAINER} && docker start ${CONTAINER}" ;;
+      esac
     fi
     if ! ssh_run "$host" "sudo docker ps --format '{{.Names}}' | grep -qx ${CONTAINER}"; then
       die "${host}: container is not running; check: docker logs ${CONTAINER}"
@@ -159,27 +269,37 @@ cmd_convert() {
 
   for host in "$@"; do
     echo "==> convert ${host}"
-    local live public_host label target
+    require_known_host "$host"
+
+    local live existing target seed public_host
     live="$(detect_container "$host")"
     [ -n "$live" ] || die "${host}: no relay container found; provision it first (lightsail-up.sh or 'create')"
 
-    # Reuse the identity the bootstrap helper already baked in, so a convert does
-    # not silently relabel or re-home an existing relay.
-    public_host="$(container_env_value "$host" "$live" OPENRUNG_PUBLIC_HOST)"
-    label="$(container_env_value "$host" "$live" OPENRUNG_LABEL)"
-    [ -n "$public_host" ] || die "${host}: could not read OPENRUNG_PUBLIC_HOST from ${live}"
-    [ -n "$label" ] || die "${host}: could not read OPENRUNG_LABEL from ${live}"
-
     # Overwrite an existing env file in place; only fall back to the canonical
     # path when the host has none, so we never leave two token files behind.
-    target="$(detect_env_file "$host")"
-    [ -n "$target" ] || target="$ENV_FILE"
+    existing="$(detect_env_file "$host")"
+    target="${existing:-$ENV_FILE}"
 
-    log "identity: label=${label} public_host=${public_host}"
-    install_env_file "$host" "$public_host" "$label" "$token" "$target"
-    log "wrote ${target} (root:root 0600)"
+    # Seed from the env file when there is one, else from the running container.
+    # Either way every setting already in force is carried over — stable identity
+    # (client id, Reality keys, short id), capacity limits, and camouflage would
+    # otherwise be silently regenerated, breaking clients on cached descriptors.
+    if [ -n "$existing" ]; then
+      seed="$(ssh_run "$host" "sudo cat '${existing}'")"
+    else
+      seed="$(ssh_run "$host" "sudo docker inspect ${live} --format '{{range .Config.Env}}{{println .}}{{end}}'" | grep -E '^OPENRUNG_' || true)"
+    fi
+    [ -n "$seed" ] || die "${host}: could not read any existing OPENRUNG_* configuration to preserve"
+    assert_no_conflicting_mode "$host" "$seed"
+
+    public_host="$(printf '%s\n' "$seed" | sed -n 's/^OPENRUNG_PUBLIC_HOST=//p' | head -1)"
+    [ -n "$public_host" ] || die "${host}: could not determine OPENRUNG_PUBLIC_HOST"
+
+    log "preserving $(printf '%s\n' "$seed" | grep -cE '^OPENRUNG_' || true) existing setting(s); public_host=${public_host}"
+    install_env_file "$host" "$token" "$target" "$seed"
+    log "wrote ${target} (root:root 0600, atomic)"
     recreate_container "$host" "$target" "$live"
-    verify_foundation "$host"
+    verify_foundation "$host" "$public_host"
   done
 }
 
@@ -189,13 +309,25 @@ cmd_update() {
   # instead of taking every relay down.
   for host in "$@"; do
     echo "==> update ${host}"
-    local live env_file
+    require_known_host "$host"
+
+    local live env_file public_host
     env_file="$(detect_env_file "$host")"
     [ -n "$env_file" ] || die "${host}: no env file (${ENV_FILE} or ${LEGACY_ENV_FILE}); run 'convert' first"
+
+    # An env file alone proves nothing. Without a token the relay legitimately
+    # registers as volunteer and logs the same line a Foundation relay does, so
+    # skipping this check would let the roll certify a volunteer as Foundation.
+    env_file_has_token "$host" "$env_file" \
+      || die "${host}: ${env_file} has no OPENRUNG_FOUNDATION_TOKEN. This host would come back volunteer-class, not Foundation. Run 'convert' instead."
+
+    public_host="$(ssh_run "$host" "sudo sed -n 's/^OPENRUNG_PUBLIC_HOST=//p' '${env_file}' | head -1")"
+    [ -n "$public_host" ] || die "${host}: could not read OPENRUNG_PUBLIC_HOST from ${env_file}"
+
     live="$(detect_container "$host")"
     log "reusing ${env_file}; image ${IMAGE}"
     recreate_container "$host" "$env_file" "$live"
-    verify_foundation "$host"
+    verify_foundation "$host" "$public_host"
   done
 }
 
@@ -203,8 +335,13 @@ cmd_create() {
   require_https_broker
   read_token >/dev/null   # fail before provisioning, not after
 
-  local out ip name
-  out="$("${HERE}/lightsail-up.sh" "$@")"
+  local out ip name region="${OPENRUNG_REGION:-ap-northeast-1}"
+  # lightsail-up.sh rejects credential variables outright (user-data persists), so
+  # they must be stripped from its environment or it exits 2 before provisioning.
+  # The token is read above and delivered later, over SSH.
+  out="$(env -u OPENRUNG_FOUNDATION_TOKEN -u OPENRUNG_FOUNDATION_TOKEN_CMD \
+             -u OPENRUNG_VOLUNTEER_TOKEN -u OPENRUNG_NODE_CLASS \
+             "${HERE}/lightsail-up.sh" "$@")"
   echo "$out"
   # lightsail-up.sh's machine-readable handoff line.
   name="$(printf '%s\n' "$out" | sed -n 's/^OPENRUNG_RELAY name=\([^ ]*\) ip=.*$/\1/p' | head -1)"
@@ -213,11 +350,17 @@ cmd_create() {
 
   echo "==> waiting for ${name} (${ip}) to finish bootstrapping"
   local i=0
-  until ssh_run "$ip" "sudo docker inspect ${CONTAINER} >/dev/null 2>&1" 2>/dev/null; do
+  until ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY" \
+          "${SSH_USER}@${ip}" "sudo docker inspect ${CONTAINER} >/dev/null 2>&1" 2>/dev/null; do
     i=$((i + 1))
     [ "$i" -lt 60 ] || die "${ip}: relay container did not appear within 5 minutes; check /var/log/openrung-init.log"
     sleep 5
   done
+
+  # Pin the key from the AWS API before convert sends the token. The poll above
+  # deliberately does not trust the key for anything but an existence check.
+  ssh-keygen -R "$ip" >/dev/null 2>&1 || true
+  cmd_trust "$region" "$name"
   cmd_convert "$ip"
 }
 
@@ -227,5 +370,6 @@ case "$subcommand" in
   create)  cmd_create "$@" ;;
   convert) cmd_convert "$@" ;;
   update)  cmd_update "$@" ;;
+  trust)   cmd_trust "$@" ;;
   *)       usage ;;
 esac


### PR DESCRIPTION
Follow-up to #68, which **merged before this review landed**, so these fixes go on top of `main` rather than amending that PR. All four findings were valid; three are P1.

## P1 — Token was sent over an unverified first SSH connection

`StrictHostKeyChecking=accept-new` trusts whichever host key answers first, and the script then streamed the **fleet-wide** Foundation token over that connection. A first-connection machine-in-the-middle could capture it.

Fixed properly rather than documented-around. Lightsail witnesses each instance's host keys from its own console output at first boot and exposes the fingerprints via `get-instance-access-details` — an authenticated, out-of-band channel. So TOFU can be eliminated, not just narrowed:

- `StrictHostKeyChecking=yes`; an unknown host is a **hard failure before anything is transmitted**.
- New `trust <region> <name>` pins the key by matching every `ssh-keyscan`-presented key against the AWS-witnessed fingerprints. A key matching none of them **aborts** as a possible MITM.
- `create` pins automatically, so the automated path needs no manual step.

Verified read-only against `witty-salmon`: all 3 presented keys matched the AWS-witnessed fingerprints; an unpinned host aborts before the token is sent.

## P1 — `update` could falsely certify a volunteer relay as Foundation

The sharpest of the four. `verify_foundation` only looked for the generic `registered relay` log, and `update` checked merely that *some* env file existed. With no token in it, the relay legitimately registers as **volunteer** and emits that identical log — so the roll reported success.

Root cause: the binary's guard at `cmd/relay/main.go:695` only fires `if req.NodeClass == foundation`. No token means no claim, so no guard, and the log line (`main.go:412`) carries no class.

- `update` now asserts the env file holds a non-empty `OPENRUNG_FOUNDATION_TOKEN` **before** recreating.
- Verification reads the broker's attested `node_class` back from the signed directory; a mismatch is a **hard failure** with rollback instructions.
- Both the list and mirror endpoints cap at 20 relays, so a relay absent from the response is reported as **unconfirmed** rather than assumed good.

## P1 — `convert` destroyed existing relay configuration

`install_env_file` truncated the env file and wrote five values, dropping stable identity (`OPENRUNG_CLIENT_ID`, Reality keys, `OPENRUNG_SHORT_ID`), capacity limits, and camouflage — silently rotating relay credentials and breaking clients holding a cached descriptor. `.env.example` defines 25 vars; the old code preserved 5.

- Now merges: every existing setting is preserved, only the two controlled keys replaced.
- `OPENRUNG_NODE_CLASS` / `OPENRUNG_VOLUNTEER_TOKEN` are dropped — the token forces the class and a stale value there is a startup error.
- Config implying the hub path (`MODE`/`TUNNEL`/`HUB_ADDR`) **aborts** the convert rather than being silently stripped: Foundation requires direct mode, and silently changing an operator's chosen setting is its own bug.
- Written atomically via temp file + `mv`.

## P2 — `create` could not run with the documented env-token form

It forwarded `OPENRUNG_FOUNDATION_TOKEN` into `lightsail-up.sh`, which rejects it by design, so the run died before provisioning. Reproduced locally, confirming the report. The token is now read once up front and the bootstrap helper invoked with the credential variables stripped from its environment.

## Testing

- `bash -n` clean; usage, HTTPS fail-fast, missing-token, and unknown-host guards all exercised.
- P2 reproduced against the real `lightsail-up.sh` guard, then confirmed fixed.
- Merge logic verified to preserve identity/capacity/camouflage while dropping the conflicting keys.
- Host-key matching and `broker_attested_class` validated **read-only** against real AWS and the live broker (`witty-salmon` → `foundation`; absent host → `unknown`).
- Still **not** smoke-tested end-to-end against a live host — that means recreating a production relay's container, which I have not been asked to do. Happy to run `update` against one relay if you want that proof.

## Note

Since #68 is already merged, `main` currently carries these defects. Worth prioritising this review — the host-key issue is the one I would not want sitting on `main` for long, though exploiting it requires an active MITM on a first connection to a host whose key is not yet known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)