### PR TITLE
Reimplement foundation-up.sh with security fixes (redo of #68)

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -16,6 +16,17 @@ permissions:
   contents: read
 
 jobs:
+  relay-deploy-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Foundation deploy state matrix
+        run: |
+          bash -n deploy/relay/foundation-up.sh
+          bash -n deploy/relay/foundation-up_test.sh
+          bash deploy/relay/foundation-up_test.sh
+
   go:
     runs-on: ubuntu-latest
     steps:

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -87,6 +87,70 @@ also set `OPENRUNG_NODE_CLASS` or `OPENRUNG_MODE`:
 traverses. A Foundation-operated relay hub therefore does not make the
 volunteer-run relays tunneled through it Foundation-operated.
 
+#### Automating the post-boot step
+
+[`foundation-up.sh`](foundation-up.sh) automates the two-step dance above. It
+**wraps** `lightsail-up.sh` rather than changing it: the token still reaches the
+host only over SSH, after boot, and never through user-data — `create` even
+strips the token variables from the provisioning child's environment, so no bug
+in `lightsail-up.sh` could ever embed the credential.
+
+```sh
+# Provision a new Lightsail host and install credentials on it.
+OPENRUNG_FOUNDATION_TOKEN_CMD='pass show openrung/foundation-token' \
+  deploy/relay/foundation-up.sh create
+
+# Promote hosts that are already serving as volunteer-class relays.
+OPENRUNG_FOUNDATION_TOKEN_CMD='pass show openrung/foundation-token' \
+  deploy/relay/foundation-up.sh convert 203.0.113.10 203.0.113.11
+
+# Roll a new image across the fleet. Needs no token: the credentials already on
+# each host are reused as-is.
+OPENRUNG_IMAGE=ghcr.io/openrung/openrung-relay:sha-abc1234 \
+  deploy/relay/foundation-up.sh update 203.0.113.10 203.0.113.11
+```
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `OPENRUNG_FOUNDATION_TOKEN_CMD` | — | Command printing the token (`pass show …`, `aws secretsmanager get-secret-value …`, `op read …`). Preferred. Run via `bash -c`; the first output line is the token. |
+| `OPENRUNG_FOUNDATION_TOKEN` | — | The token itself. Fallback for CI; prefer the command form so the secret is not sitting in your environment. |
+| `OPENRUNG_IMAGE` | `…/openrung-relay:main` | Image to run. Pin a `sha-…` tag (or an `@sha256:…` digest) for reproducible rolls. |
+| `OPENRUNG_BROKER_URL` | `https://broker-origin.openrung.org` | The broker's **direct TLS origin** (see `deploy/broker/origin-tls.md`), not a CDN front: a front would decrypt the Foundation bearer at every edge POP and collapse per-relay rate limiting onto shared edge IPs. Must be HTTPS; the script fails fast otherwise. |
+| `OPENRUNG_ENV_FILE` | `/etc/openrung/relay.env` | Where credentials live. `convert` writes the canonical path and, once the relay verifies, removes a legacy `volunteer.env` so exactly one copy of the token remains on disk. |
+| `OPENRUNG_SSH_KEY` / `OPENRUNG_SSH_USER` | `~/.ssh/id_ed25519_openrung` / `ubuntu` | SSH access to the host. |
+| `OPENRUNG_REGION` | `ap-northeast-1` | Region used to look up Lightsail-published SSH host keys for pinning. |
+
+Notes on the design:
+
+- **The token is never a command-line argument.** `argv` is world-readable via
+  `/proc` and is retained in shell history, so it is read from the environment or
+  a command (run via `bash -c`, never `eval`) and streamed to the host over
+  stdin. The script keeps shell tracing (`bash -x`) disabled so the token cannot
+  leak into trace output, and the env-file write is atomic (tmp + rename).
+- **SSH host keys are pinned out-of-band when possible.** Before the first
+  connection that will carry the token, the host's SSH keys are fetched over the
+  authenticated Lightsail API (`get-instance-access-details`) and written to
+  `known_hosts`, upgrading first contact from trust-on-first-use to verified.
+  Non-Lightsail hosts fall back to `accept-new` with a warning.
+- **Everything read back from a host is allowlist-validated** (container names,
+  env-file paths, identity values) before it is reused in a privileged command
+  or echoed to the terminal, so a compromised relay cannot inject shell or
+  terminal escapes into the operator's session.
+- **`update` needs no token**, because it reuses the env file the host already
+  has — but it refuses to run against an env file that lacks
+  `OPENRUNG_FOUNDATION_TOKEN` (presence check only), so it cannot silently
+  "verify" a non-Foundation host.
+- **`update` is sequential and fails fast.** A bad image stops the roll at the
+  first host rather than taking down every relay, and failures print an in-place
+  rollback command (the previous container is kept, stopped, as
+  `openrung-relay-old`).
+- **Verification is self-contained.** A relay that presents the Foundation token
+  forces `node_class=foundation` and exits during startup if the broker attests
+  any other class, so a container that is still running and has logged a
+  registration *is* the proof — no broker query needed.
+- Legacy `openrung-volunteer` container and `volunteer.env` names are detected,
+  so hosts predating the rename are handled without manual cleanup.
+
 ### Stable relay identity (recommended)
 
 Without an explicit identity, the relay generates a fresh one on every restart.

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -164,9 +164,10 @@ Notes on the design:
   kept, stopped, as `openrung-relay-old`) is only printed once the old container
   has actually been swapped out — never on a pull failure, where the live relay
   is untouched and "rolling back" would destroy it. The swap also refuses to
-  discard an existing `-old` backup while the "live" container is not running
-  (the signature of a previously failed roll), so re-running after a failure
-  cannot delete the last healthy relay.
+  discard an existing `-old` backup unless the current container has itself
+  registered and stayed up — a failed rollout can be running yet never
+  register — so re-running after a failure can never delete the last
+  known-good relay.
 - **Verification is self-contained.** A relay that presents the Foundation token
   forces `node_class=foundation` and exits during startup if the broker attests
   any other class, so a container that logged a registration and is running

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -116,9 +116,10 @@ OPENRUNG_IMAGE=ghcr.io/openrung/openrung-relay:sha-abc1234 \
 | `OPENRUNG_FOUNDATION_TOKEN` | — | The token itself. Fallback for CI; prefer the command form so the secret is not sitting in your environment. |
 | `OPENRUNG_IMAGE` | `…/openrung-relay:main` | Image to run. Pin a `sha-…` tag (or an `@sha256:…` digest) for reproducible rolls. |
 | `OPENRUNG_BROKER_URL` | `https://broker-origin.openrung.org` | The broker's **direct TLS origin** (see `deploy/broker/origin-tls.md`), not a CDN front: a front would decrypt the Foundation bearer at every edge POP and collapse per-relay rate limiting onto shared edge IPs. Must be HTTPS; the script fails fast otherwise. |
-| `OPENRUNG_ENV_FILE` | `/etc/openrung/relay.env` | Where credentials live. `convert` writes the canonical path and, once the relay verifies, removes a legacy `volunteer.env` so exactly one copy of the token remains on disk. |
+| `OPENRUNG_ENV_FILE` | `/etc/openrung/relay.env` | Where credentials live. `convert` writes the canonical path — preserving every setting the host already had — and, once the relay verifies, removes a legacy `volunteer.env` so exactly one copy of the token remains on disk. |
 | `OPENRUNG_SSH_KEY` / `OPENRUNG_SSH_USER` | `~/.ssh/id_ed25519_openrung` / `ubuntu` | SSH access to the host. |
 | `OPENRUNG_REGION` | `ap-northeast-1` | Region used to look up Lightsail-published SSH host keys for pinning. |
+| `OPENRUNG_ALLOW_TOFU` | `0` | Every mode refuses to contact a host whose SSH key cannot be verified out-of-band (a tokenless mode that silently accepted a key would launder it into "known" for a later token-carrying run); set to `1` to explicitly accept a first-seen key (non-Lightsail hosts). |
 
 Notes on the design:
 
@@ -127,27 +128,51 @@ Notes on the design:
   a command (run via `bash -c`, never `eval`) and streamed to the host over
   stdin. The script keeps shell tracing (`bash -x`) disabled so the token cannot
   leak into trace output, and the env-file write is atomic (tmp + rename).
-- **SSH host keys are pinned out-of-band when possible.** Before the first
-  connection that will carry the token, the host's SSH keys are fetched over the
-  authenticated Lightsail API (`get-instance-access-details`) and written to
-  `known_hosts`, upgrading first contact from trust-on-first-use to verified.
-  Non-Lightsail hosts fall back to `accept-new` with a warning.
+- **`convert` preserves the host's `OPENRUNG_*` settings, and only manages the
+  broker URL + token.** A pinned identity (`OPENRUNG_CLIENT_ID`, Reality keys,
+  short id), capacity limits, and camouflage are carried into the new env file
+  verbatim — staged on the host itself, so none of it transits the connection —
+  and a re-convert never rotates a pinned identity. (Bootstrap-provisioned
+  relays carry no pinned identity and regenerate one per restart; that is fleet
+  status quo, unchanged by this script.) No `OPENRUNG_LISTEN_HOST` default is
+  injected — the binary's own `::` (dual-stack) default stands. Dropped
+  deliberately: `OPENRUNG_VOLUNTEER_TOKEN` / `OPENRUNG_NODE_CLASS` (the
+  foundation token forces the class; a spare credential is liability) and
+  `OPENRUNG_XRAY_PATH` / `OPENRUNG_CONFIG_OUT` (image internals that must not
+  be pinned on the host).
+- **SSH host keys are verified out-of-band before any contact.** The host's SSH
+  keys are fetched over the authenticated Lightsail API
+  (`get-instance-access-details`) and written to `known_hosts` before first
+  contact. If that is impossible, **every mode refuses to proceed** rather than
+  fall back to trust-on-first-use — set `OPENRUNG_ALLOW_TOFU=1` to accept a
+  first-seen key explicitly. (IPv6/DNS targets are looked up by IPv4 address
+  only; pin those manually or use `OPENRUNG_ALLOW_TOFU=1`.)
 - **Everything read back from a host is allowlist-validated** (container names,
-  env-file paths, identity values) before it is reused in a privileged command
-  or echoed to the terminal, so a compromised relay cannot inject shell or
-  terminal escapes into the operator's session.
+  env-file paths) before it is reused in a privileged command, and everything
+  remote that reaches the terminal — captured output and passed-through stderr
+  alike — is stripped of control characters, so a compromised relay cannot
+  inject shell or terminal escapes into the operator's session.
 - **`update` needs no token**, because it reuses the env file the host already
-  has — but it refuses to run against an env file that lacks
-  `OPENRUNG_FOUNDATION_TOKEN` (presence check only), so it cannot silently
-  "verify" a non-Foundation host.
+  has — but it refuses to run against an env file whose
+  `OPENRUNG_FOUNDATION_TOKEN` is missing, empty, whitespace-only (a trailing
+  `\r` from a CRLF edit counts: docker strips it and the container sees an
+  empty token), or shadowed by an empty duplicate (docker's last occurrence
+  wins). The value itself is never read back.
 - **`update` is sequential and fails fast.** A bad image stops the roll at the
-  first host rather than taking down every relay, and failures print an in-place
-  rollback command (the previous container is kept, stopped, as
-  `openrung-relay-old`).
+  first host rather than taking down every relay. Failures name the exact state
+  the host is in, and the in-place rollback command (the previous container is
+  kept, stopped, as `openrung-relay-old`) is only printed once the old container
+  has actually been swapped out — never on a pull failure, where the live relay
+  is untouched and "rolling back" would destroy it. The swap also refuses to
+  discard an existing `-old` backup while the "live" container is not running
+  (the signature of a previously failed roll), so re-running after a failure
+  cannot delete the last healthy relay.
 - **Verification is self-contained.** A relay that presents the Foundation token
   forces `node_class=foundation` and exits during startup if the broker attests
-  any other class, so a container that is still running and has logged a
-  registration *is* the proof — no broker query needed.
+  any other class, so a container that logged a registration and is running
+  cleanly (`Running` with `RestartCount` 0 — a post-registration crash loop
+  fails verification) *is* the proof — no broker query needed. Transient ssh
+  errors during polling are retried, never misdiagnosed as a dead container.
 - Legacy `openrung-volunteer` container and `volunteer.env` names are detected,
   so hosts predating the rename are handled without manual cleanup.
 

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -108,6 +108,10 @@ OPENRUNG_FOUNDATION_TOKEN_CMD='pass show openrung/foundation-token' \
 # each host are reused as-is.
 OPENRUNG_IMAGE=ghcr.io/openrung/openrung-relay:sha-abc1234 \
   deploy/relay/foundation-up.sh update 203.0.113.10 203.0.113.11
+
+# Restore the stopped pre-roll container after an interrupted update. This only
+# accepts the exact old-only or old+new state created by this script.
+deploy/relay/foundation-up.sh rollback 203.0.113.10
 ```
 
 | Variable | Default | Meaning |
@@ -116,12 +120,21 @@ OPENRUNG_IMAGE=ghcr.io/openrung/openrung-relay:sha-abc1234 \
 | `OPENRUNG_FOUNDATION_TOKEN` | — | The token itself. Fallback for CI; prefer the command form so the secret is not sitting in your environment. |
 | `OPENRUNG_IMAGE` | `…/openrung-relay:main` | Image to run. Pin a `sha-…` tag (or an `@sha256:…` digest) for reproducible rolls. |
 | `OPENRUNG_BROKER_URL` | `https://broker-origin.openrung.org` | The broker's **direct TLS origin** (see `deploy/broker/origin-tls.md`), not a CDN front: a front would decrypt the Foundation bearer at every edge POP and collapse per-relay rate limiting onto shared edge IPs. Must be HTTPS; the script fails fast otherwise. |
-| `OPENRUNG_ENV_FILE` | `/etc/openrung/relay.env` | Where credentials live. `convert` writes the canonical path — preserving every setting the host already had — and, once the relay verifies, removes a legacy `volunteer.env` so exactly one copy of the token remains on disk. |
+| `OPENRUNG_ENV_FILE` | `/etc/openrung/relay.env` | Canonical credential path. `convert` preserves settings from this file or the canonical running container; it never reads, merges, or removes legacy `volunteer.env`. |
 | `OPENRUNG_SSH_KEY` / `OPENRUNG_SSH_USER` | `~/.ssh/id_ed25519_openrung` / `ubuntu` | SSH access to the host. |
 | `OPENRUNG_REGION` | `ap-northeast-1` | Region used to look up Lightsail-published SSH host keys for pinning. |
 | `OPENRUNG_ALLOW_TOFU` | `0` | Every mode refuses to contact a host whose SSH key cannot be verified out-of-band (a tokenless mode that silently accepted a key would launder it into "known" for a later token-carrying run); set to `1` to explicitly accept a first-seen key (non-Lightsail hosts). |
 
 Notes on the design:
+
+- **The supported state space is deliberately small.** `convert` and `update`
+  accept exactly one running `openrung-relay`, with no `openrung-relay-old`,
+  `openrung-relay-new`, legacy container/env, staged `.tmp`, or unrecognized
+  relay/volunteer-suffixed container (for example, `openrung-relay-old-2026`).
+  Every target is inspected before the first host is changed. Legacy or
+  ambiguous state makes the entire command fail read-only with inspection and
+  manual migration instructions; it is never guessed at or cleaned up
+  automatically.
 
 - **The token is never a command-line argument.** `argv` is world-readable via
   `/proc` and is retained in shell history, so it is read from the environment or
@@ -158,24 +171,34 @@ Notes on the design:
   `\r` from a CRLF edit counts: docker strips it and the container sees an
   empty token), or shadowed by an empty duplicate (docker's last occurrence
   wins). The value itself is never read back.
-- **`update` is sequential and fails fast.** A bad image stops the roll at the
-  first host rather than taking down every relay. Failures name the exact state
-  the host is in, and the in-place rollback command (the previous container is
-  kept, stopped, as `openrung-relay-old`) is only printed once the old container
-  has actually been swapped out — never on a pull failure, where the live relay
-  is untouched and "rolling back" would destroy it. The swap also refuses to
-  discard an existing `-old` backup unless the current container has itself
-  registered and stayed up — a failed rollout can be running yet never
-  register — so re-running after a failure can never delete the last
-  known-good relay.
+- **A candidate never owns the live name before verification.** The current
+  relay is stopped and renamed to `openrung-relay-old`; the replacement runs as
+  `openrung-relay-new`. Only after the candidate registers, remains running, and
+  has `RestartCount` 0 is it renamed to `openrung-relay`. The old container is
+  removed last, returning the host to the single supported steady state.
+- **Interrupted rolls are explicit.** A start failure leaves `-old`; a
+  verification failure leaves `-old` + `-new`. Normal commands refuse both.
+  `rollback` accepts only those exact states, removes an optional uncommitted
+  candidate, and restores the stopped old container through the same pinned SSH
+  configuration. Any live+backup, legacy, running-backup, or staged-temp
+  combination remains manual-only.
 - **Verification is self-contained.** A relay that presents the Foundation token
   forces `node_class=foundation` and exits during startup if the broker attests
   any other class, so a container that logged a registration and is running
   cleanly (`Running` with `RestartCount` 0 — a post-registration crash loop
   fails verification) *is* the proof — no broker query needed. Transient ssh
   errors during polling are retried, never misdiagnosed as a dead container.
-- Legacy `openrung-volunteer` container and `volunteer.env` names are detected,
-  so hosts predating the rename are handled without manual cleanup.
+- Legacy `openrung-volunteer` container and `volunteer.env` names are detected
+  only to refuse mutation and print manual migration instructions.
+
+State policy:
+
+| Entry state | `convert` / `update` | `rollback` |
+|---|---|---|
+| Running `openrung-relay` only | Allowed (`update` also requires canonical env + token) | Refused |
+| Stopped `openrung-relay-old` only | Refused | Restored |
+| Stopped `openrung-relay-old` + `openrung-relay-new` | Refused | Candidate removed, old restored |
+| Any legacy artifact, unrecognized relay/volunteer-suffixed container, `.tmp`, live+backup, or other combination | No mutation; manual instructions | No mutation; manual instructions |
 
 ### Stable relay identity (recommended)
 

--- a/deploy/relay/foundation-up.sh
+++ b/deploy/relay/foundation-up.sh
@@ -54,6 +54,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # so the check and the connection cannot diverge on a per-host ssh_config.
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
 
+# TOKEN is a generic name the caller may already have exported; a plain
+# assignment would inherit that export attribute and hand the bearer to every
+# child process (ssh, aws, lightsail-up.sh). Unset first so the variable is
+# recreated unexported.
+unset TOKEN
 TOKEN=""   # set once per run by the commands that need it; never leaves this process except over SSH stdin
 
 die()  { echo "error: $*" >&2; exit 1; }
@@ -283,7 +288,8 @@ stage_preserved_env() { # host container
            if test -f ${ENV_FILE}; then cat ${ENV_FILE}; fi; \
          else docker inspect ${container} --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null || true; fi; } \
        | sed -n '/^OPENRUNG_[A-Za-z0-9_]*=/p' | sed -E '${PRESERVE_DROP}' > ${ENV_FILE}.tmp \
