### PR TITLE
Add shellcheck CI gate for deploy scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,51 @@
+name: shellcheck
+
+# Lint every shell script under deploy/ (provisioning helpers and container
+# entrypoints) on each PR and push to main — the missing gate was called out
+# in the reviews of PRs #68 and #72. No paths filter: the run takes seconds
+# and an always-on check can never be silently skipped for a PR that touches
+# scripts through an unanticipated path.
+#
+# The shellcheck binary is pinned by version + sha256 (release asset digest)
+# instead of using the runner's preinstalled copy, so findings don't drift
+# when the runner image updates; bump the pin deliberately. Project-wide
+# directives (e.g. the acknowledged SC2029 client-side ssh expansion) live in
+# deploy/.shellcheckrc, which shellcheck reads for CI and local runs alike.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pinned shellcheck
+        env:
+          VERSION: v0.11.0
+          SHA256: b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/shellcheck.tar.gz" \
+            "https://github.com/koalaman/shellcheck/releases/download/${VERSION}/shellcheck-${VERSION}.linux.x86_64.tar.gz"
+          echo "${SHA256}  ${RUNNER_TEMP}/shellcheck.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/shellcheck.tar.gz" -C "$RUNNER_TEMP"
+          echo "${RUNNER_TEMP}/shellcheck-${VERSION}" >> "$GITHUB_PATH"
+
+      - name: Lint deploy scripts
+        run: |
+          set -euo pipefail
+          shellcheck --version
+          mapfile -d '' scripts < <(find deploy -type f -name '*.sh' -print0 | sort -z)
+          if [ "${#scripts[@]}" -eq 0 ]; then
+            echo "no *.sh files found under deploy/ — did the layout change?" >&2
+            exit 1
+          fi
+          printf '%s\n' "${scripts[@]}"
+          shellcheck "${scripts[@]}"

--- a/deploy/.shellcheckrc
+++ b/deploy/.shellcheckrc
@@ -1,0 +1,9 @@
+# ShellCheck directives for every script under deploy/. ShellCheck finds this
+# file by walking up from the checked script's directory, so the same rules
+# apply in CI (.github/workflows/shellcheck.yml), local runs, and editors.
+#
+# SC2029 (info, "this word is expanded on the client side"): the provisioning
+# scripts intentionally expand validated, locally-constructed variables inside
+# ssh command strings — the remote shell is meant to receive the final values.
+# Acknowledged here once rather than per call site.
+disable=SC2029

--- a/deploy/broker/lightsail-up.sh
+++ b/deploy/broker/lightsail-up.sh
@@ -189,6 +189,9 @@ if [ -n "$SSH_PUBKEY" ]; then
   KEYPAIR_ARG="--key-pair-name $SSH_KEY_NAME"
 fi
 
+# KEYPAIR_ARG deliberately expands unquoted: it is either empty or the two
+# words "--key-pair-name <name>".
+# shellcheck disable=SC2086
 aws lightsail create-instances \
   --instance-names "$NAME" \
   $KEYPAIR_ARG \

--- a/deploy/relay/entrypoint.sh
+++ b/deploy/relay/entrypoint.sh
@@ -8,7 +8,7 @@ set -eu
 # legacy OPENRUNG_TUNNEL boolean, then to auto when a hub is configured, else
 # direct. The resolved value is passed back as -mode so this wrapper and the
 # binary can never disagree about which mode is active.
-norm() { printf '%s' "$1" | tr 'A-Z' 'a-z' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; }
+norm() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; }
 mode="$(norm "${OPENRUNG_MODE:-}")"
 if [ -n "${OPENRUNG_FOUNDATION_TOKEN:-}" ]; then
   # A foundation token forces direct mode, mirroring the binary's

--- a/deploy/relay/lightsail-up.sh
+++ b/deploy/relay/lightsail-up.sh
@@ -100,6 +100,9 @@ if [ -n "$SSH_PUBKEY" ]; then
   KEYPAIR_ARG="--key-pair-name $SSH_KEY_NAME"
 fi
 
+# KEYPAIR_ARG deliberately expands unquoted: it is either empty or the two
+# words "--key-pair-name <name>".
+# shellcheck disable=SC2086
 aws lightsail create-instances \
   --instance-names "$NAME" \
   $KEYPAIR_ARG \

--- a/deploy/relayhub/ec2-up.sh
+++ b/deploy/relayhub/ec2-up.sh
@@ -56,7 +56,7 @@ AMI="$(aws ssm get-parameter --region "$REGION" \
   --query 'Parameter.Value' --output text)"
 
 VPC="$(aws ec2 describe-vpcs --region "$REGION" --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text)"