-    && grep -q '^OPENRUNG_PUBLIC_HOST=..*' ${ENV_FILE}.tmp\"" \
+    && grep -q '^OPENRUNG_PUBLIC_HOST=..*' ${ENV_FILE}.tmp \
+    || { rm -f ${ENV_FILE}.tmp; exit 1; }\"" \
     || die "${host}: could not stage the relay's existing settings (is OPENRUNG_PUBLIC_HOST set in its env file or container?)"
 }
 
@@ -332,9 +338,10 @@ rollback_hint() {
 # rollback hint is only printed once the swap has actually happened, because
 # before that point "rm -f openrung-relay + rename -old" would destroy the
 # healthy live container. The swap stage also refuses to discard an existing
-# -old backup when the "live" container is not actually running: that state
-# means a previous roll already failed, and deleting the backup before the new
-# image has proven itself would destroy the last healthy relay.
+# -old backup unless the current container has itself verified — registered
+# and stayed up (a failed rollout can be running yet never register): a backup
+# only exists because a previous roll happened, and deleting the last
+# known-good relay for an unproven replacement is never right.
 #
 # Container hardening mirrors lightsail-up.sh exactly: --cap-drop ALL with only
 # NET_BIND_SERVICE re-added (the binary binds 443 through a cap_net_bind_service
@@ -344,16 +351,27 @@ recreate_container() {
   local host="$1" env_file="$2" live="$3"
   ssh_run "$host" "sudo docker pull ${IMAGE} >/dev/null" \
     || die "${host}: image pull failed; the live container was not touched"
+  local rc=0
   ssh_run "$host" "set -e
-    if [ \"\$(sudo docker inspect -f '{{.State.Running}}' '${live}' 2>/dev/null)\" != true ] \
-       && sudo docker inspect ${CONTAINER}-old >/dev/null 2>&1; then
-      echo 'refusing to discard the ${CONTAINER}-old backup: ${live} is not running (previous roll failed?)' >&2
-      exit 42
+    if sudo docker inspect ${CONTAINER}-old >/dev/null 2>&1 || sudo docker inspect ${LEGACY_CONTAINER}-old >/dev/null 2>&1; then
+      if [ \"\$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' '${live}' 2>/dev/null)\" != 'true 0' ] \
+         || ! sudo docker logs '${live}' 2>&1 | grep -q 'registered relay'; then
+        echo 'refusing to discard the existing backup: ${live} has not registered and stayed up (previous roll failed?)' >&2
+        exit 42
+      fi
     fi
     sudo docker rm -f ${CONTAINER}-old ${LEGACY_CONTAINER}-old >/dev/null 2>&1 || true
     sudo docker stop '${live}' >/dev/null
-    sudo docker rename '${live}' ${CONTAINER}-old" \
-    || die "${host}: could not swap out '${live}'. If a stopped '${live}' coexists with a '${CONTAINER}-old' backup, a previous roll failed — restore the backup (docker rename ${CONTAINER}-old ${live}; docker start ${live}) or remove the dead container, then re-run. If '${live}' was stopped but not renamed, restart it with: docker start '${live}'"
+    sudo docker rename '${live}' ${CONTAINER}-old" || rc=$?
+  if [ "$rc" = 42 ]; then
+    # A backup exists and the current container never verified: the backup is
+    # the last known-good relay, so it must not be discarded for an unproven
+    # replacement. Rolling back to it (below) IS the correct recovery here.
+    rollback_hint "$host"
+    die "${host}: refusing to discard the existing backup: '${live}' has not registered and stayed up (previous roll failed?). Roll back to the backup (above) or remove the failed '${live}' container, then re-run"
+  elif [ "$rc" != 0 ]; then
+    die "${host}: could not swap out '${live}'. Inspect with 'docker ps -a': if '${live}' was stopped but not renamed, restart it with: docker start '${live}'"
+  fi
   ssh_run "$host" "sudo docker run -d --name ${CONTAINER} --restart unless-stopped \
       --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
       --env-file ${env_file} \
@@ -406,7 +424,11 @@ convert_host() {
   # Everything already configured on the host is preserved; only the broker URL
   # and the token are (re)written. The identity readback below is display-only.
   stage_preserved_env "$host" "$live"
-  ident="$(ssh_run "$host" "sudo sed -n -e 's/^OPENRUNG_PUBLIC_HOST=/public_host=/p' -e 's/^OPENRUNG_LABEL=/label=/p' ${ENV_FILE}.tmp")"
+  # On readback failure, remove the staged tmp (it holds the preserved Reality
+  # private key and no trap guards it until install_env_file's session).
+  ident="$(ssh_run "$host" "sudo sed -n -e 's/^OPENRUNG_PUBLIC_HOST=/public_host=/p' -e 's/^OPENRUNG_LABEL=/label=/p' ${ENV_FILE}.tmp")" \
+    || { ssh_run "$host" "sudo rm -f ${ENV_FILE}.tmp" >/dev/null 2>&1 || true
+         die "${host}: could not read back the staged identity"; }
   public_host="$(printf '%s\n' "$ident" | sed -n 's/^public_host=//p' | tail -1 | scrub | head -c 100)"
   label="$(printf '%s\n' "$ident" | sed -n 's/^label=//p' | tail -1 | scrub | head -c 100)"
 

--- a/deploy/relay/foundation-up.sh
+++ b/deploy/relay/foundation-up.sh
@@ -26,7 +26,8 @@
 # broker rate-limits each relay by its real IP instead of by shared edge IPs.
 #
 # Overridable via env: OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_ENV_FILE,
-# OPENRUNG_SSH_KEY, OPENRUNG_SSH_USER, OPENRUNG_REGION (host-key pinning lookups).
+# OPENRUNG_SSH_KEY, OPENRUNG_SSH_USER, OPENRUNG_REGION (host-key pinning lookups),
+# OPENRUNG_ALLOW_TOFU=1 (explicitly accept an unverifiable first-contact host key).
 # `create` also forwards OPENRUNG_BUNDLE and the rest of lightsail-up.sh's knobs.
 set -euo pipefail
 
@@ -46,10 +47,12 @@ LEGACY_CONTAINER="openrung-volunteer"      # pre-rename fleets still run this na
 LEGACY_ENV_FILE="/etc/openrung/volunteer.env"
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# accept-new never accepts a CHANGED key; pin_host_key (below) upgrades first
-# contact from trust-on-first-use to verified whenever the Lightsail API can
-# vouch for the host key.
-SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
+# accept-new never accepts a CHANGED key, and pin_host_key below guarantees a
+# key is already known (API-pinned, operator-added, or explicitly TOFU'd via
+# OPENRUNG_ALLOW_TOFU=1) before any mode connects — no key is ever learned
+# implicitly. UserKnownHostsFile pins ssh to the same file pin_host_key writes,
+# so the check and the connection cannot diverge on a per-host ssh_config.
+SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
 
 TOKEN=""   # set once per run by the commands that need it; never leaves this process except over SSH stdin
 
@@ -70,27 +73,34 @@ EOF
   exit 2
 }
 
-ssh_run() { local host="$1"; shift; ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" "$@"; }
+# Remote stderr reaches the operator's terminal for diagnostics, but a
+# compromised host must not be able to write terminal escapes through it —
+# strip everything but printable characters, newlines, and tabs.
+scrub_stream() { tr -cd '[:print:]\n\t'; }
+scrub()        { tr -cd '[:print:]'; }
+
+ssh_run() {
+  local host="$1"; shift
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" "$@" 2> >(scrub_stream >&2)
+}
 
 # --- input validation -------------------------------------------------------
 #
 # Everything read back from a host (container names, env-file paths, env values,
-# log lines) is attacker-controlled if that host is compromised. Nothing remote
-# is interpolated into another command or echoed to the terminal until it has
-# passed one of these allowlists; display-only strings are stripped of control
-# characters so a hostile value cannot inject terminal escapes.
+# log lines, stderr) is attacker-controlled if that host is compromised. Nothing
+# remote is interpolated into another command until it has passed one of these
+# allowlists, and everything remote that reaches the terminal — captured stdout
+# and passed-through stderr alike — is stripped of control characters first.
 
 NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'      # instance names, labels, container names
 HOST_RE='^[A-Za-z0-9][A-Za-z0-9.:-]*$'      # IPv4, IPv6, DNS names
-
-scrub() { tr -cd '[:print:]'; }
 
 assert_matches() { # value regex what
   local val="$1" re="$2" what="$3"
   [[ "$val" =~ $re ]] || die "unexpected ${what}: '$(printf '%s' "$val" | scrub | head -c 100)'"
 }
 
-# Exactly one of the two known values (or empty): remote detection output must
+# Exactly one of the known values (or empty): remote detection output must
 # never become a free-form string in a later privileged command.
 assert_one_of() { # value what allowed...
   local val="$1" what="$2"; shift 2
@@ -143,16 +153,26 @@ read_token() {
   printf '%s' "$raw"
 }
 
+# Capture the token for this run, then drop the source variables so children
+# (ssh, aws, ssh-keygen) never inherit the credential — the same rationale as
+# create's env -u for lightsail-up.sh.
+load_token() {
+  TOKEN="$(read_token)"
+  unset OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD
+}
+
 # --- SSH host identity ------------------------------------------------------
 
-# Upgrade first contact from trust-on-first-use to verified: Lightsail publishes
-# each instance's SSH host keys over the (TLS, SigV4-authenticated) AWS API, so
-# pin them into known_hosts before the first connection that will carry the
-# token. Best-effort — a non-Lightsail host or an instance outside
-# OPENRUNG_REGION falls back to accept-new, loudly.
+# Verify first contact out-of-band: Lightsail publishes each instance's SSH host
+# keys over the (TLS, SigV4-authenticated) AWS API, so pin them into known_hosts
+# before the first connection. When the key can be neither found locally nor
+# pinned, EVERY mode refuses to connect — a tokenless mode that silently
+# accepted a first-seen key would launder it into "known" for a later
+# token-carrying convert. OPENRUNG_ALLOW_TOFU=1 is the explicit, per-run opt-in
+# (e.g. for a non-Lightsail host whose key was checked another way).
 pin_host_key() { # host [instance-name] [attempts]
   local host="$1" name="${2:-}" attempts="${3:-1}" keys="" i=0
-  ssh-keygen -F "$host" >/dev/null 2>&1 && return 0
+  ssh-keygen -F "$host" -f "$HOME/.ssh/known_hosts" >/dev/null 2>&1 && return 0
 
   if [ -z "$name" ]; then
     name="$(aws lightsail get-instances --region "$REGION" \
@@ -169,8 +189,11 @@ pin_host_key() { # host [instance-name] [attempts]
     done
   fi
   if [ -z "$keys" ]; then
-    warn "${host}: no Lightsail-published host key (non-Lightsail host, or not in ${REGION}); first contact is trust-on-first-use"
-    return 0
+    if [ "${OPENRUNG_ALLOW_TOFU:-0}" = 1 ]; then
+      warn "${host}: no Lightsail-published host key; first contact is trust-on-first-use (OPENRUNG_ALLOW_TOFU=1)"
+      return 0
+    fi
+    die "${host}: cannot verify the SSH host key out-of-band (no Lightsail-published key: non-Lightsail host, or not in ${REGION}; IPv6/DNS targets are looked up by IPv4 address only). No mode contacts an unverified host implicitly. Verify the key via your provider's console, add it to ~/.ssh/known_hosts, and re-run ('convert ${host}' if the instance is already provisioned) — or set OPENRUNG_ALLOW_TOFU=1 to accept the first-seen key explicitly."
   fi
 
   mkdir -p "$HOME/.ssh"
@@ -188,7 +211,8 @@ pin_host_key() { # host [instance-name] [attempts]
 # --- host inspection --------------------------------------------------------
 
 # Echo whichever relay container name is present on the host, preferring the
-# canonical one. Empty when the host runs neither.
+# canonical one. Empty when the host runs neither. Note: matches stopped
+# containers too — callers that need a live one must check state themselves.
 detect_container() {
   local found
   found="$(ssh_run "$1" "for c in ${CONTAINER} ${LEGACY_CONTAINER}; do
@@ -208,50 +232,91 @@ detect_env_file() {
   printf '%s' "$found"
 }
 
-# Read one non-secret OPENRUNG_* value out of the running container. The filter
-# runs on the host, so secret-bearing env lines never transit the connection.
-container_env_value() {
-  local host="$1" container="$2" key="$3"
-  ssh_run "$host" "sudo docker inspect ${container} --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
-    | sed -n 's/^${key}=//p' | head -1"
-}
-
-# Confirm the env file carries the Foundation credential (presence only — the
-# value is never read back). Without this, `update` would happily roll and
-# "verify" a host that is not a Foundation relay at all.
+# Confirm the env file carries a usable Foundation credential (presence only —
+# the value is never read back): at least one token line whose value starts
+# with a non-whitespace character, and no empty assignment anywhere. Both
+# checks matter: docker's --env-file strips a trailing CR (so 'TOKEN=\r' is
+# empty in the container despite looking non-empty to grep), and on duplicate
+# keys the LAST occurrence wins (so 'TOKEN=x' followed by 'TOKEN=' is empty
+# too). An empty token silently demotes the relay to volunteer class, which
+# verify_foundation could not tell apart from success.
 require_env_has_token() {
   local host="$1" file="$2"
-  ssh_run "$host" "sudo grep -q '^OPENRUNG_FOUNDATION_TOKEN=' ${file}" \
-    || die "${host}: ${file} has no OPENRUNG_FOUNDATION_TOKEN; not a Foundation relay — run 'convert' first"
+  ssh_run "$host" "sudo grep -q '^OPENRUNG_FOUNDATION_TOKEN=[^[:space:]]' ${file} \
+      && ! sudo grep -q '^OPENRUNG_FOUNDATION_TOKEN=[[:space:]]*\$' ${file}" \
+    || die "${host}: ${file} has no usable OPENRUNG_FOUNDATION_TOKEN (missing, empty, or an empty duplicate); not a Foundation relay — run 'convert' first"
 }
 
 # --- mutation ---------------------------------------------------------------
 
-# Write the root-owned mode-0600 env file. The token arrives on stdin so it never
-# appears in argv on either side of the connection, and the write is atomic
-# (tmp + rename) so a dropped connection cannot leave a truncated credential file.
-install_env_file() { # host public_host label   (token from $TOKEN, target is $ENV_FILE)
-  { set +x; } 2>/dev/null
-  local host="$1" public_host="$2" label="$3"
-  {
-    printf 'OPENRUNG_BROKER_URL=%s\n' "$BROKER_URL"
-    printf 'OPENRUNG_PUBLIC_HOST=%s\n' "$public_host"
-    printf 'OPENRUNG_LISTEN_HOST=0.0.0.0\n'
-    printf 'OPENRUNG_LABEL=%s\n' "$label"
-    printf 'OPENRUNG_FOUNDATION_TOKEN=%s\n' "$TOKEN"
-  } | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" \
-      "sudo install -d -m 700 -o root -g root /etc/openrung \
-       && sudo sh -c 'umask 077 && cat > ${ENV_FILE}.tmp && mv -f ${ENV_FILE}.tmp ${ENV_FILE}'"
+# Keys this script owns and (re)writes on convert. Everything else already
+# configured on the host — stable identity (OPENRUNG_CLIENT_ID, Reality keys,
+# short id), capacity limits, camouflage — is preserved verbatim, so a convert
+# or re-convert never rotates a pinned identity or drops tuning. (Bootstrap
+# relays carry no pinned identity and regenerate one per restart; that is fleet
+# status quo, unchanged by this script.) Dropped deliberately:
+#   VOLUNTEER_TOKEN / NODE_CLASS — the foundation token forces the class (a
+#     conflicting node_class is a startup error) and a spare credential in the
+#     file is pure liability;
+#   XRAY_PATH / CONFIG_OUT — image/entrypoint internals that docker inspect
+#     reports from the image's own ENV; pinning them in the host env file would
+#     permanently override future images that relocate those paths.
+PRESERVE_DROP='/^OPENRUNG_(BROKER_URL|FOUNDATION_TOKEN|VOLUNTEER_TOKEN|NODE_CLASS|XRAY_PATH|CONFIG_OUT)=/d'
+
+# Stage the preserved settings into ENV_FILE.tmp on the host. Sources: the
+# legacy env file, then the canonical one (both when present — docker's
+# last-occurrence-wins semantics make the canonical file take precedence per
+# key while legacy-only keys still survive), else the running container's
+# OPENRUNG_* environment. Only OPENRUNG_* lines are kept. The filter runs on
+# the host and the result stays there: no secret and no preserved value ever
+# transits the connection or a command line. Fails when no OPENRUNG_PUBLIC_HOST
+# survives, since direct mode cannot run without one. Deliberately no
+# OPENRUNG_LISTEN_HOST default is added: the binary's own default (::,
+# dual-stack) is correct, and pinning 0.0.0.0 here would silently cut IPv6 on
+# hosts that relied on the default.
+stage_preserved_env() { # host container
+  local host="$1" container="$2"
+  ssh_run "$host" "sudo sh -c \"set -e; umask 077 \
+    && { test -d ${ENV_FILE%/*} || install -d -m 700 -o root -g root ${ENV_FILE%/*}; } \
+    && { if test -f ${ENV_FILE} || test -f ${LEGACY_ENV_FILE}; then \
+           if test -f ${LEGACY_ENV_FILE}; then cat ${LEGACY_ENV_FILE}; fi; \
+           if test -f ${ENV_FILE}; then cat ${ENV_FILE}; fi; \
+         else docker inspect ${container} --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null || true; fi; } \
+       | sed -n '/^OPENRUNG_[A-Za-z0-9_]*=/p' | sed -E '${PRESERVE_DROP}' > ${ENV_FILE}.tmp \
+    && grep -q '^OPENRUNG_PUBLIC_HOST=..*' ${ENV_FILE}.tmp\"" \
+    || die "${host}: could not stage the relay's existing settings (is OPENRUNG_PUBLIC_HOST set in its env file or container?)"
 }
 
-# A convert writes the canonical path; once the relay has verified, remove the
-# legacy volunteer.env so exactly one copy of the token remains on disk. (The
-# rollback container does not need the file: its env was baked in at create.)
-cleanup_legacy_env() {
+# Append the managed keys to the staged file and move it into place. The token
+# arrives on stdin so it never appears in argv on either side of the connection.
+# tmp + rename keeps the canonical path complete-or-previous; the EXIT trap
+# removes the token-bearing tmp on orderly failures (a hard connection drop can
+# still strand it briefly — the next stage_preserved_env truncates it).
+install_env_file() { # host   (managed values from $TOKEN / $BROKER_URL; preserved settings already staged)
+  { set +x; } 2>/dev/null
   local host="$1"
+  {
+    printf 'OPENRUNG_BROKER_URL=%s\n' "$BROKER_URL"
+    printf 'OPENRUNG_FOUNDATION_TOKEN=%s\n' "$TOKEN"
+  } | ssh_run "$host" \
+      "sudo sh -c 'trap \"rm -f ${ENV_FILE}.tmp\" EXIT; set -e; umask 077; cat >> ${ENV_FILE}.tmp; mv -f ${ENV_FILE}.tmp ${ENV_FILE}'"
+}
+
+# A convert writes the canonical path with everything preserved into it; once
+# the relay has verified, remove the legacy volunteer.env so exactly one copy
+# of the token remains on disk. (The rollback container does not need the file:
+# its env was baked in at create.) Post-success hygiene: an ssh failure here
+# warns rather than fails the conversion, but never silently — and it is
+# distinguished from "no legacy file" by an explicit marker, not an exit code.
+cleanup_legacy_env() {
+  local host="$1" present
   [ "$ENV_FILE" = "$LEGACY_ENV_FILE" ] && return 0   # operator pointed the canonical path at the legacy one
-  if ssh_run "$host" "sudo test -f ${LEGACY_ENV_FILE}"; then
-    ssh_run "$host" "sudo sh -c 'shred -u ${LEGACY_ENV_FILE} 2>/dev/null || rm -f ${LEGACY_ENV_FILE}'"
+  present="$(ssh_run "$host" "sudo sh -c 'rm -f ${ENV_FILE}.tmp; if test -f ${LEGACY_ENV_FILE}; then echo yes; else echo no; fi'")" \
+    || { warn "${host}: could not check for a legacy env file; re-run convert or remove ${LEGACY_ENV_FILE} manually"; return 0; }
+  assert_one_of "$present" "legacy-check result" yes no
+  if [ "$present" = yes ]; then
+    ssh_run "$host" "sudo sh -c 'shred -u ${LEGACY_ENV_FILE} 2>/dev/null || rm -f ${LEGACY_ENV_FILE}'" \
+      || { warn "${host}: could not remove ${LEGACY_ENV_FILE}; remove it manually"; return 0; }
     log "removed legacy ${LEGACY_ENV_FILE}; credentials now live only at ${ENV_FILE}"
   fi
 }
@@ -261,8 +326,15 @@ rollback_hint() {
   echo "  rollback: ssh ${SSH_USER}@${host} 'sudo docker rm -f ${CONTAINER}; sudo docker rename ${CONTAINER}-old ${CONTAINER} && sudo docker start ${CONTAINER}'" >&2
 }
 
-# Recreate the relay container against env_file. Keeps the previous container,
-# stopped, as <name>-old so a bad image can be rolled back in place.
+# Recreate the relay container against env_file, in three separately-reported
+# stages so a failure names exactly what state the host is in. The previous
+# container is kept, stopped, as <name>-old for in-place rollback — and the
+# rollback hint is only printed once the swap has actually happened, because
+# before that point "rm -f openrung-relay + rename -old" would destroy the
+# healthy live container. The swap stage also refuses to discard an existing
+# -old backup when the "live" container is not actually running: that state
+# means a previous roll already failed, and deleting the backup before the new
+# image has proven itself would destroy the last healthy relay.
 #
 # Container hardening mirrors lightsail-up.sh exactly: --cap-drop ALL with only
 # NET_BIND_SERVICE re-added (the binary binds 443 through a cap_net_bind_service
@@ -270,39 +342,52 @@ rollback_hint() {
 # no-new-privileges, which would disable that file capability and break the bind.
 recreate_container() {
   local host="$1" env_file="$2" live="$3"
+  ssh_run "$host" "sudo docker pull ${IMAGE} >/dev/null" \
+    || die "${host}: image pull failed; the live container was not touched"
   ssh_run "$host" "set -e
-    sudo docker pull ${IMAGE} >/dev/null
-    sudo docker rm -f ${CONTAINER}-old ${LEGACY_CONTAINER}-old >/dev/null 2>&1 || true
-    if [ -n '${live}' ]; then
-      sudo docker stop '${live}' >/dev/null
-      sudo docker rename '${live}' ${CONTAINER}-old
+    if [ \"\$(sudo docker inspect -f '{{.State.Running}}' '${live}' 2>/dev/null)\" != true ] \
+       && sudo docker inspect ${CONTAINER}-old >/dev/null 2>&1; then
+      echo 'refusing to discard the ${CONTAINER}-old backup: ${live} is not running (previous roll failed?)' >&2
+      exit 42
     fi
-    sudo docker run -d --name ${CONTAINER} --restart unless-stopped \
+    sudo docker rm -f ${CONTAINER}-old ${LEGACY_CONTAINER}-old >/dev/null 2>&1 || true
+    sudo docker stop '${live}' >/dev/null
+    sudo docker rename '${live}' ${CONTAINER}-old" \
+    || die "${host}: could not swap out '${live}'. If a stopped '${live}' coexists with a '${CONTAINER}-old' backup, a previous roll failed — restore the backup (docker rename ${CONTAINER}-old ${live}; docker start ${live}) or remove the dead container, then re-run. If '${live}' was stopped but not renamed, restart it with: docker start '${live}'"
+  ssh_run "$host" "sudo docker run -d --name ${CONTAINER} --restart unless-stopped \
       --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
       --env-file ${env_file} \
       ${IMAGE} >/dev/null" \
-    || { rollback_hint "$host"; die "${host}: container recreate failed"; }
+    || { rollback_hint "$host"; die "${host}: docker run failed"; }
 }
 
 # A relay that presents the Foundation token forces node_class=foundation, and it
 # exits during startup if the broker attests any other class (cmd/relay refuses a
 # mismatched attestation; the broker 403s a foundation claim without the token).
-# So a container that is still running and has logged a registration IS the proof
-# the broker attested Foundation — no separate broker query needed. This holds
-# only because convert always writes the token and update asserts its presence.
+# So a container that logged a registration AND is running cleanly (no restarts —
+# a post-registration crash loop keeps the old log line while the relay flaps) IS
+# the proof the broker attested Foundation. This holds only because convert
+# always writes a validated non-empty token and update asserts one is present.
+# An ssh failure during polling is treated as transient — never as evidence the
+# container died — so a network blip cannot trigger a false rollback hint.
 verify_foundation() {
-  local host="$1" i=0 line
+  local host="$1" i=0 line state ps_out
   while [ "$i" -lt 30 ]; do
     if ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep -q 'registered relay'"; then
-      ssh_run "$host" "sudo docker ps --format '{{.Names}}' | grep -qx ${CONTAINER}" \
-        || { rollback_hint "$host"; die "${host}: container exited after registering; check: docker logs ${CONTAINER}"; }
-      line="$(ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep 'registered relay' | tail -1" | scrub | head -c 300)" || line=""
-      log "registered and running: ${line}"
-      return 0
-    fi
-    if ! ssh_run "$host" "sudo docker ps --format '{{.Names}}' | grep -qx ${CONTAINER}"; then
-      rollback_hint "$host"
-      die "${host}: container is not running; check: docker logs ${CONTAINER}"
+      if state="$(ssh_run "$host" "sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' ${CONTAINER} 2>/dev/null")"; then
+        if [ "$state" = "true 0" ]; then
+          line="$(ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep 'registered relay' | tail -1" | scrub | head -c 300)" || line=""
+          log "registered and running: ${line}"
+          return 0
+        fi
+        rollback_hint "$host"
+        die "${host}: container registered but is not running cleanly (state: $(printf '%s' "$state" | scrub | head -c 40)); check: docker logs ${CONTAINER}"
+      fi
+    elif ps_out="$(ssh_run "$host" "sudo docker ps --format '{{.Names}}'" 2>/dev/null)"; then
+      if ! printf '%s\n' "$ps_out" | grep -qx "${CONTAINER}"; then
+        rollback_hint "$host"
+        die "${host}: container is not running; check: docker logs ${CONTAINER}"
+      fi
     fi
     i=$((i + 1)); sleep 2
   done
@@ -313,24 +398,21 @@ verify_foundation() {
 # --- commands ---------------------------------------------------------------
 
 convert_host() {
-  local host="$1" live public_host label
+  local host="$1" live ident public_host label
   echo "==> convert ${host}"
   live="$(detect_container "$host")"
   [ -n "$live" ] || die "${host}: no relay container found; provision it first (lightsail-up.sh or 'create')"
 
-  # Reuse the identity the bootstrap helper already baked in, so a convert does
-  # not silently relabel or re-home an existing relay. Both values came from the
-  # host: validate before they are reused or displayed.
-  public_host="$(container_env_value "$host" "$live" OPENRUNG_PUBLIC_HOST)"
-  label="$(container_env_value "$host" "$live" OPENRUNG_LABEL)"
-  [ -n "$public_host" ] || die "${host}: could not read OPENRUNG_PUBLIC_HOST from ${live}"
-  [ -n "$label" ] || die "${host}: could not read OPENRUNG_LABEL from ${live}"
-  assert_matches "$public_host" "$HOST_RE" "OPENRUNG_PUBLIC_HOST"
-  assert_matches "$label" "$NAME_RE" "OPENRUNG_LABEL"
+  # Everything already configured on the host is preserved; only the broker URL
+  # and the token are (re)written. The identity readback below is display-only.
+  stage_preserved_env "$host" "$live"
+  ident="$(ssh_run "$host" "sudo sed -n -e 's/^OPENRUNG_PUBLIC_HOST=/public_host=/p' -e 's/^OPENRUNG_LABEL=/label=/p' ${ENV_FILE}.tmp")"
+  public_host="$(printf '%s\n' "$ident" | sed -n 's/^public_host=//p' | tail -1 | scrub | head -c 100)"
+  label="$(printf '%s\n' "$ident" | sed -n 's/^label=//p' | tail -1 | scrub | head -c 100)"
 
-  log "identity: label=${label} public_host=${public_host}"
-  install_env_file "$host" "$public_host" "$label"
-  log "wrote ${ENV_FILE} (root:root 0600)"
+  log "identity: label=${label:--} public_host=${public_host} (preserved)"
+  install_env_file "$host"
+  log "wrote ${ENV_FILE} (root:root 0600; existing settings preserved, broker URL + token updated)"
   recreate_container "$host" "$ENV_FILE" "$live"
   verify_foundation "$host"
   cleanup_legacy_env "$host"
@@ -340,7 +422,7 @@ cmd_convert() {
   [ "$#" -ge 1 ] || usage
   require_https_broker
   validate_config
-  TOKEN="$(read_token)"
+  load_token
   local host
   for host in "$@"; do
     assert_matches "$host" "$HOST_RE" "host"
@@ -364,6 +446,7 @@ cmd_update() {
     [ -n "$env_file" ] || die "${host}: no env file (${ENV_FILE} or ${LEGACY_ENV_FILE}); run 'convert' first"
     require_env_has_token "$host" "$env_file"
     live="$(detect_container "$host")"
+    [ -n "$live" ] || die "${host}: no relay container found to update; run 'convert' (or 'create') first"
     log "reusing ${env_file}; image ${IMAGE}"
     recreate_container "$host" "$env_file" "$live"
     verify_foundation "$host"
@@ -373,7 +456,7 @@ cmd_update() {
 cmd_create() {
   require_https_broker
   validate_config
-  TOKEN="$(read_token)"   # fail before provisioning, not after
+  load_token   # fail before provisioning, not after
 
   # lightsail-up.sh refuses to run with token variables set (its own user-data
   # guard), and stripping them here makes the guarantee structural: the
@@ -390,15 +473,20 @@ cmd_create() {
   assert_matches "$name" "$NAME_RE" "instance name"
   assert_matches "$ip" "$HOST_RE" "instance ip"
 
-  # Pin before the first connection that will carry the token. Host keys are
-  # published shortly after boot; retry while the instance settles.
+  # Pin before the first connection; the token transits this session, so an
+  # unverifiable key is fatal (see pin_host_key). Host keys are published
+  # shortly after boot; retry while the instance settles.
   pin_host_key "$ip" "$name" 6
 
+  # The wait loop polls quietly, but a persistent ssh failure (wrong key pair,
+  # host-key mismatch) must not masquerade as "still bootstrapping" — surface
+  # the last ssh error when the wait times out. Direct ssh (not ssh_run) so the
+  # error is captured synchronously; it is scrubbed before display.
   echo "==> waiting for ${name} (${ip}) to finish bootstrapping"
-  local i=0
-  until ssh_run "$ip" "sudo docker inspect ${CONTAINER} >/dev/null 2>&1" 2>/dev/null; do
+  local i=0 waiterr=""
+  until waiterr="$(ssh "${SSH_OPTS[@]}" "${SSH_USER}@${ip}" "sudo docker inspect ${CONTAINER} >/dev/null 2>&1" 2>&1)"; do
     i=$((i + 1))
-    [ "$i" -lt 60 ] || die "${ip}: relay container did not appear within 5 minutes; check /var/log/openrung-init.log"
+    [ "$i" -lt 60 ] || die "${ip}: relay container did not appear within 5 minutes (last ssh error: $(printf '%s' "$waiterr" | scrub | tail -c 160)); check /var/log/openrung-init.log"
     sleep 5
   done
   convert_host "$ip"

--- a/deploy/relay/foundation-up.sh
+++ b/deploy/relay/foundation-up.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+#
+# Provision, convert, and update OpenRung Foundation-operated relays.
+#
+#   deploy/relay/foundation-up.sh create [name]        # new Lightsail host, then install credentials
+#   deploy/relay/foundation-up.sh convert <host>...    # install credentials on an existing host
+#   deploy/relay/foundation-up.sh update  <host>...    # pull the image and recreate, reusing credentials
+#
+# This wraps — and never replaces — lightsail-up.sh. That helper deliberately
+# refuses registration tokens because Lightsail retains user-data, so a Foundation
+# relay has always needed a second, manual step: install a root-owned mode-0600 env
+# file over SSH and recreate the container with --env-file. This script automates
+# exactly that step, preserving the invariant rather than weakening it: the token
+# reaches the host only over SSH, after boot, and never through user-data. `create`
+# even strips the token variables from lightsail-up.sh's environment, so the
+# provisioning step structurally cannot see the credential, let alone embed it.
+#
+# The token is read from OPENRUNG_FOUNDATION_TOKEN_CMD (preferred; run via
+# `bash -c`, first output line is the token) or OPENRUNG_FOUNDATION_TOKEN. It is
+# never accepted as a command-line argument: argv is world-readable via /proc and
+# is retained in shell history.
+#
+# The broker URL defaults to the broker's own TLS origin, NOT a CDN front. A
+# front decrypts the Foundation bearer at every edge POP; the direct origin
+# (deploy/broker/origin-tls.md) means only the broker box ever sees it, and the
+# broker rate-limits each relay by its real IP instead of by shared edge IPs.
+#
+# Overridable via env: OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_ENV_FILE,
+# OPENRUNG_SSH_KEY, OPENRUNG_SSH_USER, OPENRUNG_REGION (host-key pinning lookups).
+# `create` also forwards OPENRUNG_BUNDLE and the rest of lightsail-up.sh's knobs.
+set -euo pipefail
+
+# A credential transits this script's variables: keep xtrace off even under
+# `bash -x`, so the token can never appear in trace output.
+{ set +x; } 2>/dev/null
+
+IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
+BROKER_URL="${OPENRUNG_BROKER_URL:-https://broker-origin.openrung.org}"
+ENV_FILE="${OPENRUNG_ENV_FILE:-/etc/openrung/relay.env}"
+SSH_KEY="${OPENRUNG_SSH_KEY:-$HOME/.ssh/id_ed25519_openrung}"
+SSH_USER="${OPENRUNG_SSH_USER:-ubuntu}"
+REGION="${OPENRUNG_REGION:-ap-northeast-1}"
+
+CONTAINER="openrung-relay"
+LEGACY_CONTAINER="openrung-volunteer"      # pre-rename fleets still run this name
+LEGACY_ENV_FILE="/etc/openrung/volunteer.env"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# accept-new never accepts a CHANGED key; pin_host_key (below) upgrades first
+# contact from trust-on-first-use to verified whenever the Lightsail API can
+# vouch for the host key.
+SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
+
+TOKEN=""   # set once per run by the commands that need it; never leaves this process except over SSH stdin
+
+die()  { echo "error: $*" >&2; exit 1; }
+log()  { echo "  $*"; }
+warn() { echo "  warning: $*" >&2; }
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  deploy/relay/foundation-up.sh create [name]        # new Lightsail host, then install credentials
+  deploy/relay/foundation-up.sh convert <host>...    # install credentials on an existing host
+  deploy/relay/foundation-up.sh update  <host>...    # pull the image and recreate, reusing credentials
+
+The Foundation token is read from OPENRUNG_FOUNDATION_TOKEN_CMD (preferred) or
+OPENRUNG_FOUNDATION_TOKEN — never from argv. `update` needs no token.
+EOF
+  exit 2
+}
+
+ssh_run() { local host="$1"; shift; ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" "$@"; }
+
+# --- input validation -------------------------------------------------------
+#
+# Everything read back from a host (container names, env-file paths, env values,
+# log lines) is attacker-controlled if that host is compromised. Nothing remote
+# is interpolated into another command or echoed to the terminal until it has
+# passed one of these allowlists; display-only strings are stripped of control
+# characters so a hostile value cannot inject terminal escapes.
+
+NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'      # instance names, labels, container names
+HOST_RE='^[A-Za-z0-9][A-Za-z0-9.:-]*$'      # IPv4, IPv6, DNS names
+
+scrub() { tr -cd '[:print:]'; }
+
+assert_matches() { # value regex what
+  local val="$1" re="$2" what="$3"
+  [[ "$val" =~ $re ]] || die "unexpected ${what}: '$(printf '%s' "$val" | scrub | head -c 100)'"
+}
+
+# Exactly one of the two known values (or empty): remote detection output must
+# never become a free-form string in a later privileged command.
+assert_one_of() { # value what allowed...
+  local val="$1" what="$2"; shift 2
+  [ -z "$val" ] && return 0
+  local allowed
+  for allowed in "$@"; do [ "$val" = "$allowed" ] && return 0; done
+  die "host returned an unexpected ${what}: '$(printf '%s' "$val" | scrub | head -c 100)'"
+}
+
+# The relay binary refuses to send the Foundation bearer over cleartext, so a
+# non-HTTPS broker URL would fail at runtime as a confusing crash loop. Fail here
+# instead, with the reason. The URL is also written into the env file, so reject
+# whitespace and control characters (an embedded newline would inject extra
+# variables into the file).
+require_https_broker() {
+  case "$BROKER_URL" in
+    https://*) ;;
+    *) die "OPENRUNG_BROKER_URL must be https for a Foundation relay (got '$(printf '%s' "$BROKER_URL" | scrub)'); the relay refuses to send the token over cleartext" ;;
+  esac
+  assert_matches "$BROKER_URL" '^[[:graph:]]+$' "OPENRUNG_BROKER_URL"
+}
+
+# Operator-set values that get interpolated into privileged remote commands.
+validate_config() {
+  assert_matches "$ENV_FILE" '^/[A-Za-z0-9/._-]+$' "OPENRUNG_ENV_FILE"
+  assert_matches "$IMAGE" '^[A-Za-z0-9][A-Za-z0-9:/@._-]*$' "OPENRUNG_IMAGE"
+}
+
+# --- credentials ------------------------------------------------------------
+
+# Print the Foundation token on stdout. Never echoed, never in argv. The token
+# command runs under `bash -c` in a child shell — not `eval` — so it cannot
+# read or clobber this script's own state, and only its first output line is
+# taken (matching `pass show`, whose later lines are metadata).
+read_token() {
+  { set +x; } 2>/dev/null
+  local raw
+  if [ -n "${OPENRUNG_FOUNDATION_TOKEN_CMD:-}" ]; then
+    raw="$(bash -c "$OPENRUNG_FOUNDATION_TOKEN_CMD")" || die "OPENRUNG_FOUNDATION_TOKEN_CMD failed"
+  elif [ -n "${OPENRUNG_FOUNDATION_TOKEN:-}" ]; then
+    raw="$OPENRUNG_FOUNDATION_TOKEN"
+  else
+    die "no token source: set OPENRUNG_FOUNDATION_TOKEN_CMD (e.g. 'pass show openrung/foundation-token' or an 'aws secretsmanager get-secret-value ...' invocation) or OPENRUNG_FOUNDATION_TOKEN"
+  fi
+  raw="${raw%%$'\n'*}"
+  [ -n "$raw" ] || die "token source produced an empty token"
+  # The token is written into a KEY=VALUE env file: whitespace or control
+  # characters would corrupt it (or inject extra variables), so refuse them.
+  [[ "$raw" =~ ^[[:graph:]]+$ ]] || die "token contains whitespace or control characters; refusing to write it to an env file"
+  printf '%s' "$raw"
+}
+
+# --- SSH host identity ------------------------------------------------------
+
+# Upgrade first contact from trust-on-first-use to verified: Lightsail publishes
+# each instance's SSH host keys over the (TLS, SigV4-authenticated) AWS API, so
+# pin them into known_hosts before the first connection that will carry the
+# token. Best-effort — a non-Lightsail host or an instance outside
+# OPENRUNG_REGION falls back to accept-new, loudly.
+pin_host_key() { # host [instance-name] [attempts]
+  local host="$1" name="${2:-}" attempts="${3:-1}" keys="" i=0
+  ssh-keygen -F "$host" >/dev/null 2>&1 && return 0
+
+  if [ -z "$name" ]; then
+    name="$(aws lightsail get-instances --region "$REGION" \
+      --query "instances[?publicIpAddress=='${host}'].name | [0]" --output text 2>/dev/null)" || name=""
+    [ "$name" = "None" ] && name=""
+  fi
+  if [ -n "$name" ] && [[ "$name" =~ $NAME_RE ]]; then
+    while [ "$i" -lt "$attempts" ]; do
+      keys="$(aws lightsail get-instance-access-details --instance-name "$name" --region "$REGION" \
+        --query 'accessDetails.hostKeys[].[algorithm,publicKey]' --output text 2>/dev/null)" || keys=""
+      [ -n "$keys" ] && [ "$keys" != "None" ] && break
+      keys=""
+      i=$((i + 1)); [ "$i" -lt "$attempts" ] && sleep 10
+    done
+  fi
+  if [ -z "$keys" ]; then
+    warn "${host}: no Lightsail-published host key (non-Lightsail host, or not in ${REGION}); first contact is trust-on-first-use"
+    return 0
+  fi
+
+  mkdir -p "$HOME/.ssh"
+  [ -f "$HOME/.ssh/known_hosts" ] || { touch "$HOME/.ssh/known_hosts"; chmod 600 "$HOME/.ssh/known_hosts"; }
+  local algo key
+  while read -r algo key; do
+    [ -n "$algo" ] && [ -n "$key" ] || continue
+    assert_matches "$algo" '^[A-Za-z0-9@.-]+$' "host-key algorithm"
+    assert_matches "$key" '^[A-Za-z0-9+/=]+$' "host-key material"
+    printf '%s %s %s\n' "$host" "$algo" "$key" >> "$HOME/.ssh/known_hosts"
+  done <<< "$keys"
+  log "pinned ${host}'s SSH host key from the Lightsail API"
+}
+
+# --- host inspection --------------------------------------------------------
+
+# Echo whichever relay container name is present on the host, preferring the
+# canonical one. Empty when the host runs neither.
+detect_container() {
+  local found
+  found="$(ssh_run "$1" "for c in ${CONTAINER} ${LEGACY_CONTAINER}; do
+    if sudo docker inspect \"\$c\" >/dev/null 2>&1; then echo \"\$c\"; exit 0; fi
+  done")"
+  assert_one_of "$found" "container name" "$CONTAINER" "$LEGACY_CONTAINER"
+  printf '%s' "$found"
+}
+
+# Echo whichever env file exists, preferring the canonical path. Empty when neither.
+detect_env_file() {
+  local found
+  found="$(ssh_run "$1" "for f in ${ENV_FILE} ${LEGACY_ENV_FILE}; do
+    if sudo test -f \"\$f\"; then echo \"\$f\"; exit 0; fi
+  done")"
+  assert_one_of "$found" "env-file path" "$ENV_FILE" "$LEGACY_ENV_FILE"
+  printf '%s' "$found"
+}
+
+# Read one non-secret OPENRUNG_* value out of the running container. The filter
+# runs on the host, so secret-bearing env lines never transit the connection.
+container_env_value() {
+  local host="$1" container="$2" key="$3"
+  ssh_run "$host" "sudo docker inspect ${container} --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
+    | sed -n 's/^${key}=//p' | head -1"
+}
+
+# Confirm the env file carries the Foundation credential (presence only — the
+# value is never read back). Without this, `update` would happily roll and
+# "verify" a host that is not a Foundation relay at all.
+require_env_has_token() {
+  local host="$1" file="$2"
+  ssh_run "$host" "sudo grep -q '^OPENRUNG_FOUNDATION_TOKEN=' ${file}" \
+    || die "${host}: ${file} has no OPENRUNG_FOUNDATION_TOKEN; not a Foundation relay — run 'convert' first"
+}
+
+# --- mutation ---------------------------------------------------------------
+
+# Write the root-owned mode-0600 env file. The token arrives on stdin so it never
+# appears in argv on either side of the connection, and the write is atomic
+# (tmp + rename) so a dropped connection cannot leave a truncated credential file.
+install_env_file() { # host public_host label   (token from $TOKEN, target is $ENV_FILE)
+  { set +x; } 2>/dev/null
+  local host="$1" public_host="$2" label="$3"
+  {
+    printf 'OPENRUNG_BROKER_URL=%s\n' "$BROKER_URL"
+    printf 'OPENRUNG_PUBLIC_HOST=%s\n' "$public_host"
+    printf 'OPENRUNG_LISTEN_HOST=0.0.0.0\n'
+    printf 'OPENRUNG_LABEL=%s\n' "$label"
+    printf 'OPENRUNG_FOUNDATION_TOKEN=%s\n' "$TOKEN"
+  } | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" \
+      "sudo install -d -m 700 -o root -g root /etc/openrung \
+       && sudo sh -c 'umask 077 && cat > ${ENV_FILE}.tmp && mv -f ${ENV_FILE}.tmp ${ENV_FILE}'"
+}
+
+# A convert writes the canonical path; once the relay has verified, remove the
+# legacy volunteer.env so exactly one copy of the token remains on disk. (The
+# rollback container does not need the file: its env was baked in at create.)
+cleanup_legacy_env() {
+  local host="$1"
+  [ "$ENV_FILE" = "$LEGACY_ENV_FILE" ] && return 0   # operator pointed the canonical path at the legacy one
+  if ssh_run "$host" "sudo test -f ${LEGACY_ENV_FILE}"; then
+    ssh_run "$host" "sudo sh -c 'shred -u ${LEGACY_ENV_FILE} 2>/dev/null || rm -f ${LEGACY_ENV_FILE}'"
+    log "removed legacy ${LEGACY_ENV_FILE}; credentials now live only at ${ENV_FILE}"
+  fi
+}
+
+rollback_hint() {
+  local host="$1"
+  echo "  rollback: ssh ${SSH_USER}@${host} 'sudo docker rm -f ${CONTAINER}; sudo docker rename ${CONTAINER}-old ${CONTAINER} && sudo docker start ${CONTAINER}'" >&2
+}
+
+# Recreate the relay container against env_file. Keeps the previous container,
+# stopped, as <name>-old so a bad image can be rolled back in place.
+#
+# Container hardening mirrors lightsail-up.sh exactly: --cap-drop ALL with only
+# NET_BIND_SERVICE re-added (the binary binds 443 through a cap_net_bind_service
+# file capability), read-only rootfs, and deliberately NO --security-opt
+# no-new-privileges, which would disable that file capability and break the bind.
+recreate_container() {
+  local host="$1" env_file="$2" live="$3"
+  ssh_run "$host" "set -e
+    sudo docker pull ${IMAGE} >/dev/null
+    sudo docker rm -f ${CONTAINER}-old ${LEGACY_CONTAINER}-old >/dev/null 2>&1 || true
+    if [ -n '${live}' ]; then
+      sudo docker stop '${live}' >/dev/null
+      sudo docker rename '${live}' ${CONTAINER}-old
+    fi
+    sudo docker run -d --name ${CONTAINER} --restart unless-stopped \
+      --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
+      --env-file ${env_file} \
+      ${IMAGE} >/dev/null" \
+    || { rollback_hint "$host"; die "${host}: container recreate failed"; }
+}
+
+# A relay that presents the Foundation token forces node_class=foundation, and it
+# exits during startup if the broker attests any other class (cmd/relay refuses a
+# mismatched attestation; the broker 403s a foundation claim without the token).
+# So a container that is still running and has logged a registration IS the proof
+# the broker attested Foundation — no separate broker query needed. This holds
+# only because convert always writes the token and update asserts its presence.
+verify_foundation() {
+  local host="$1" i=0 line
+  while [ "$i" -lt 30 ]; do
+    if ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep -q 'registered relay'"; then
+      ssh_run "$host" "sudo docker ps --format '{{.Names}}' | grep -qx ${CONTAINER}" \
+        || { rollback_hint "$host"; die "${host}: container exited after registering; check: docker logs ${CONTAINER}"; }
+      line="$(ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep 'registered relay' | tail -1" | scrub | head -c 300)" || line=""
+      log "registered and running: ${line}"
+      return 0
+    fi
+    if ! ssh_run "$host" "sudo docker ps --format '{{.Names}}' | grep -qx ${CONTAINER}"; then
+      rollback_hint "$host"
+      die "${host}: container is not running; check: docker logs ${CONTAINER}"
+    fi
+    i=$((i + 1)); sleep 2
+  done
+  rollback_hint "$host"
+  die "${host}: no registration within 60s; check: docker logs ${CONTAINER}"
+}
+
+# --- commands ---------------------------------------------------------------
+
+convert_host() {
+  local host="$1" live public_host label
+  echo "==> convert ${host}"
+  live="$(detect_container "$host")"
+  [ -n "$live" ] || die "${host}: no relay container found; provision it first (lightsail-up.sh or 'create')"
+
+  # Reuse the identity the bootstrap helper already baked in, so a convert does
+  # not silently relabel or re-home an existing relay. Both values came from the
+  # host: validate before they are reused or displayed.
+  public_host="$(container_env_value "$host" "$live" OPENRUNG_PUBLIC_HOST)"
+  label="$(container_env_value "$host" "$live" OPENRUNG_LABEL)"
+  [ -n "$public_host" ] || die "${host}: could not read OPENRUNG_PUBLIC_HOST from ${live}"
+  [ -n "$label" ] || die "${host}: could not read OPENRUNG_LABEL from ${live}"
+  assert_matches "$public_host" "$HOST_RE" "OPENRUNG_PUBLIC_HOST"
+  assert_matches "$label" "$NAME_RE" "OPENRUNG_LABEL"
+
+  log "identity: label=${label} public_host=${public_host}"
+  install_env_file "$host" "$public_host" "$label"
+  log "wrote ${ENV_FILE} (root:root 0600)"
+  recreate_container "$host" "$ENV_FILE" "$live"
+  verify_foundation "$host"
+  cleanup_legacy_env "$host"
+}
+
+cmd_convert() {
+  [ "$#" -ge 1 ] || usage
+  require_https_broker
+  validate_config
+  TOKEN="$(read_token)"
+  local host
+  for host in "$@"; do
+    assert_matches "$host" "$HOST_RE" "host"
+    pin_host_key "$host"
+    convert_host "$host"
+  done
+}
+
+cmd_update() {
+  [ "$#" -ge 1 ] || usage
+  validate_config
+  # No token needed: the credentials already on each host are reused as-is.
+  # Fail-fast across the fleet: a broken image stops the roll at the first host
+  # instead of taking every relay down.
+  local host live env_file
+  for host in "$@"; do
+    assert_matches "$host" "$HOST_RE" "host"
+    echo "==> update ${host}"
+    pin_host_key "$host"
+    env_file="$(detect_env_file "$host")"
+    [ -n "$env_file" ] || die "${host}: no env file (${ENV_FILE} or ${LEGACY_ENV_FILE}); run 'convert' first"
+    require_env_has_token "$host" "$env_file"
+    live="$(detect_container "$host")"
+    log "reusing ${env_file}; image ${IMAGE}"
+    recreate_container "$host" "$env_file" "$live"
+    verify_foundation "$host"
+  done
+}
+
+cmd_create() {
+  require_https_broker
+  validate_config
+  TOKEN="$(read_token)"   # fail before provisioning, not after
+
+  # lightsail-up.sh refuses to run with token variables set (its own user-data
+  # guard), and stripping them here makes the guarantee structural: the
+  # provisioning child never holds the credential, so no bug in it could ever
+  # embed the token in user-data.
+  local out ip name
+  out="$(env -u OPENRUNG_FOUNDATION_TOKEN -u OPENRUNG_FOUNDATION_TOKEN_CMD \
+             -u OPENRUNG_VOLUNTEER_TOKEN -u OPENRUNG_NODE_CLASS \
+             "${HERE}/lightsail-up.sh" "$@" | tee /dev/stderr)"
+  # lightsail-up.sh's machine-readable handoff line.
+  name="$(printf '%s\n' "$out" | sed -n 's/^OPENRUNG_RELAY name=\([^ ]*\) ip=.*$/\1/p' | head -1)"
+  ip="$(printf '%s\n' "$out" | sed -n 's/^OPENRUNG_RELAY .*ip=\(.*\)$/\1/p' | head -1)"
+  [ -n "$ip" ] && [ -n "$name" ] || die "could not parse the 'OPENRUNG_RELAY name=... ip=...' line from lightsail-up.sh"
+  assert_matches "$name" "$NAME_RE" "instance name"
+  assert_matches "$ip" "$HOST_RE" "instance ip"
+
+  # Pin before the first connection that will carry the token. Host keys are
+  # published shortly after boot; retry while the instance settles.
+  pin_host_key "$ip" "$name" 6
+
+  echo "==> waiting for ${name} (${ip}) to finish bootstrapping"
+  local i=0
+  until ssh_run "$ip" "sudo docker inspect ${CONTAINER} >/dev/null 2>&1" 2>/dev/null; do
+    i=$((i + 1))
+    [ "$i" -lt 60 ] || die "${ip}: relay container did not appear within 5 minutes; check /var/log/openrung-init.log"
+    sleep 5
+  done
+  convert_host "$ip"
+}
+
+[ "$#" -ge 1 ] || usage
+subcommand="$1"; shift
+case "$subcommand" in
+  create)  cmd_create "$@" ;;
+  convert) cmd_convert "$@" ;;
+  update)  cmd_update "$@" ;;
+  *)       usage ;;
+esac

--- a/deploy/relay/foundation-up.sh
+++ b/deploy/relay/foundation-up.sh
@@ -5,6 +5,7 @@
 #   deploy/relay/foundation-up.sh create [name]        # new Lightsail host, then install credentials
 #   deploy/relay/foundation-up.sh convert <host>...    # install credentials on an existing host
 #   deploy/relay/foundation-up.sh update  <host>...    # pull the image and recreate, reusing credentials
+#   deploy/relay/foundation-up.sh rollback <host>...   # restore an exact interrupted roll
 #
 # This wraps — and never replaces — lightsail-up.sh. That helper deliberately
 # refuses registration tokens because Lightsail retains user-data, so a Foundation
@@ -35,6 +36,18 @@ set -euo pipefail
 # `bash -x`, so the token can never appear in trace output.
 { set +x; } 2>/dev/null
 
+# Keep caller-supplied token sources in this shell, but remove their export
+# attribute before the first command substitution or child process. This lets
+# convert inspect every host before invoking a secret-manager command without
+# leaking a direct token (or a token-bearing command) to ssh, aws, dirname, or
+# any other child.
+export -n OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD 2>/dev/null || true
+
+# TOKEN is a generic name the caller may already have exported; recreate it as
+# an unexported shell variable for the same reason.
+unset TOKEN
+TOKEN=""   # set once per run; never leaves this process except over SSH stdin
+
 IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
 BROKER_URL="${OPENRUNG_BROKER_URL:-https://broker-origin.openrung.org}"
 ENV_FILE="${OPENRUNG_ENV_FILE:-/etc/openrung/relay.env}"
@@ -43,7 +56,10 @@ SSH_USER="${OPENRUNG_SSH_USER:-ubuntu}"
 REGION="${OPENRUNG_REGION:-ap-northeast-1}"
 
 CONTAINER="openrung-relay"
-LEGACY_CONTAINER="openrung-volunteer"      # pre-rename fleets still run this name
+OLD_CONTAINER="${CONTAINER}-old"
+NEW_CONTAINER="${CONTAINER}-new"
+LEGACY_CONTAINER="openrung-volunteer"
+LEGACY_OLD_CONTAINER="${LEGACY_CONTAINER}-old"
 LEGACY_ENV_FILE="/etc/openrung/volunteer.env"
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -53,13 +69,6 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # implicitly. UserKnownHostsFile pins ssh to the same file pin_host_key writes,
 # so the check and the connection cannot diverge on a per-host ssh_config.
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o ConnectTimeout=10 -o BatchMode=yes -i "$SSH_KEY")
-
-# TOKEN is a generic name the caller may already have exported; a plain
-# assignment would inherit that export attribute and hand the bearer to every
-# child process (ssh, aws, lightsail-up.sh). Unset first so the variable is
-# recreated unexported.
-unset TOKEN
-TOKEN=""   # set once per run by the commands that need it; never leaves this process except over SSH stdin
 
 die()  { echo "error: $*" >&2; exit 1; }
 log()  { echo "  $*"; }
@@ -71,9 +80,15 @@ usage:
   deploy/relay/foundation-up.sh create [name]        # new Lightsail host, then install credentials
   deploy/relay/foundation-up.sh convert <host>...    # install credentials on an existing host
   deploy/relay/foundation-up.sh update  <host>...    # pull the image and recreate, reusing credentials
+  deploy/relay/foundation-up.sh rollback <host>...   # restore an exact interrupted roll
 
 The Foundation token is read from OPENRUNG_FOUNDATION_TOKEN_CMD (preferred) or
-OPENRUNG_FOUNDATION_TOKEN — never from argv. `update` needs no token.
+OPENRUNG_FOUNDATION_TOKEN — never from argv. `update` and `rollback` need no token.
+
+Automation accepts one steady state only: a running `openrung-relay`, with no
+legacy container/env, `-old` backup, `-new` candidate, or staged `.tmp` file.
+Unsupported states are inspected but never changed; the script prints manual
+migration or recovery instructions instead.
 EOF
   exit 2
 }
@@ -105,16 +120,6 @@ assert_matches() { # value regex what
   [[ "$val" =~ $re ]] || die "unexpected ${what}: '$(printf '%s' "$val" | scrub | head -c 100)'"
 }
 
-# Exactly one of the known values (or empty): remote detection output must
-# never become a free-form string in a later privileged command.
-assert_one_of() { # value what allowed...
-  local val="$1" what="$2"; shift 2
-  [ -z "$val" ] && return 0
-  local allowed
-  for allowed in "$@"; do [ "$val" = "$allowed" ] && return 0; done
-  die "host returned an unexpected ${what}: '$(printf '%s' "$val" | scrub | head -c 100)'"
-}
-
 # The relay binary refuses to send the Foundation bearer over cleartext, so a
 # non-HTTPS broker URL would fail at runtime as a confusing crash loop. Fail here
 # instead, with the reason. The URL is also written into the env file, so reject
@@ -132,6 +137,8 @@ require_https_broker() {
 validate_config() {
   assert_matches "$ENV_FILE" '^/[A-Za-z0-9/._-]+$' "OPENRUNG_ENV_FILE"
   assert_matches "$IMAGE" '^[A-Za-z0-9][A-Za-z0-9:/@._-]*$' "OPENRUNG_IMAGE"
+  [ "$ENV_FILE" != "$LEGACY_ENV_FILE" ] \
+    || die "OPENRUNG_ENV_FILE may not use the legacy path ${LEGACY_ENV_FILE}; migrate it to a canonical path first"
 }
 
 # --- credentials ------------------------------------------------------------
@@ -162,7 +169,7 @@ read_token() {
 # (ssh, aws, ssh-keygen) never inherit the credential — the same rationale as
 # create's env -u for lightsail-up.sh.
 load_token() {
-  TOKEN="$(read_token)"
+  TOKEN="$(read_token)" || return
   unset OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD
 }
 
@@ -201,40 +208,190 @@ pin_host_key() { # host [instance-name] [attempts]
     die "${host}: cannot verify the SSH host key out-of-band (no Lightsail-published key: non-Lightsail host, or not in ${REGION}; IPv6/DNS targets are looked up by IPv4 address only). No mode contacts an unverified host implicitly. Verify the key via your provider's console, add it to ~/.ssh/known_hosts, and re-run ('convert ${host}' if the instance is already provisioned) — or set OPENRUNG_ALLOW_TOFU=1 to accept the first-seen key explicitly."
   fi
 
-  mkdir -p "$HOME/.ssh"
-  [ -f "$HOME/.ssh/known_hosts" ] || { touch "$HOME/.ssh/known_hosts"; chmod 600 "$HOME/.ssh/known_hosts"; }
-  local algo key
+  mkdir -p "$HOME/.ssh" \
+    || die "${host}: could not create $HOME/.ssh; host key was not pinned"
+  if [ ! -f "$HOME/.ssh/known_hosts" ]; then
+    touch "$HOME/.ssh/known_hosts" \
+      || die "${host}: could not create $HOME/.ssh/known_hosts; host key was not pinned"
+    chmod 600 "$HOME/.ssh/known_hosts" \
+      || die "${host}: could not protect $HOME/.ssh/known_hosts; host key was not pinned"
+  fi
+  local algo key added=0
   while read -r algo key; do
     [ -n "$algo" ] && [ -n "$key" ] || continue
     assert_matches "$algo" '^[A-Za-z0-9@.-]+$' "host-key algorithm"
     assert_matches "$key" '^[A-Za-z0-9+/=]+$' "host-key material"
-    printf '%s %s %s\n' "$host" "$algo" "$key" >> "$HOME/.ssh/known_hosts"
+    printf '%s %s %s\n' "$host" "$algo" "$key" >> "$HOME/.ssh/known_hosts" \
+      || die "${host}: could not write $HOME/.ssh/known_hosts; host key was not pinned"
+    added=$((added + 1))
   done <<< "$keys"
+  [ "$added" -gt 0 ] \
+    || die "${host}: Lightsail returned no valid SSH host keys; host key was not pinned"
   log "pinned ${host}'s SSH host key from the Lightsail API"
 }
 
 # --- host inspection --------------------------------------------------------
 
-# Echo whichever relay container name is present on the host, preferring the
-# canonical one. Empty when the host runs neither. Note: matches stopped
-# containers too — callers that need a live one must check state themselves.
-detect_container() {
-  local found
-  found="$(ssh_run "$1" "for c in ${CONTAINER} ${LEGACY_CONTAINER}; do
-    if sudo docker inspect \"\$c\" >/dev/null 2>&1; then echo \"\$c\"; exit 0; fi
-  done")"
-  assert_one_of "$found" "container name" "$CONTAINER" "$LEGACY_CONTAINER"
-  printf '%s' "$found"
+# One read-only snapshot replaces the old preference-based detection, which
+# could hide a legacy container behind a canonical one. The eleven fields are:
+#   live live_running old old_running new legacy legacy_old env legacy_env tmp unexpected
+# Every field is an allowlisted bit before it influences a decision.
+inspect_host_state() {
+  local host="$1" state
+  state="$(ssh_run "$host" "
+    live=0; live_running=0; old=0; old_running=0; new=0
+    legacy=0; legacy_old=0; env=0; legacy_env=0; tmp=0; unexpected=0
+    names=\"\$(sudo docker ps -a --format '{{.Names}}')\" || exit 1
+    for c in \$names; do
+      case \"\$c\" in
+        ${CONTAINER}) live=1 ;;
+        ${OLD_CONTAINER}) old=1 ;;
+        ${NEW_CONTAINER}) new=1 ;;
+        ${LEGACY_CONTAINER}) legacy=1 ;;
+        ${LEGACY_OLD_CONTAINER}) legacy_old=1 ;;
+        ${CONTAINER}-*|${CONTAINER}_*|${CONTAINER}.*|${LEGACY_CONTAINER}-*|${LEGACY_CONTAINER}_*|${LEGACY_CONTAINER}.*) unexpected=1 ;;
+      esac
+    done
+    if [ \"\$live\" = 1 ]; then
+      [ \"\$(sudo docker inspect -f '{{.State.Running}}' ${CONTAINER} 2>/dev/null)\" = true ] && live_running=1
+    fi
+    if [ \"\$old\" = 1 ]; then
+      [ \"\$(sudo docker inspect -f '{{.State.Running}}' ${OLD_CONTAINER} 2>/dev/null)\" = true ] && old_running=1
+    fi
+    sudo test -f ${ENV_FILE} && env=1
+    if sudo test -e ${LEGACY_ENV_FILE} || sudo test -L ${LEGACY_ENV_FILE}; then legacy_env=1; fi
+    if sudo test -e ${ENV_FILE}.tmp || sudo test -L ${ENV_FILE}.tmp; then tmp=1; fi
+    printf '%s %s %s %s %s %s %s %s %s %s %s\\n' \
+      \"\$live\" \"\$live_running\" \"\$old\" \"\$old_running\" \"\$new\" \
+      \"\$legacy\" \"\$legacy_old\" \"\$env\" \"\$legacy_env\" \"\$tmp\" \"\$unexpected\"
+  ")" || die "${host}: could not inspect relay state; no remote changes were made"
+  [[ "$state" =~ ^[01](\ [01]){10}$ ]] \
+    || die "${host}: host returned an invalid state snapshot: '$(printf '%s' "$state" | scrub | head -c 100)'"
+  printf '%s' "$state"
 }
 
-# Echo whichever env file exists, preferring the canonical path. Empty when neither.
-detect_env_file() {
-  local found
-  found="$(ssh_run "$1" "for f in ${ENV_FILE} ${LEGACY_ENV_FILE}; do
-    if sudo test -f \"\$f\"; then echo \"\$f\"; exit 0; fi
-  done")"
-  assert_one_of "$found" "env-file path" "$ENV_FILE" "$LEGACY_ENV_FILE"
-  printf '%s' "$found"
+print_ssh_command() {
+  local host="$1" arg
+  printf '  connect:' >&2
+  for arg in ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}"; do
+    printf ' %q' "$arg" >&2
+  done
+  printf '\n' >&2
+}
+
+print_manual_state_help() { # host reason
+  local host="$1" reason="$2"
+  echo "error: ${host}: ${reason}" >&2
+  echo "  no relay container, env-file, image, backup, or candidate changes were made on this host" >&2
+  print_ssh_command "$host"
+  cat >&2 <<EOF
+  inspect:
+    sudo docker ps -a --filter name=openrung-relay --filter name=openrung-volunteer
+    sudo ls -l ${ENV_FILE} ${ENV_FILE}.tmp ${LEGACY_ENV_FILE} 2>/dev/null
+
+  automation requires exactly one running ${CONTAINER}, plus no ${OLD_CONTAINER},
+  ${NEW_CONTAINER}, ${LEGACY_CONTAINER}, ${LEGACY_OLD_CONTAINER}, legacy env, .tmp,
+  or unrecognized ${CONTAINER}-* / ${LEGACY_CONTAINER}-* container.
+
+  manual legacy migration (only after identifying the healthy container/config):
+    sudo docker stop ${LEGACY_CONTAINER}
+    sudo docker rename ${LEGACY_CONTAINER} ${CONTAINER}
+    sudo docker start ${CONTAINER}
+    sudo install -m 0600 ${LEGACY_ENV_FILE} ${ENV_FILE}   # only if the legacy file is authoritative
+    # remove ${LEGACY_ENV_FILE} only after the canonical relay is verified
+
+  interrupted canonical rolls (${OLD_CONTAINER} with optional ${NEW_CONTAINER},
+  and no live/legacy artifacts) may be restored with:
+    deploy/relay/foundation-up.sh rollback ${host}
+EOF
+}
+
+parse_state() { # state; populates STATE_* globals for the caller
+  read -r STATE_LIVE STATE_LIVE_RUNNING STATE_OLD STATE_OLD_RUNNING STATE_NEW \
+    STATE_LEGACY STATE_LEGACY_OLD STATE_ENV STATE_LEGACY_ENV STATE_TMP \
+    STATE_UNEXPECTED <<< "$1"
+}
+
+# convert/update deliberately accept one entry state only. Any backup, candidate,
+# legacy artifact, stopped live container, or staged tmp is an operator decision,
+# not something automation guesses how to reconcile.
+require_clean_state() { # host mode state
+  local host="$1" mode="$2" state="$3"
+  parse_state "$state"
+
+  if [ "$STATE_LEGACY" = 1 ] || [ "$STATE_LEGACY_OLD" = 1 ] || [ "$STATE_LEGACY_ENV" = 1 ]; then
+    print_manual_state_help "$host" "legacy relay artifacts detected; manual migration required"
+    return 1
+  fi
+  if [ "$STATE_UNEXPECTED" = 1 ]; then
+    print_manual_state_help "$host" "unrecognized OpenRung relay container detected; manual migration required"
+    return 1
+  fi
+  if [ "$STATE_OLD" = 1 ] || [ "$STATE_NEW" = 1 ] || [ "$STATE_TMP" = 1 ]; then
+    print_manual_state_help "$host" "backup, candidate, or staged env detected; state is not a clean automation entry point"
+    return 1
+  fi
+  if [ "$STATE_LIVE" != 1 ]; then
+    print_manual_state_help "$host" "canonical container ${CONTAINER} is absent"
+    return 1
+  fi
+  if [ "$STATE_LIVE_RUNNING" != 1 ]; then
+    print_manual_state_help "$host" "canonical container ${CONTAINER} is not running"
+    return 1
+  fi
+  if [ "$STATE_OLD_RUNNING" != 0 ]; then
+    print_manual_state_help "$host" "inconsistent backup state returned by host"
+    return 1
+  fi
+  if [ "$mode" = update ] && [ "$STATE_ENV" != 1 ]; then
+    print_manual_state_help "$host" "canonical env file ${ENV_FILE} is absent; run convert after reconciling the host"
+    return 1
+  fi
+  return 0
+}
+
+# rollback supports only the two exact interruption states this script creates:
+# stopped old alone (candidate failed to start), or stopped old + candidate
+# (candidate failed verification/commit). Everything else is ambiguous.
+require_rollback_state() { # host state
+  local host="$1" state="$2"
+  parse_state "$state"
+  if [ "$STATE_LEGACY" = 1 ] || [ "$STATE_LEGACY_OLD" = 1 ] || [ "$STATE_LEGACY_ENV" = 1 ] || [ "$STATE_TMP" = 1 ]; then
+    print_manual_state_help "$host" "rollback refused because legacy or staged artifacts are present"
+    return 1
+  fi
+  if [ "$STATE_UNEXPECTED" = 1 ]; then
+    print_manual_state_help "$host" "rollback refused because an unrecognized OpenRung relay container is present"
+    return 1
+  fi
+  if [ "$STATE_LIVE" != 0 ] || [ "$STATE_LIVE_RUNNING" != 0 ] \
+     || [ "$STATE_OLD" != 1 ] || [ "$STATE_OLD_RUNNING" != 0 ]; then
+    print_manual_state_help "$host" "rollback requires no live container and exactly one stopped ${OLD_CONTAINER}"
+    return 1
+  fi
+  return 0
+}
+
+preflight_host() { # host mode
+  local host="$1" mode="$2" state
+  state="$(inspect_host_state "$host")" || return
+  if [ "$mode" = rollback ]; then
+    require_rollback_state "$host" "$state" || return
+  else
+    require_clean_state "$host" "$mode" "$state" || return
+    if [ "$mode" = update ]; then require_env_has_token "$host" "$ENV_FILE" || return; fi
+  fi
+  return 0
+}
+
+preflight_fleet() { # mode host...
+  local mode="$1" host; shift
+  for host in "$@"; do
+    assert_matches "$host" "$HOST_RE" "host" || return
+    pin_host_key "$host" || return
+    preflight_host "$host" "$mode" || return
+  done
+  return 0
 }
 
 # Confirm the env file carries a usable Foundation credential (presence only —
@@ -268,14 +425,13 @@ require_env_has_token() {
 #     permanently override future images that relocate those paths.
 PRESERVE_DROP='/^OPENRUNG_(BROKER_URL|FOUNDATION_TOKEN|VOLUNTEER_TOKEN|NODE_CLASS|XRAY_PATH|CONFIG_OUT)=/d'
 
-# Stage the preserved settings into ENV_FILE.tmp on the host. Sources: the
-# legacy env file, then the canonical one (both when present — docker's
-# last-occurrence-wins semantics make the canonical file take precedence per
-# key while legacy-only keys still survive), else the running container's
-# OPENRUNG_* environment. Only OPENRUNG_* lines are kept. The filter runs on
-# the host and the result stays there: no secret and no preserved value ever
-# transits the connection or a command line. Fails when no OPENRUNG_PUBLIC_HOST
-# survives, since direct mode cannot run without one. Deliberately no
+# Stage the preserved settings into ENV_FILE.tmp on the host. The only accepted
+# sources are the canonical env file, when present, or the canonical running
+# container. Legacy files are rejected during preflight and are never merged or
+# removed automatically. Only OPENRUNG_* lines are kept. The filter runs on the
+# host and the result stays there: no secret and no preserved value ever transits
+# the connection or a command line. Fails when no OPENRUNG_PUBLIC_HOST survives,
+# since direct mode cannot run without one. Deliberately no
 # OPENRUNG_LISTEN_HOST default is added: the binary's own default (::,
 # dual-stack) is correct, and pinning 0.0.0.0 here would silently cut IPv6 on
 # hosts that relied on the default.
@@ -283,9 +439,7 @@ stage_preserved_env() { # host container
   local host="$1" container="$2"
   ssh_run "$host" "sudo sh -c \"set -e; umask 077 \
     && { test -d ${ENV_FILE%/*} || install -d -m 700 -o root -g root ${ENV_FILE%/*}; } \
-    && { if test -f ${ENV_FILE} || test -f ${LEGACY_ENV_FILE}; then \
-           if test -f ${LEGACY_ENV_FILE}; then cat ${LEGACY_ENV_FILE}; fi; \
-           if test -f ${ENV_FILE}; then cat ${ENV_FILE}; fi; \
+    && { if test -f ${ENV_FILE}; then cat ${ENV_FILE}; \
          else docker inspect ${container} --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null || true; fi; } \
        | sed -n '/^OPENRUNG_[A-Za-z0-9_]*=/p' | sed -E '${PRESERVE_DROP}' > ${ENV_FILE}.tmp \
     && grep -q '^OPENRUNG_PUBLIC_HOST=..*' ${ENV_FILE}.tmp \
@@ -308,75 +462,92 @@ install_env_file() { # host   (managed values from $TOKEN / $BROKER_URL; preserv
       "sudo sh -c 'trap \"rm -f ${ENV_FILE}.tmp\" EXIT; set -e; umask 077; cat >> ${ENV_FILE}.tmp; mv -f ${ENV_FILE}.tmp ${ENV_FILE}'"
 }
 
-# A convert writes the canonical path with everything preserved into it; once
-# the relay has verified, remove the legacy volunteer.env so exactly one copy
-# of the token remains on disk. (The rollback container does not need the file:
-# its env was baked in at create.) Post-success hygiene: an ssh failure here
-# warns rather than fails the conversion, but never silently — and it is
-# distinguished from "no legacy file" by an explicit marker, not an exit code.
-cleanup_legacy_env() {
-  local host="$1" present
-  [ "$ENV_FILE" = "$LEGACY_ENV_FILE" ] && return 0   # operator pointed the canonical path at the legacy one
-  present="$(ssh_run "$host" "sudo sh -c 'rm -f ${ENV_FILE}.tmp; if test -f ${LEGACY_ENV_FILE}; then echo yes; else echo no; fi'")" \
-    || { warn "${host}: could not check for a legacy env file; re-run convert or remove ${LEGACY_ENV_FILE} manually"; return 0; }
-  assert_one_of "$present" "legacy-check result" yes no
-  if [ "$present" = yes ]; then
-    ssh_run "$host" "sudo sh -c 'shred -u ${LEGACY_ENV_FILE} 2>/dev/null || rm -f ${LEGACY_ENV_FILE}'" \
-      || { warn "${host}: could not remove ${LEGACY_ENV_FILE}; remove it manually"; return 0; }
-    log "removed legacy ${LEGACY_ENV_FILE}; credentials now live only at ${ENV_FILE}"
-  fi
+print_recovery_help() {
+  local host="$1" reason="$2"
+  echo "error: ${host}: ${reason}" >&2
+  echo "  the previous relay remains as stopped ${OLD_CONTAINER}; automation will refuse further convert/update runs until this exact state is resolved" >&2
+  print_ssh_command "$host"
+  echo "  restore with: deploy/relay/foundation-up.sh rollback ${host}" >&2
 }
 
-rollback_hint() {
-  local host="$1"
-  echo "  rollback: ssh ${SSH_USER}@${host} 'sudo docker rm -f ${CONTAINER}; sudo docker rename ${CONTAINER}-old ${CONTAINER} && sudo docker start ${CONTAINER}'" >&2
+print_interrupted_state_help() {
+  local host="$1" reason="$2"
+  echo "error: ${host}: ${reason}" >&2
+  echo "  the commit guard made no further container changes; an earlier roll step may already have created ${OLD_CONTAINER} or ${NEW_CONTAINER}" >&2
+  print_ssh_command "$host"
+  echo "  inspect: sudo docker ps -a --filter name=openrung-relay" >&2
+  echo "  use 'deploy/relay/foundation-up.sh rollback ${host}' only if inspection shows no live container and one stopped ${OLD_CONTAINER}, with at most ${NEW_CONTAINER}" >&2
 }
 
-# Recreate the relay container against env_file, in three separately-reported
-# stages so a failure names exactly what state the host is in. The previous
-# container is kept, stopped, as <name>-old for in-place rollback — and the
-# rollback hint is only printed once the swap has actually happened, because
-# before that point "rm -f openrung-relay + rename -old" would destroy the
-# healthy live container. The swap stage also refuses to discard an existing
-# -old backup unless the current container has itself verified — registered
-# and stayed up (a failed rollout can be running yet never register): a backup
-# only exists because a previous roll happened, and deleting the last
-# known-good relay for an unproven replacement is never right.
-#
-# Container hardening mirrors lightsail-up.sh exactly: --cap-drop ALL with only
-# NET_BIND_SERVICE re-added (the binary binds 443 through a cap_net_bind_service
-# file capability), read-only rootfs, and deliberately NO --security-opt
-# no-new-privileges, which would disable that file capability and break the bind.
-recreate_container() {
-  local host="$1" env_file="$2" live="$3"
-  ssh_run "$host" "sudo docker pull ${IMAGE} >/dev/null" \
-    || die "${host}: image pull failed; the live container was not touched"
-  local rc=0
+# Pull only after an exact clean-state guard. This is the first remote mutation;
+# all fleet targets have already passed the read-only preflight before it runs.
+prepare_image() {
+  local host="$1" rc=0
   ssh_run "$host" "set -e
-    if sudo docker inspect ${CONTAINER}-old >/dev/null 2>&1 || sudo docker inspect ${LEGACY_CONTAINER}-old >/dev/null 2>&1; then
-      if [ \"\$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' '${live}' 2>/dev/null)\" != 'true 0' ] \
-         || ! sudo docker logs '${live}' 2>&1 | grep -q 'registered relay'; then
-        echo 'refusing to discard the existing backup: ${live} has not registered and stayed up (previous roll failed?)' >&2
-        exit 42
-      fi
-    fi
-    sudo docker rm -f ${CONTAINER}-old ${LEGACY_CONTAINER}-old >/dev/null 2>&1 || true
-    sudo docker stop '${live}' >/dev/null
-    sudo docker rename '${live}' ${CONTAINER}-old" || rc=$?
+    names=\"\$(sudo docker ps -a --format '{{.Names}}')\" || exit 42
+    live_seen=0
+    for c in \$names; do
+      case \"\$c\" in
+        ${CONTAINER}) live_seen=1 ;;
+        ${OLD_CONTAINER}|${NEW_CONTAINER}|${LEGACY_CONTAINER}|${LEGACY_OLD_CONTAINER}|${CONTAINER}-*|${CONTAINER}_*|${CONTAINER}.*|${LEGACY_CONTAINER}-*|${LEGACY_CONTAINER}_*|${LEGACY_CONTAINER}.*) exit 42 ;;
+      esac
+    done
+    [ \"\$live_seen\" = 1 ] || exit 42
+    [ \"\$(sudo docker inspect -f '{{.State.Running}}' ${CONTAINER} 2>/dev/null)\" = true ] || exit 42
+    ! sudo test -e ${LEGACY_ENV_FILE} && ! sudo test -L ${LEGACY_ENV_FILE} || exit 42
+    ! sudo test -e ${ENV_FILE}.tmp && ! sudo test -L ${ENV_FILE}.tmp || exit 42
+    sudo docker pull ${IMAGE} >/dev/null" || rc=$?
   if [ "$rc" = 42 ]; then
-    # A backup exists and the current container never verified: the backup is
-    # the last known-good relay, so it must not be discarded for an unproven
-    # replacement. Rolling back to it (below) IS the correct recovery here.
-    rollback_hint "$host"
-    die "${host}: refusing to discard the existing backup: '${live}' has not registered and stayed up (previous roll failed?). Roll back to the backup (above) or remove the failed '${live}' container, then re-run"
+    print_manual_state_help "$host" "relay state changed after preflight; refusing before image pull"
+    return 1
   elif [ "$rc" != 0 ]; then
-    die "${host}: could not swap out '${live}'. Inspect with 'docker ps -a': if '${live}' was stopped but not renamed, restart it with: docker start '${live}'"
+    die "${host}: image pull failed; the live container and env file were not touched"
   fi
-  ssh_run "$host" "sudo docker run -d --name ${CONTAINER} --restart unless-stopped \
+}
+
+# After preparation, recheck that no competing state appeared, then move the
+# running live relay to the one exact backup name. Nothing is deleted here.
+begin_roll() {
+  local host="$1" rc=0
+  ssh_run "$host" "set -e
+    names=\"\$(sudo docker ps -a --format '{{.Names}}')\" || exit 42
+    live_seen=0
+    for c in \$names; do
+      case \"\$c\" in
+        ${CONTAINER}) live_seen=1 ;;
+        ${OLD_CONTAINER}|${NEW_CONTAINER}|${LEGACY_CONTAINER}|${LEGACY_OLD_CONTAINER}|${CONTAINER}-*|${CONTAINER}_*|${CONTAINER}.*|${LEGACY_CONTAINER}-*|${LEGACY_CONTAINER}_*|${LEGACY_CONTAINER}.*) exit 42 ;;
+      esac
+    done
+    [ \"\$live_seen\" = 1 ] || exit 42
+    [ \"\$(sudo docker inspect -f '{{.State.Running}}' ${CONTAINER} 2>/dev/null)\" = true ] || exit 42
+    ! sudo test -e ${LEGACY_ENV_FILE} && ! sudo test -L ${LEGACY_ENV_FILE} || exit 42
+    ! sudo test -e ${ENV_FILE}.tmp && ! sudo test -L ${ENV_FILE}.tmp || exit 42
+    sudo test -f ${ENV_FILE} || exit 42
+    sudo grep -q '^OPENRUNG_FOUNDATION_TOKEN=[^[:space:]]' ${ENV_FILE} || exit 42
+    ! sudo grep -q '^OPENRUNG_FOUNDATION_TOKEN=[[:space:]]*\$' ${ENV_FILE} || exit 42
+    sudo docker stop ${CONTAINER} >/dev/null
+    sudo docker rename ${CONTAINER} ${OLD_CONTAINER}" || rc=$?
+  if [ "$rc" = 42 ]; then
+    echo "error: ${host}: relay state changed after preparation; no container was stopped or removed" >&2
+    print_ssh_command "$host"
+    return 1
+  elif [ "$rc" != 0 ]; then
+    echo "error: ${host}: could not move the live relay to ${OLD_CONTAINER}; inspect whether ${CONTAINER} needs to be restarted" >&2
+    print_ssh_command "$host"
+    return 1
+  fi
+}
+
+# Container hardening mirrors lightsail-up.sh exactly. The uncommitted image
+# always runs under NEW_CONTAINER; it never occupies the live name until after
+# verification succeeds.
+run_candidate() { # host env_file
+  local host="$1" env_file="$2"
+  ssh_run "$host" "sudo docker run -d --name ${NEW_CONTAINER} --restart unless-stopped \
       --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
       --env-file ${env_file} \
       ${IMAGE} >/dev/null" \
-    || { rollback_hint "$host"; die "${host}: docker run failed"; }
+    || { print_recovery_help "$host" "candidate container failed to start"; return 1; }
 }
 
 # A relay that presents the Foundation token forces node_class=foundation, and it
@@ -387,43 +558,125 @@ recreate_container() {
 # the proof the broker attested Foundation. This holds only because convert
 # always writes a validated non-empty token and update asserts one is present.
 # An ssh failure during polling is treated as transient — never as evidence the
-# container died — so a network blip cannot trigger a false rollback hint.
-verify_foundation() {
-  local host="$1" i=0 line state ps_out
+# container died — so a network blip cannot trigger a false recovery diagnosis.
+verify_foundation() { # host container
+  local host="$1" container="$2" i=0 line state ps_out
   while [ "$i" -lt 30 ]; do
-    if ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep -q 'registered relay'"; then
-      if state="$(ssh_run "$host" "sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' ${CONTAINER} 2>/dev/null")"; then
+    if ssh_run "$host" "sudo docker logs ${container} 2>&1 | grep -q 'registered relay'"; then
+      if state="$(ssh_run "$host" "sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' ${container} 2>/dev/null")"; then
         if [ "$state" = "true 0" ]; then
-          line="$(ssh_run "$host" "sudo docker logs ${CONTAINER} 2>&1 | grep 'registered relay' | tail -1" | scrub | head -c 300)" || line=""
+          line="$(ssh_run "$host" "sudo docker logs ${container} 2>&1 | grep 'registered relay' | tail -1" | scrub | head -c 300)" || line=""
           log "registered and running: ${line}"
           return 0
         fi
-        rollback_hint "$host"
-        die "${host}: container registered but is not running cleanly (state: $(printf '%s' "$state" | scrub | head -c 40)); check: docker logs ${CONTAINER}"
+        print_recovery_help "$host" "candidate registered but is not running cleanly (state: $(printf '%s' "$state" | scrub | head -c 40))"
+        return 1
       fi
     elif ps_out="$(ssh_run "$host" "sudo docker ps --format '{{.Names}}'" 2>/dev/null)"; then
-      if ! printf '%s\n' "$ps_out" | grep -qx "${CONTAINER}"; then
-        rollback_hint "$host"
-        die "${host}: container is not running; check: docker logs ${CONTAINER}"
+      if ! printf '%s\n' "$ps_out" | grep -qx "${container}"; then
+        print_recovery_help "$host" "candidate container is not running"
+        return 1
       fi
     fi
     i=$((i + 1)); sleep 2
   done
-  rollback_hint "$host"
-  die "${host}: no registration within 60s; check: docker logs ${CONTAINER}"
+  print_recovery_help "$host" "candidate did not register within 60s"
+  return 1
+}
+
+# Commit only the verified candidate: rename it to the live name, then remove
+# the stopped old container last. A cleanup failure leaves a visible live+old
+# state that every later automation run refuses to guess about.
+commit_candidate() {
+  local host="$1" rc=0
+  ssh_run "$host" "set -e
+    names=\"\$(sudo docker ps -a --format '{{.Names}}')\" || exit 42
+    old_seen=0; new_seen=0
+    for c in \$names; do
+      case \"\$c\" in
+        ${OLD_CONTAINER}) old_seen=1 ;;
+        ${NEW_CONTAINER}) new_seen=1 ;;
+        ${CONTAINER}|${LEGACY_CONTAINER}|${LEGACY_OLD_CONTAINER}) exit 42 ;;
+        ${CONTAINER}-*|${CONTAINER}_*|${CONTAINER}.*|${LEGACY_CONTAINER}-*|${LEGACY_CONTAINER}_*|${LEGACY_CONTAINER}.*) exit 42 ;;
+      esac
+    done
+    [ \"\$old_seen\" = 1 ] && [ \"\$new_seen\" = 1 ] || exit 42
+    [ \"\$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' ${NEW_CONTAINER} 2>/dev/null)\" = 'true 0' ] || exit 42
+    sudo docker logs ${NEW_CONTAINER} 2>&1 | grep -q 'registered relay' || exit 42
+    [ \"\$(sudo docker inspect -f '{{.State.Running}}' ${OLD_CONTAINER} 2>/dev/null)\" = false ] || exit 42
+    ! sudo test -e ${LEGACY_ENV_FILE} && ! sudo test -L ${LEGACY_ENV_FILE} || exit 42
+    ! sudo test -e ${ENV_FILE}.tmp && ! sudo test -L ${ENV_FILE}.tmp || exit 42
+    sudo docker rename ${NEW_CONTAINER} ${CONTAINER}
+    sudo docker rm -f ${OLD_CONTAINER} >/dev/null || exit 43" || rc=$?
+  if [ "$rc" = 42 ]; then
+    print_interrupted_state_help "$host" "candidate state changed after verification; refusing to promote or delete the old relay"
+    return 1
+  elif [ "$rc" = 43 ]; then
+    echo "error: ${host}: candidate is live and verified, but ${OLD_CONTAINER} could not be removed; future automation will refuse until you inspect and remove that stale backup" >&2
+    print_ssh_command "$host"
+    return 1
+  elif [ "$rc" != 0 ]; then
+    echo "error: ${host}: candidate commit was interrupted; inspect ${CONTAINER}, ${NEW_CONTAINER}, and ${OLD_CONTAINER} before taking action" >&2
+    print_ssh_command "$host"
+    return 1
+  fi
+  log "committed verified candidate; removed ${OLD_CONTAINER}"
+}
+
+roll_host() { # host env_file
+  local host="$1" env_file="$2"
+  begin_roll "$host" || return
+  run_candidate "$host" "$env_file" || return
+  verify_foundation "$host" "$NEW_CONTAINER" || return
+  commit_candidate "$host" || return
+}
+
+rollback_host() {
+  local host="$1" rc=0
+  preflight_host "$host" rollback || return
+  ssh_run "$host" "set -e
+    names=\"\$(sudo docker ps -a --format '{{.Names}}')\" || exit 42
+    old_seen=0; new_seen=0
+    for c in \$names; do
+      case \"\$c\" in
+        ${OLD_CONTAINER}) old_seen=1 ;;
+        ${NEW_CONTAINER}) new_seen=1 ;;
+        ${CONTAINER}|${LEGACY_CONTAINER}|${LEGACY_OLD_CONTAINER}) exit 42 ;;
+        ${CONTAINER}-*|${CONTAINER}_*|${CONTAINER}.*|${LEGACY_CONTAINER}-*|${LEGACY_CONTAINER}_*|${LEGACY_CONTAINER}.*) exit 42 ;;
+      esac
+    done
+    [ \"\$old_seen\" = 1 ] || exit 42
+    [ \"\$(sudo docker inspect -f '{{.State.Running}}' ${OLD_CONTAINER} 2>/dev/null)\" = false ] || exit 42
+    ! sudo test -e ${LEGACY_ENV_FILE} && ! sudo test -L ${LEGACY_ENV_FILE} || exit 42
+    ! sudo test -e ${ENV_FILE}.tmp && ! sudo test -L ${ENV_FILE}.tmp || exit 42
+    if [ \"\$new_seen\" = 1 ]; then sudo docker rm -f ${NEW_CONTAINER} >/dev/null; fi
+    sudo docker rename ${OLD_CONTAINER} ${CONTAINER}
+    sudo docker start ${CONTAINER} >/dev/null" || rc=$?
+  if [ "$rc" = 42 ]; then
+    print_manual_state_help "$host" "rollback state changed after preflight; refusing without mutation"
+    return 1
+  elif [ "$rc" != 0 ]; then
+    echo "error: ${host}: rollback was interrupted; inspect the canonical container names manually" >&2
+    print_ssh_command "$host"
+    return 1
+  fi
+  log "restored ${OLD_CONTAINER} as running ${CONTAINER}"
 }
 
 # --- commands ---------------------------------------------------------------
 
 convert_host() {
-  local host="$1" live ident public_host label
+  local host="$1" ident public_host label
   echo "==> convert ${host}"
-  live="$(detect_container "$host")"
-  [ -n "$live" ] || die "${host}: no relay container found; provision it first (lightsail-up.sh or 'create')"
+  # Recheck immediately before this host's first mutation. Fleet-wide preflight
+  # already ensured a later host cannot begin in an unsupported state after an
+  # earlier host has changed.
+  preflight_host "$host" convert || return
+  prepare_image "$host" || return
 
   # Everything already configured on the host is preserved; only the broker URL
   # and the token are (re)written. The identity readback below is display-only.
-  stage_preserved_env "$host" "$live"
+  stage_preserved_env "$host" "$CONTAINER" || return
   # On readback failure, remove the staged tmp (it holds the preserved Reality
   # private key and no trap guards it until install_env_file's session).
   ident="$(ssh_run "$host" "sudo sed -n -e 's/^OPENRUNG_PUBLIC_HOST=/public_host=/p' -e 's/^OPENRUNG_LABEL=/label=/p' ${ENV_FILE}.tmp")" \
@@ -433,52 +686,60 @@ convert_host() {
   label="$(printf '%s\n' "$ident" | sed -n 's/^label=//p' | tail -1 | scrub | head -c 100)"
 
   log "identity: label=${label:--} public_host=${public_host} (preserved)"
-  install_env_file "$host"
+  install_env_file "$host" || return
   log "wrote ${ENV_FILE} (root:root 0600; existing settings preserved, broker URL + token updated)"
-  recreate_container "$host" "$ENV_FILE" "$live"
-  verify_foundation "$host"
-  cleanup_legacy_env "$host"
+  roll_host "$host" "$ENV_FILE" || return
 }
 
 cmd_convert() {
   [ "$#" -ge 1 ] || usage
-  require_https_broker
-  validate_config
-  load_token
+  require_https_broker || return
+  validate_config || return
+  export -n OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD 2>/dev/null || true
   local host
+  # Inspect the entire fleet before invoking the token source. The source
+  # variables were made non-exported at startup, so aws/ssh children cannot see
+  # them during this read-only phase.
+  preflight_fleet convert "$@" || return
+  load_token || return
   for host in "$@"; do
-    assert_matches "$host" "$HOST_RE" "host"
-    pin_host_key "$host"
-    convert_host "$host"
+    convert_host "$host" || return
   done
 }
 
 cmd_update() {
   [ "$#" -ge 1 ] || usage
-  validate_config
+  validate_config || return
+  unset OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD
   # No token needed: the credentials already on each host are reused as-is.
-  # Fail-fast across the fleet: a broken image stops the roll at the first host
-  # instead of taking every relay down.
-  local host live env_file
+  # Every target passes read-only preflight before the first image pull.
+  local host
+  preflight_fleet update "$@" || return
   for host in "$@"; do
-    assert_matches "$host" "$HOST_RE" "host"
     echo "==> update ${host}"
-    pin_host_key "$host"
-    env_file="$(detect_env_file "$host")"
-    [ -n "$env_file" ] || die "${host}: no env file (${ENV_FILE} or ${LEGACY_ENV_FILE}); run 'convert' first"
-    require_env_has_token "$host" "$env_file"
-    live="$(detect_container "$host")"
-    [ -n "$live" ] || die "${host}: no relay container found to update; run 'convert' (or 'create') first"
-    log "reusing ${env_file}; image ${IMAGE}"
-    recreate_container "$host" "$env_file" "$live"
-    verify_foundation "$host"
+    preflight_host "$host" update || return
+    prepare_image "$host" || return
+    log "reusing ${ENV_FILE}; image ${IMAGE}"
+    roll_host "$host" "$ENV_FILE" || return
+  done
+}
+
+cmd_rollback() {
+  [ "$#" -ge 1 ] || usage
+  validate_config || return
+  unset OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD
+  local host
+  preflight_fleet rollback "$@" || return
+  for host in "$@"; do
+    echo "==> rollback ${host}"
+    rollback_host "$host" || return
   done
 }
 
 cmd_create() {
-  require_https_broker
-  validate_config
-  load_token   # fail before provisioning, not after
+  require_https_broker || return
+  validate_config || return
+  load_token || return   # fail before provisioning, not after
 
   # lightsail-up.sh refuses to run with token variables set (its own user-data
   # guard), and stripping them here makes the guarantee structural: the
@@ -487,7 +748,8 @@ cmd_create() {
   local out ip name
   out="$(env -u OPENRUNG_FOUNDATION_TOKEN -u OPENRUNG_FOUNDATION_TOKEN_CMD \
              -u OPENRUNG_VOLUNTEER_TOKEN -u OPENRUNG_NODE_CLASS \
-             "${HERE}/lightsail-up.sh" "$@" | tee /dev/stderr)"
+             "${HERE}/lightsail-up.sh" "$@" | tee /dev/stderr)" \
+    || die "Lightsail provisioning failed; no credential installation was attempted"
   # lightsail-up.sh's machine-readable handoff line.
   name="$(printf '%s\n' "$out" | sed -n 's/^OPENRUNG_RELAY name=\([^ ]*\) ip=.*$/\1/p' | head -1)"
   ip="$(printf '%s\n' "$out" | sed -n 's/^OPENRUNG_RELAY .*ip=\(.*\)$/\1/p' | head -1)"
@@ -498,7 +760,7 @@ cmd_create() {
   # Pin before the first connection; the token transits this session, so an
   # unverifiable key is fatal (see pin_host_key). Host keys are published
   # shortly after boot; retry while the instance settles.
-  pin_host_key "$ip" "$name" 6
+  pin_host_key "$ip" "$name" 6 || return
 
   # The wait loop polls quietly, but a persistent ssh failure (wrong key pair,
   # host-key mismatch) must not masquerade as "still bootstrapping" — surface
@@ -511,14 +773,21 @@ cmd_create() {
     [ "$i" -lt 60 ] || die "${ip}: relay container did not appear within 5 minutes (last ssh error: $(printf '%s' "$waiterr" | scrub | tail -c 160)); check /var/log/openrung-init.log"
     sleep 5
   done
-  convert_host "$ip"
+  convert_host "$ip" || return
 }
 
-[ "$#" -ge 1 ] || usage
-subcommand="$1"; shift
-case "$subcommand" in
-  create)  cmd_create "$@" ;;
-  convert) cmd_convert "$@" ;;
-  update)  cmd_update "$@" ;;
-  *)       usage ;;
-esac
+main() {
+  [ "$#" -ge 1 ] || usage
+  local subcommand="$1"; shift
+  case "$subcommand" in
+    create)   cmd_create "$@" ;;
+    convert)  cmd_convert "$@" ;;
+    update)   cmd_update "$@" ;;
+    rollback) cmd_rollback "$@" ;;
+    *)        usage ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/deploy/relay/foundation-up_test.sh
+++ b/deploy/relay/foundation-up_test.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/foundation-up.sh"
+
+# shellcheck source=foundation-up.sh
+source "$SCRIPT"
+set +e
+
+reset_script_functions() {
+  # Function mocks are global in bash; re-source between test groups so one
+  # failure-injection setup cannot contaminate the next group.
+  source "$SCRIPT"
+  set +e
+}
+
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+MUTATION_LOG="${TEST_TMP}/mutations"
+OUTPUT="${TEST_TMP}/output"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); }
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+
+assert_eq() { # want got context
+  local want="$1" got="$2" context="$3"
+  if [ "$want" = "$got" ]; then pass; else fail "${context}: want '${want}', got '${got}'"; fi
+}
+
+assert_contains() { # haystack needle context
+  local haystack="$1" needle="$2" context="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then pass; else fail "${context}: missing '${needle}'"; fi
+}
+
+assert_before() { # haystack first second context
+  local haystack="$1" first="$2" second="$3" context="$4"
+  if [[ "$haystack" == *"$first"*"$second"* ]]; then
+    pass
+  else
+    fail "${context}: '${first}' does not precede '${second}'"
+  fi
+}
+
+state_from_mask() {
+  local mask="$1" i out=""
+  for i in 0 1 2 3 4 5 6 7 8 9 10; do
+    out="${out}${out:+ }$(( (mask >> i) & 1 ))"
+  done
+  printf '%s' "$out"
+}
+
+expected_clean() { # mode state
+  local mode="$1" state="$2"
+  local live live_running old old_running new legacy legacy_old env legacy_env tmp unexpected
+  read -r live live_running old old_running new legacy legacy_old env legacy_env tmp unexpected <<< "$state"
+  [ "$live" = 1 ] && [ "$live_running" = 1 ] \
+    && [ "$old" = 0 ] && [ "$old_running" = 0 ] && [ "$new" = 0 ] \
+    && [ "$legacy" = 0 ] && [ "$legacy_old" = 0 ] \
+    && [ "$legacy_env" = 0 ] && [ "$tmp" = 0 ] && [ "$unexpected" = 0 ] \
+    && { [ "$mode" != update ] || [ "$env" = 1 ]; }
+}
+
+expected_rollback() { # state
+  local state="$1"
+  local live live_running old old_running new legacy legacy_old env legacy_env tmp unexpected
+  read -r live live_running old old_running new legacy legacy_old env legacy_env tmp unexpected <<< "$state"
+  [ "$live" = 0 ] && [ "$live_running" = 0 ] \
+    && [ "$old" = 1 ] && [ "$old_running" = 0 ] \
+    && [ "$legacy" = 0 ] && [ "$legacy_old" = 0 ] \
+    && [ "$legacy_env" = 0 ] && [ "$tmp" = 0 ] && [ "$unexpected" = 0 ]
+}
+
+install_matrix_mocks() {
+  pin_host_key() { :; }
+  print_manual_state_help() { :; }
+  load_token() {
+    TOKEN="test-token"
+    unset OPENRUNG_FOUNDATION_TOKEN OPENRUNG_FOUNDATION_TOKEN_CMD
+  }
+  inspect_host_state() { printf '%s' "$MOCK_STATE"; }
+  require_env_has_token() { :; }
+  convert_host() { printf 'convert\n' >> "$MUTATION_LOG"; }
+  prepare_image() { printf 'pull\n' >> "$MUTATION_LOG"; }
+  roll_host() { printf 'roll\n' >> "$MUTATION_LOG"; }
+  rollback_host() { printf 'rollback\n' >> "$MUTATION_LOG"; }
+}
+
+run_matrix() { # mode
+  local mode="$1" mask state expected rc mutations
+  for ((mask=0; mask<2048; mask++)); do
+    state="$(state_from_mask "$mask")"
+    MOCK_STATE="$state"
+    : > "$MUTATION_LOG"
+    if "cmd_${mode}" 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+    mutations="$(wc -l < "$MUTATION_LOG" | tr -d '[:space:]')"
+    expected=1
+    if [ "$mode" = rollback ]; then
+      expected_rollback "$state" && expected=0
+    else
+      expected_clean "$mode" "$state" && expected=0
+    fi
+    if [ "$expected" = 0 ]; then
+      [ "$rc" = 0 ] || fail "${mode} rejected supported state ${state}"
+      [ "$mutations" -gt 0 ] || fail "${mode} did not reach mutation for supported state ${state}"
+    else
+      [ "$rc" != 0 ] || fail "${mode} accepted unsupported state ${state}"
+      [ "$mutations" = 0 ] || fail "${mode} mutated rejected state ${state}"
+    fi
+  done
+  pass
+}
+
+test_state_matrix() {
+  reset_script_functions
+  install_matrix_mocks
+  run_matrix convert
+  run_matrix update
+  run_matrix rollback
+}
+
+test_fleet_preflight_is_all_or_nothing() {
+  reset_script_functions
+  local token_log="${TEST_TMP}/token-reads"
+  pin_host_key() { :; }
+  load_token() { printf 'read\n' >> "$token_log"; TOKEN="test-token"; }
+  inspect_host_state() {
+    if [ "$1" = 203.0.113.11 ]; then
+      printf '1 1 0 0 0 1 0 1 0 0 0' # second host has a legacy container
+    else
+      printf '1 1 0 0 0 0 0 1 0 0 0'
+    fi
+  }
+  convert_host() { printf 'convert\n' >> "$MUTATION_LOG"; }
+  : > "$MUTATION_LOG"
+  : > "$token_log"
+  if (set -e; cmd_convert 203.0.113.10 203.0.113.11) >"$OUTPUT" 2>&1; then
+    fail "fleet convert accepted a legacy second host"
+  else
+    pass
+  fi
+  assert_eq 0 "$(wc -l < "$MUTATION_LOG" | tr -d '[:space:]')" "fleet preflight mutation count"
+  assert_eq 0 "$(wc -l < "$token_log" | tr -d '[:space:]')" "rejected fleet does not invoke token source"
+  assert_contains "$(<"$OUTPUT")" "manual migration required" "fleet preflight guidance"
+}
+
+test_token_export_is_removed() {
+  reset_script_functions
+  local out rc
+  if out="$(TOKEN=preexisting OPENRUNG_FOUNDATION_TOKEN=foundation-secret bash -c '
+      export TOKEN OPENRUNG_FOUNDATION_TOKEN
+      source "$1"
+      load_token
+      declare -p TOKEN
+      if env | grep -q "^TOKEN="; then exit 9; fi
+    ' bash "$SCRIPT" 2>&1)"; then rc=0; else rc=$?; fi
+  assert_eq 0 "$rc" "token export regression"
+  assert_contains "$out" 'declare -- TOKEN="foundation-secret"' "TOKEN is a non-exported shell variable"
+}
+
+test_update_unsets_unused_token_sources() {
+  reset_script_functions
+  MOCK_STATE='1 1 0 0 0 0 0 1 0 0 0'
+  inspect_host_state() { printf '%s' "$MOCK_STATE"; }
+  require_env_has_token() { :; }
+  pin_host_key() {
+    if env | grep -q '^OPENRUNG_FOUNDATION_TOKEN='; then
+      echo leaked >&2
+      return 1
+    fi
+  }
+  prepare_image() { :; }
+  roll_host() { :; }
+  if (set -e; OPENRUNG_FOUNDATION_TOKEN=unused-secret; export OPENRUNG_FOUNDATION_TOKEN; cmd_update 203.0.113.10) >"$OUTPUT" 2>&1; then
+    pass
+  else
+    fail "update leaked an unused token source to preflight children"
+  fi
+}
+
+test_convert_unexports_token_before_preflight() {
+  reset_script_functions
+  inspect_host_state() { printf '1 1 0 0 0 0 0 1 0 0 0'; }
+  pin_host_key() {
+    if env | grep -q '^OPENRUNG_FOUNDATION_TOKEN='; then
+      echo leaked >&2
+      return 1
+    fi
+  }
+  load_token() { TOKEN="$OPENRUNG_FOUNDATION_TOKEN"; unset OPENRUNG_FOUNDATION_TOKEN; }
+  convert_host() { :; }
+  if (set -e; OPENRUNG_FOUNDATION_TOKEN=foundation-secret; export OPENRUNG_FOUNDATION_TOKEN; cmd_convert 203.0.113.10) >"$OUTPUT" 2>&1; then
+    pass
+  else
+    fail "convert leaked its token source to preflight children"
+  fi
+}
+
+test_roll_order_and_failure_boundaries() {
+  reset_script_functions
+  local got rc
+  begin_roll() { printf 'begin\n' >> "$MUTATION_LOG"; }
+  run_candidate() { printf 'run:%s\n' "$2" >> "$MUTATION_LOG"; }
+  verify_foundation() { printf 'verify:%s\n' "$2" >> "$MUTATION_LOG"; }
+  commit_candidate() { printf 'commit\n' >> "$MUTATION_LOG"; }
+  : > "$MUTATION_LOG"
+  (set -e; roll_host 203.0.113.10 /etc/openrung/relay.env)
+  got="$(<"$MUTATION_LOG")"
+  assert_eq $'begin\nrun:/etc/openrung/relay.env\nverify:openrung-relay-new\ncommit' "$got" "candidate transaction order"
+
+  run_candidate() { printf 'run\n' >> "$MUTATION_LOG"; return 1; }
+  : > "$MUTATION_LOG"
+  if (set -e; roll_host 203.0.113.10 /etc/openrung/relay.env) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "candidate start failure return code"
+  got="$(<"$MUTATION_LOG")"
+  assert_eq $'begin\nrun' "$got" "candidate start failure stops transaction"
+
+  run_candidate() { printf 'run\n' >> "$MUTATION_LOG"; }
+  verify_foundation() { printf 'verify\n' >> "$MUTATION_LOG"; return 1; }
+  : > "$MUTATION_LOG"
+  if (set -e; roll_host 203.0.113.10 /etc/openrung/relay.env) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "verification failure return code"
+  got="$(<"$MUTATION_LOG")"
+  assert_eq $'begin\nrun\nverify' "$got" "verification failure cannot commit candidate"
+}
+
+test_convert_prepares_image_before_env_write() {
+  reset_script_functions
+  preflight_host() { :; }
+  prepare_image() { printf 'pull\n' >> "$MUTATION_LOG"; }
+  stage_preserved_env() { printf 'stage\n' >> "$MUTATION_LOG"; }
+  ssh_run() { printf 'public_host=203.0.113.10\nlabel=test\n'; }
+  install_env_file() { printf 'install\n' >> "$MUTATION_LOG"; }
+  roll_host() { printf 'roll\n' >> "$MUTATION_LOG"; }
+  : > "$MUTATION_LOG"
+  (set -e; convert_host 203.0.113.10) >"$OUTPUT" 2>&1
+  assert_eq $'pull\nstage\ninstall\nroll' "$(<"$MUTATION_LOG")" "convert mutation order"
+}
+
+# Execute the script's real multiline remote commands against a tiny file-backed
+# Docker model. This checks command ordering and state transitions rather than
+# merely checking which shell helper was called.
+test_real_transaction_and_rollback_commands() {
+  reset_script_functions
+  local sim_dir="${TEST_TMP}/docker-state" sim_log="${TEST_TMP}/docker-mutations" rc before
+  SIM_DIR="$sim_dir"
+  SIM_LOG="$sim_log"
+  ENV_FILE="${TEST_TMP}/relay.env"
+  LEGACY_ENV_FILE="${TEST_TMP}/volunteer.env"
+  export SIM_DIR SIM_LOG
+
+  sudo() { "$@"; }
+  docker() {
+    local op="${1:-}" fmt="" name="" src="" dst="" running restart registered path all=0 arg
+    [ "$#" -gt 0 ] && shift
+    case "$op" in
+      inspect)
+        if [ "${1:-}" = -f ] || [ "${1:-}" = --format ]; then
+          fmt="$2"
+          shift 2
+        fi
+        name="${1:-}"
+        [ "${SIM_FAIL_INSPECT_NAME:-}" != "$name" ] || return 1
+        [ -f "${SIM_DIR}/${name}" ] || return 1
+        read -r running restart registered < "${SIM_DIR}/${name}"
+        if [[ "$fmt" == *RestartCount* ]]; then
+          printf '%s %s\n' "$running" "$restart"
+        elif [[ "$fmt" == *State.Running* ]]; then
+          printf '%s\n' "$running"
+        fi
+        ;;
+      pull)
+        printf 'pull %s\n' "${1:-}" >> "$SIM_LOG"
+        [ "${SIM_FAIL_OP:-}" != pull ]
+        ;;
+      stop)
+        name="${1:-}"
+        printf 'stop %s\n' "$name" >> "$SIM_LOG"
+        [ "${SIM_FAIL_OP:-}" != stop ] || return 1
+        [ -f "${SIM_DIR}/${name}" ] || return 1
+        read -r running restart registered < "${SIM_DIR}/${name}"
+        printf 'false %s %s\n' "$restart" "$registered" > "${SIM_DIR}/${name}"
+        ;;
+      rename)
+        src="${1:-}"; dst="${2:-}"
+        printf 'rename %s %s\n' "$src" "$dst" >> "$SIM_LOG"
+        [ "${SIM_FAIL_OP:-}" != rename ] || return 1
+        [ -f "${SIM_DIR}/${src}" ] && [ ! -e "${SIM_DIR}/${dst}" ] || return 1
+        mv "${SIM_DIR}/${src}" "${SIM_DIR}/${dst}"
+        ;;
+      run)
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = --name ]; then name="$2"; shift 2; else shift; fi
+        done
+        printf 'run %s\n' "$name" >> "$SIM_LOG"
+        [ "${SIM_FAIL_OP:-}" != run ] || return 1
+        [ -n "$name" ] && [ ! -e "${SIM_DIR}/${name}" ] || return 1
+        registered=yes
+        [ "${SIM_NO_REGISTER:-}" != 1 ] || registered=no
+        printf 'true 0 %s\n' "$registered" > "${SIM_DIR}/${name}"
+        ;;
+      logs)
+        name="${1:-}"
+        [ -f "${SIM_DIR}/${name}" ] || return 1
+        read -r running restart registered < "${SIM_DIR}/${name}"
+        [ "$registered" = yes ] && printf 'registered relay (simulated)\n'
+        ;;
+      ps)
+        for arg in "$@"; do [ "$arg" = -a ] && all=1; done
+        for path in "${SIM_DIR}"/*; do
+          [ -f "$path" ] || continue
+          read -r running restart registered < "$path"
+          if [ "$all" = 1 ] || [ "$running" = true ]; then
+            printf '%s\n' "${path##*/}"
+          fi
+        done
+        ;;
+      rm)
+        [ "${1:-}" = -f ] && shift
+        name="${1:-}"
+        printf 'rm %s\n' "$name" >> "$SIM_LOG"
+        [ "${SIM_FAIL_OP:-}" != rm ] || return 1
+        [ -f "${SIM_DIR}/${name}" ] || return 1
+        rm "${SIM_DIR}/${name}"
+        ;;
+      start)
+        name="${1:-}"
+        printf 'start %s\n' "$name" >> "$SIM_LOG"
+        [ "${SIM_FAIL_OP:-}" != start ] || return 1
+        [ -f "${SIM_DIR}/${name}" ] || return 1
+        read -r running restart registered < "${SIM_DIR}/${name}"
+        printf 'true %s %s\n' "$restart" "$registered" > "${SIM_DIR}/${name}"
+        ;;
+      *) return 2 ;;
+    esac
+  }
+  export -f sudo docker
+
+  ssh_run() {
+    local host="$1"; shift
+    SIM_FAIL_OP="${SIM_FAIL_OP:-}" SIM_NO_REGISTER="${SIM_NO_REGISTER:-}" \
+      SIM_FAIL_INSPECT_NAME="${SIM_FAIL_INSPECT_NAME:-}" bash -c "$*"
+  }
+  sim_reset() {
+    rm -rf "$SIM_DIR"
+    mkdir -p "$SIM_DIR"
+    : > "$SIM_LOG"
+    printf 'OPENRUNG_FOUNDATION_TOKEN=simulated\n' > "$ENV_FILE"
+    rm -f "$LEGACY_ENV_FILE" "${ENV_FILE}.tmp"
+    unset SIM_FAIL_OP SIM_NO_REGISTER SIM_FAIL_INSPECT_NAME
+  }
+  sim_put() { printf '%s 0 %s\n' "$2" "${3:-yes}" > "${SIM_DIR}/$1"; }
+  sim_running() {
+    local running
+    read -r running _ < "${SIM_DIR}/$1"
+    printf '%s' "$running"
+  }
+  sim_snapshot() {
+    for path in "${SIM_DIR}"/*; do
+      [ -f "$path" ] || continue
+      printf '%s ' "${path##*/}"
+      cksum "$path"
+    done | sort
+  }
+
+  # The actual begin/run/verify/commit commands return to the sole steady state.
+  sim_reset
+  sim_put "$CONTAINER" true
+  if roll_host 203.0.113.10 "$ENV_FILE" >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 0 "$rc" "real candidate transaction succeeds"
+  assert_eq true "$(sim_running "$CONTAINER")" "committed live container is running"
+  assert_eq 0 "$([ ! -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${NEW_CONTAINER}" ]; echo $?)" "success removes old and candidate names"
+  assert_before "$(<"$SIM_LOG")" "rename ${CONTAINER} ${OLD_CONTAINER}" "run ${NEW_CONTAINER}" "candidate starts after live becomes old"
+  assert_before "$(<"$SIM_LOG")" "rename ${NEW_CONTAINER} ${CONTAINER}" "rm ${OLD_CONTAINER}" "backup removal follows promotion"
+
+  # A run failure leaves old-only; the real rollback command restores it.
+  sim_reset
+  sim_put "$CONTAINER" true
+  SIM_FAIL_OP=run
+  if roll_host 203.0.113.10 "$ENV_FILE" >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "candidate start failure propagates"
+  assert_eq 0 "$([ -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${CONTAINER}" ]; echo $?)" "run failure leaves stopped old only"
+  unset SIM_FAIL_OP
+  if rollback_host 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 0 "$rc" "old-only rollback succeeds"
+  assert_eq true "$(sim_running "$CONTAINER")" "old-only rollback restarts live"
+
+  # A verification failure leaves old+new; rollback removes only the candidate.
+  sim_reset
+  sim_put "$CONTAINER" true
+  verify_foundation() { return 1; }
+  if roll_host 203.0.113.10 "$ENV_FILE" >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "verification failure propagates"
+  assert_eq 0 "$([ -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ -e "${SIM_DIR}/${NEW_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${CONTAINER}" ]; echo $?)" "verification failure leaves exact rollback state"
+  if rollback_host 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 0 "$rc" "old+new rollback succeeds"
+  assert_eq true "$(sim_running "$CONTAINER")" "old+new rollback restarts live"
+
+  # Cleanup failure leaves live+old. That ambiguous backup is then read-only.
+  sim_reset
+  sim_put "$OLD_CONTAINER" false
+  sim_put "$NEW_CONTAINER" true
+  SIM_FAIL_OP=rm
+  if commit_candidate 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "backup cleanup failure propagates"
+  assert_eq 0 "$([ -e "${SIM_DIR}/${CONTAINER}" ] && [ -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${NEW_CONTAINER}" ]; echo $?)" "cleanup failure leaves visible live plus old"
+  unset SIM_FAIL_OP
+  : > "$SIM_LOG"
+  before="$(sim_snapshot)"
+  if preflight_host 203.0.113.10 update >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "live plus backup is rejected"
+  assert_eq 0 "$(wc -l < "$SIM_LOG" | tr -d '[:space:]')" "ambiguous backup triggers no Docker mutation"
+  assert_eq "$before" "$(sim_snapshot)" "ambiguous backup state stays unchanged"
+
+  # Existence comes from docker ps -a, not a second fallible inspect. A backup
+  # listed in the snapshot therefore cannot disappear from the policy decision.
+  sim_reset
+  sim_put "$CONTAINER" true
+  sim_put "$OLD_CONTAINER" false
+  SIM_FAIL_INSPECT_NAME="$OLD_CONTAINER"
+  if preflight_host 203.0.113.10 convert >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "listed backup remains visible when its inspect fails"
+  assert_eq 0 "$(wc -l < "$SIM_LOG" | tr -d '[:space:]')" "inspect failure cannot turn backup into a mutable clean state"
+  if begin_roll 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "mutation guard rejects backup directly from name snapshot"
+  assert_eq 0 "$(wc -l < "$SIM_LOG" | tr -d '[:space:]')" "hidden backup cannot trigger stop or rename"
+  unset SIM_FAIL_INSPECT_NAME
+
+  # Unrecognized relay-prefixed backups are part of the refused state space,
+  # even though they do not collide with the three canonical transaction names.
+  sim_reset
+  sim_put "$CONTAINER" true
+  sim_put "${CONTAINER}-old-2026" false
+  before="$(sim_snapshot)"
+  if preflight_host 203.0.113.10 convert >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "unrecognized relay backup is rejected by real snapshot"
+  assert_contains "$(<"$OUTPUT")" "unrecognized OpenRung relay container" "unexpected-container manual guidance"
+  assert_eq 0 "$(wc -l < "$SIM_LOG" | tr -d '[:space:]')" "unexpected container preflight triggers no Docker mutation"
+  assert_eq "$before" "$(sim_snapshot)" "unexpected container state stays unchanged"
+
+  # The immediate mutation guard repeats the check in case such a container
+  # appears after fleet preflight.
+  : > "$SIM_LOG"
+  if prepare_image 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "unexpected container blocks image preparation"
+  assert_eq 0 "$(wc -l < "$SIM_LOG" | tr -d '[:space:]')" "unexpected container blocks image pull"
+  if begin_roll 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "unexpected container blocks live-container swap"
+  assert_eq 0 "$(wc -l < "$SIM_LOG" | tr -d '[:space:]')" "unexpected container blocks stop and rename"
+
+  export -n -f sudo docker 2>/dev/null || true
+  unset -f sudo docker
+}
+
+test_commit_rechecks_before_deleting_old() {
+  reset_script_functions
+  local calls rc command_log
+  calls=0
+  ssh_run() {
+    calls=$((calls + 1))
+    printf '%s\n' "$*" > "${TEST_TMP}/last-command"
+    printf 'guard-promote\n' >> "$MUTATION_LOG"
+    if [ "$calls" = 1 ]; then return 42; fi
+    return 0
+  }
+  : > "$MUTATION_LOG"
+  if commit_candidate 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "commit refuses candidate that changed after verification"
+  assert_eq 1 "$calls" "failed commit never reaches old deletion"
+  assert_contains "$(<"${TEST_TMP}/last-command")" "RestartCount" "commit atomically rechecks candidate health"
+
+  calls=0
+  ssh_run() {
+    calls=$((calls + 1))
+    printf '%s\n' "$*" > "${TEST_TMP}/last-command"
+    return 0
+  }
+  : > "$MUTATION_LOG"
+  if commit_candidate 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 0 "$rc" "healthy candidate commits"
+  assert_eq 1 "$calls" "promotion and old removal share one guarded SSH transaction"
+  command_log="$(<"${TEST_TMP}/last-command")"
+  assert_before "$command_log" "docker rename ${NEW_CONTAINER} ${CONTAINER}" "docker rm -f ${OLD_CONTAINER}" "old removal follows guarded candidate promotion"
+}
+
+test_fail_closed_function_boundaries() {
+  reset_script_functions
+  inspect_host_state() { return 1; }
+  if preflight_host 203.0.113.10 convert >"$OUTPUT" 2>&1; then
+    fail "preflight swallowed a failed state snapshot"
+  else
+    pass
+  fi
+
+  read_token() { return 1; }
+  if load_token >"$OUTPUT" 2>&1; then
+    fail "load_token swallowed a failed token source"
+  else
+    pass
+  fi
+}
+
+test_host_key_write_failure_is_fatal() {
+  reset_script_functions
+  local rc
+  if (
+    ssh-keygen() { return 1; }
+    aws() {
+      case "${2:-}" in
+        get-instances) printf 'simulated-instance\n' ;;
+        get-instance-access-details) printf 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISimulated\n' ;;
+        *) return 2 ;;
+      esac
+    }
+    mkdir() { return 1; }
+    HOME="${TEST_TMP}/unwritable-home"
+    pin_host_key 203.0.113.10
+  ) >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "host-key directory write failure propagates"
+  assert_contains "$(<"$OUTPUT")" "host key was not pinned" "host-key write failure is explicit"
+  if [[ "$(<"$OUTPUT")" == *"pinned 203.0.113.10"* ]]; then
+    fail "host-key write failure falsely reported success"
+  else
+    pass
+  fi
+}
+
+test_malformed_host_keys_cannot_enable_tofu() {
+  reset_script_functions
+  local rc
+  if (
+    ssh-keygen() { return 1; }
+    aws() {
+      case "${2:-}" in
+        get-instances) printf 'simulated-instance\n' ;;
+        get-instance-access-details) printf 'malformed-only\n' ;;
+        *) return 2 ;;
+      esac
+    }
+    HOME="${TEST_TMP}/malformed-key-home"
+    pin_host_key 203.0.113.10
+  ) >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
+  assert_eq 1 "$rc" "malformed host-key response propagates"
+  assert_contains "$(<"$OUTPUT")" "no valid SSH host keys" "malformed host-key failure is explicit"
+  if [[ "$(<"$OUTPUT")" == *"pinned 203.0.113.10"* ]]; then
+    fail "malformed host-key response falsely reported success"
+  else
+    pass
+  fi
+}
+
+test_manual_help_uses_configured_ssh() {
+  reset_script_functions
+  local out
+  SSH_KEY="/tmp/key with spaces"
+  SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known_hosts -i "$SSH_KEY")
+  out="$(print_manual_state_help 203.0.113.10 "ambiguous" 2>&1)"
+  assert_contains "$out" "key\\ with\\ spaces" "manual help shell-quotes configured key"
+  assert_contains "$out" "foundation-up.sh rollback 203.0.113.10" "manual help points to validated rollback"
+  assert_contains "$out" "no relay container, env-file, image, backup, or candidate changes were made" "manual help states fail-closed behavior"
+}
+
+test_state_matrix
+test_fleet_preflight_is_all_or_nothing
+test_token_export_is_removed
+test_update_unsets_unused_token_sources
+test_convert_unexports_token_before_preflight
+test_roll_order_and_failure_boundaries
+test_convert_prepares_image_before_env_write
+test_real_transaction_and_rollback_commands
+test_commit_rechecks_before_deleting_old
+test_fail_closed_function_boundaries
+test_host_key_write_failure_is_fatal
+test_malformed_host_keys_cannot_enable_tofu
+test_manual_help_uses_configured_ssh
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "foundation-up tests: ${PASS} passed, ${FAIL} failed" >&2
+  exit 1
+fi
+echo "foundation-up tests: ${PASS} passed"


### PR DESCRIPTION
## Why

#68 added `foundation-up.sh` but was merged without the review sequence and reverted in #71. This PR reimplements the same tooling — `create` / `convert` / `update` for Foundation relays, wrapping (never modifying) `lightsail-up.sh` — with the issues from a security audit of #68 fixed. Since #68 carried no review record, the audit findings are documented here in full.

## Security issues in #68, and the fixes

### 1. The Foundation bearer was routed through a third-party CDN by default

#68 defaulted `OPENRUNG_BROKER_URL` to `https://d2r7mdpyevvs1m.cloudfront.net`. Every registration and heartbeat would carry `OPENRUNG_FOUNDATION_TOKEN` through CloudFront, where viewer TLS terminates — the bearer is decrypted at every edge POP, and its exposure depends on distribution config staying correct (an `http-only`-origin or `Managed-AllViewer` regression would silently reopen the cleartext origin leg that `deploy/broker/origin-tls.md` was written to close). It also collapses broker-side per-IP rate limiting onto shared CloudFront edge IPs (the broker keys the CloudFront path per-edge, per origin-tls.md), so a fleet of relays near one POP shares one 2 req/s bucket — a heartbeat-starvation risk with 13+ relays mostly in one region.

**Fix:** default to `https://broker-origin.openrung.org` — the broker's own TLS origin (Caddy, publicly-trusted LE cert, set up 2026-07-13). The token is only ever decrypted on the broker box, and the broker rate-limits each relay by its real IP (Caddy forwards `X-Forwarded-For={remote_host}`, trusted via the loopback proxy CIDRs). Fronts exist for censored *clients*; datacenter relays have no reason to traverse one. Note for rollout: existing fleet env files keep whatever URL they were converted with until `convert` is re-run — `update` deliberately does not rewrite credentials.