-SUBNET="${OPENRUNG_EC2_SUBNET:-$(aws ec2 describe-subnets --region "$REGION" --filters Name=vpc-id,Values=$VPC --query 'Subnets[0].SubnetId' --output text)}"
+SUBNET="${OPENRUNG_EC2_SUBNET:-$(aws ec2 describe-subnets --region "$REGION" --filters Name=vpc-id,Values="$VPC" --query 'Subnets[0].SubnetId' --output text)}"
 
 echo "Provisioning EC2 relay hub '${NAME}' in ${REGION} (${ITYPE}/${ARCH}, ami ${AMI})"
 
@@ -215,7 +215,11 @@ echo "Instance: ${IID}, waiting for running..."
 aws ec2 wait instance-running --instance-ids "$IID" --region "$REGION"
 
 ENI="$(aws ec2 describe-instances --instance-ids "$IID" --region "$REGION" --query 'Reservations[0].Instances[0].NetworkInterfaces[0].NetworkInterfaceId' --output text)"
+# The backticked `true`/`false` in these queries are JMESPath literals, not
+# shell command substitutions.
+# shellcheck disable=SC2016
 PRIMARY_IP="$(aws ec2 describe-instances --instance-ids "$IID" --region "$REGION" --query 'Reservations[0].Instances[0].NetworkInterfaces[0].PrivateIpAddresses[?Primary==`true`].PrivateIpAddress | [0]' --output text)"
+# shellcheck disable=SC2016
 SECONDARY_IP="$(aws ec2 describe-instances --instance-ids "$IID" --region "$REGION" --query 'Reservations[0].Instances[0].NetworkInterfaces[0].PrivateIpAddresses[?Primary==`false`].PrivateIpAddress | [0]' --output text)"
 
 # Associate EIP1 -> primary, EIP2 -> secondary (order matches the env's

--- a/deploy/relayhub/lightsail-up.sh
+++ b/deploy/relayhub/lightsail-up.sh
@@ -133,6 +133,9 @@ if [ -n "$SSH_PUBKEY" ]; then
   KEYPAIR_ARG="--key-pair-name $SSH_KEY_NAME"
 fi
 
+# KEYPAIR_ARG deliberately expands unquoted: it is either empty or the two
+# words "--key-pair-name <name>".
+# shellcheck disable=SC2086
 aws lightsail create-instances \
   --instance-names "$NAME" \
   $KEYPAIR_ARG \


### PR DESCRIPTION
## Why

The reviews of #68 and #72 (foundation-up.sh) both called out that CI has no shell linting for the deploy scripts. This adds the gate.

## What

- **`.github/workflows/shellcheck.yml`** — runs on every PR and push to main (no paths filter, same as go-checks, so the check can never be silently skipped). Installs shellcheck **v0.11.0 pinned by version + sha256** (the hash is cross-checked against GitHub's recorded release-asset digest) instead of trusting the runner's preinstalled copy, so findings don't drift when the runner image updates. Lints every `deploy/**/*.sh` it finds and **fails if the file set is empty** (a renamed directory can't silently turn the gate green).
- **`deploy/.shellcheckrc`** — acknowledges **SC2029** (info: "expands on the client side") once, with the reason: the provisioning scripts intentionally expand validated, locally-constructed variables inside ssh command strings. The rc is discovered by walking up from each script, so CI, local runs, and editor integrations all agree. Nothing on main triggers SC2029 today — this is forward-looking for #72's foundation-up.sh, which will be picked up by the `find` automatically when it lands (no rebase needed in either merge order).
- **Script touch-ups** so the current tree lints clean (every finding was info-level):
  - Real fixes: quote `$VPC` in `deploy/relayhub/ec2-up.sh` (SC2086); `tr '[:upper:]' '[:lower:]'` instead of `tr 'A-Z' 'a-z'` in `deploy/relay/entrypoint.sh` (SC2018/SC2019 — verified byte-identical on busybox/alpine:3 for the ASCII env values it normalizes).
  - Documented inline disables for intentional patterns: the unquoted `$KEYPAIR_ARG` word-split in the three lightsail-up.sh scripts, and the JMESPath backtick literals in ec2-up.sh (SC2016 false positive). `KEYPAIR_ARG` deliberately stays a string rather than the textbook bash-array fix because `"${empty_array[@]}"` errors under `set -u` on bash 3.2 — which is what stock macOS runs these scripts with via `#!/usr/bin/env bash`.

## Verification (all with the pinned v0.11.0)

- Full lint of all six current scripts: clean, exit 0.
- Both workflow step bodies executed verbatim in an `ubuntu:24.04` container (bash 5.2, real static binary): install step (checksum format, extraction, executable bit) and lint step both pass. This is also why the workflow fetches the `.tar.gz` asset rather than `.tar.xz` — extraction then needs only gzip, not an xz-utils assumption.
- Empty-file-set guard: exits 1 with a clear message when `deploy/` has no scripts.
- SC2029 suppression proven with a probe script (`ssh "root@$host" "docker pull $image"`): fires under `--norc`, silent with `deploy/.shellcheckrc` in place.
- `actionlint` on the new workflow: clean.

## Review flow

Awaiting Codex review, then user merges. **Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