### 2. `eval` on an environment variable, and token-handling hardening

#68 ran `eval "$OPENRUNG_FOUNDATION_TOKEN_CMD"` — full shell evaluation inside the script's own context, from a process that holds fleet SSH keys and AWS credentials. **Fix:** the token command runs via `bash -c` in a child shell; only its first output line is taken (matching `pass show` semantics). Additionally: xtrace is forced off so `bash -x` can never trace the token (test-covered), the token is charset-validated before being written (an embedded newline would inject extra variables into the env file), and the remote env-file write is atomic (`tmp` + `mv`) so a dropped connection can't leave a truncated credential file. Unchanged from #68: the token is never in argv on either side and travels only over SSH stdin.

### 3. Unvalidated remote-derived values flowed into privileged commands and the operator's terminal

#68 interpolated whatever a host returned — container name, env-file path, `OPENRUNG_PUBLIC_HOST`, `OPENRUNG_LABEL`, raw `docker logs` lines — into subsequent `sudo` command strings (including the `sh -c 'cat > ${target}'` that writes the token file) and printed them raw to the controlling terminal. A compromised relay could inject shell into the commands the script runs against it, or ANSI escape sequences into the operator's terminal. **Fix:** every remote-read value must pass a strict allowlist before reuse — container name must be exactly `openrung-relay`/`openrung-volunteer`, env-file path exactly the canonical/legacy path, identity values must match tight regexes — and display-only strings (log lines) are stripped of control characters. Operator-set values that reach remote commands (`OPENRUNG_IMAGE`, `OPENRUNG_ENV_FILE`, hosts) are validated too.

### 4. `update` verified nothing Foundation-specific

The "self-contained verification" (running + registered ⇒ broker attested `foundation`) is sound **only when the relay presents the token** — that's what forces the class claim the relay then cross-checks (`cmd/relay` exits on a mismatched attestation; the broker 403s an unauthorized `foundation` claim). #68's `update` never checked the env file it reused, so a host whose env file lacked the token would register as a volunteer and still "verify". **Fix:** `update` requires an `OPENRUNG_FOUNDATION_TOKEN=` line in the env file (presence check only; the value is never read back), making the verification's precondition hold on every path.

### 5. Trust-on-first-use at the exact moment the credential is shipped

#68 used `StrictHostKeyChecking=accept-new` and immediately streamed the token over that first connection — a first-contact MITM gets the fleet credential. **Fix:** before the first connection that will carry the token, the host's SSH keys are fetched over the authenticated Lightsail API (`get-instance-access-details`, with retries on `create` while a new instance settles; reverse lookup by IP for `convert`/`update`) and pinned into `known_hosts`. Non-Lightsail hosts fall back to `accept-new` with an explicit warning. `accept-new` still never accepts a *changed* key.

### 6. `create` could never have worked with one of its two documented token sources

`lightsail-up.sh` refuses to run when `OPENRUNG_FOUNDATION_TOKEN` is set, even empty (its `${VAR+x}` user-data guard, `lightsail-up.sh:29`) — so #68's `create` failed immediately whenever the token came via the plain variable rather than `_CMD`. Evidence the path was never executed end-to-end. **Fix:** `create` invokes the provisioning child with `env -u` stripping `OPENRUNG_FOUNDATION_TOKEN`, `OPENRUNG_FOUNDATION_TOKEN_CMD`, `OPENRUNG_VOLUNTEER_TOKEN`, and `OPENRUNG_NODE_CLASS`. This both unbreaks the flow and makes the no-token-in-user-data invariant **structural**: the provisioning child never holds the credential, so no bug in it could ever embed one. (Covered by a stubbed-child test that enforces the real guard.)

### 7. Smaller hardening and correctness items

- **Single token copy, canonical path:** `convert` writes `/etc/openrung/relay.env` and, once the relay verifies, removes a legacy `volunteer.env` (`shred -u || rm`). #68 instead overwrote the legacy path in place forever. The rollback container doesn't need the file (env is baked at create).
- **Failure paths print an in-place rollback command** (the previous container is kept, stopped, as `openrung-relay-old`), instead of only "check the logs".
- `usage()` no longer `sed`-extracts fixed line numbers from its own header (silent breakage when the header moves); verification window widened to 60s; live output from `lightsail-up.sh` streams during `create` instead of appearing only at the end.

## What #68 got right and is preserved

Wrapper-not-replacement of `lightsail-up.sh`; token only over SSH stdin, post-boot, never user-data; root-owned mode-0600 env file; tokenless `update` for routine image rolls; sequential fail-fast fleet updates; identity reuse on `convert` (no silent relabel/re-home); legacy `openrung-volunteer`/`volunteer.env` detection; HTTPS-broker fail-fast; container hardening parity with `lightsail-up.sh` including the deliberate absence of `no-new-privileges` (it would break the `cap_net_bind_service` 443 bind); the attestation-based self-contained verification (now with its precondition enforced).

## Testing

- `bash -n` clean; `shellcheck` (stable, via Docker) clean — 3 informational SC2029 notes only, all intentional client-side expansion of allowlist-validated values.
- 17 offline tests, all passing: usage/dispatch; HTTPS guard; token-source missing/empty/whitespace/failing-command; multi-line token command (first line taken, proceeds past token stage); allowlist rejections for hostile `OPENRUNG_IMAGE`, `OPENRUNG_ENV_FILE`, and host arguments; `create` fails before provisioning on bad broker URL or missing token; **`bash -x` trace-leak test** (a known token value never appears in trace output); and a **stubbed `lightsail-up.sh` `create` flow** proving the `env -u` guard, handoff-line parse, host-key-pin fallback warning, and wait-loop entry.
- **Not run against production hosts** — deploy authority for this repo requires the operator in the loop, and even read-only SSH was skipped. Suggested first live steps: `update` against one relay (no token involved), then `convert` against one relay to move it to the direct-origin broker URL, then the fleet.

## Review notes

- Same soft coupling as #68: `create` parses the `OPENRUNG_RELAY name=… ip=…` handoff line from `lightsail-up.sh:125`; it fails loudly if that line is reformatted.
- The direct-origin default depends on the origin-tls.md invariants: `broker-origin.openrung.org` stays DNS-only and Caddy stays up on the broker box (`:443`). Volunteer provisioning on plaintext `:8080` is unaffected.
- CI has no shell linting; shellcheck for `deploy/**/*.sh` would be a cheap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
