### PR TITLE
Fix shellcheck gate on main: follow sources, annotate foundation-up test harness

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -48,4 +48,8 @@ jobs:
             exit 1
           fi
           printf '%s\n' "${scripts[@]}"
-          shellcheck "${scripts[@]}"
+          # -x follows `source`d files (paths resolve via source-path=SCRIPTDIR
+          # in deploy/.shellcheckrc), so a script that only uses a variable or
+          # function across the source boundary is analyzed correctly rather
+          # than reported as unused.
+          shellcheck -x "${scripts[@]}"

--- a/deploy/.shellcheckrc
+++ b/deploy/.shellcheckrc
@@ -7,3 +7,9 @@
 # ssh command strings — the remote shell is meant to receive the final values.
 # Acknowledged here once rather than per call site.
 disable=SC2029
+
+# Resolve `# shellcheck source=` directives relative to the sourcing script's
+# own directory instead of the caller's working directory, so `shellcheck -x`
+# finds the target whether it runs from the repo root (CI) or from deploy/relay
+# (a local `./foundation-up_test.sh` run, an editor).
+source-path=SCRIPTDIR

--- a/deploy/relay/foundation-up_test.sh
+++ b/deploy/relay/foundation-up_test.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# SC2329 ("function is never invoked") is disabled file-wide: nearly every test
+# here defines mock functions that shadow the real ones and are called only
+# indirectly, from the foundation-up.sh code under test. That is the harness's
+# whole design, so the check fires on every mock and cannot distinguish a
+# correct one from a mock whose name has drifted out of sync with the script.
+# shellcheck disable=SC2329
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,6 +17,7 @@ set +e
 reset_script_functions() {
   # Function mocks are global in bash; re-source between test groups so one
   # failure-injection setup cannot contaminate the next group.
+  # shellcheck source=foundation-up.sh
   source "$SCRIPT"
   set +e
 }
@@ -176,6 +183,10 @@ test_update_unsets_unused_token_sources() {
   }
   prepare_image() { :; }
   roll_host() { :; }
+  # SC2030/SC2031: confining the token to this subshell is the point -- the test
+  # asserts cmd_update unexports it before spawning preflight children, and the
+  # subshell keeps the secret out of the rest of the harness either way.
+  # shellcheck disable=SC2030
   if (set -e; OPENRUNG_FOUNDATION_TOKEN=unused-secret; export OPENRUNG_FOUNDATION_TOKEN; cmd_update 203.0.113.10) >"$OUTPUT" 2>&1; then
     pass
   else
@@ -192,6 +203,7 @@ test_convert_unexports_token_before_preflight() {
       return 1
     fi
   }
+  # shellcheck disable=SC2031
   load_token() { TOKEN="$OPENRUNG_FOUNDATION_TOKEN"; unset OPENRUNG_FOUNDATION_TOKEN; }
   convert_host() { :; }
   if (set -e; OPENRUNG_FOUNDATION_TOKEN=foundation-secret; export OPENRUNG_FOUNDATION_TOKEN; cmd_convert 203.0.113.10) >"$OUTPUT" 2>&1; then
@@ -374,6 +386,10 @@ test_real_transaction_and_rollback_commands() {
   if roll_host 203.0.113.10 "$ENV_FILE" >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
   assert_eq 0 "$rc" "real candidate transaction succeeds"
   assert_eq true "$(sim_running "$CONTAINER")" "committed live container is running"
+  # SC2319 on the next four assertions: `$?` after a `[ ... ] && [ ... ]` list
+  # is the status of the list itself -- 0 only when every path test holds --
+  # which is exactly the value being compared. Intentional, not a stray `$?`.
+  # shellcheck disable=SC2319
   assert_eq 0 "$([ ! -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${NEW_CONTAINER}" ]; echo $?)" "success removes old and candidate names"
   assert_before "$(<"$SIM_LOG")" "rename ${CONTAINER} ${OLD_CONTAINER}" "run ${NEW_CONTAINER}" "candidate starts after live becomes old"
   assert_before "$(<"$SIM_LOG")" "rename ${NEW_CONTAINER} ${CONTAINER}" "rm ${OLD_CONTAINER}" "backup removal follows promotion"
@@ -381,9 +397,10 @@ test_real_transaction_and_rollback_commands() {
   # A run failure leaves old-only; the real rollback command restores it.
   sim_reset
   sim_put "$CONTAINER" true
-  SIM_FAIL_OP=run
+  SIM_FAIL_OP="run"
   if roll_host 203.0.113.10 "$ENV_FILE" >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
   assert_eq 1 "$rc" "candidate start failure propagates"
+  # shellcheck disable=SC2319
   assert_eq 0 "$([ -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${CONTAINER}" ]; echo $?)" "run failure leaves stopped old only"
   unset SIM_FAIL_OP
   if rollback_host 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
@@ -396,6 +413,7 @@ test_real_transaction_and_rollback_commands() {
   verify_foundation() { return 1; }
   if roll_host 203.0.113.10 "$ENV_FILE" >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
   assert_eq 1 "$rc" "verification failure propagates"
+  # shellcheck disable=SC2319
   assert_eq 0 "$([ -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ -e "${SIM_DIR}/${NEW_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${CONTAINER}" ]; echo $?)" "verification failure leaves exact rollback state"
   if rollback_host 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
   assert_eq 0 "$rc" "old+new rollback succeeds"
@@ -405,9 +423,10 @@ test_real_transaction_and_rollback_commands() {
   sim_reset
   sim_put "$OLD_CONTAINER" false
   sim_put "$NEW_CONTAINER" true
-  SIM_FAIL_OP=rm
+  SIM_FAIL_OP="rm"
   if commit_candidate 203.0.113.10 >"$OUTPUT" 2>&1; then rc=0; else rc=$?; fi
   assert_eq 1 "$rc" "backup cleanup failure propagates"
+  # shellcheck disable=SC2319
   assert_eq 0 "$([ -e "${SIM_DIR}/${CONTAINER}" ] && [ -e "${SIM_DIR}/${OLD_CONTAINER}" ] && [ ! -e "${SIM_DIR}/${NEW_CONTAINER}" ]; echo $?)" "cleanup failure leaves visible live plus old"
   unset SIM_FAIL_OP
   : > "$SIM_LOG"


### PR DESCRIPTION
## Why

**`main` is red.** [Run 29463731272](https://github.com/openrung/openrung/actions/runs/29463731272/job/87512375546) — the shellcheck gate fails on `main`.

This is a semantic merge conflict, not a bad merge: #72 merged first, then #73. Each passed its own PR checks, but #73's branch never contained #72's files, so the two were **first evaluated together only after landing on main**. The gate worked exactly as intended — it caught new scripts the moment they were in the same tree.

All 41 findings are in the new `deploy/relay/foundation-up_test.sh`. **`foundation-up.sh` itself is clean**, and the SC2029 acknowledgment I added in #73 for it does its job.

## Fix, in two parts

**1. Follow sources (an analysis fix, not a suppression).** Run `shellcheck -x` and add `source-path=SCRIPTDIR` to `deploy/.shellcheckrc`. The test file already carries a `# shellcheck source=foundation-up.sh` directive that silently did nothing: `-x` was missing, and the relative path resolved against the *caller's* cwd rather than the script's. With both in place shellcheck actually reads the sourced script — which **clears three false "appears unused" warnings** (`TOKEN`, `host`, `SSH_OPTS` are genuinely consumed across the source boundary) and drops findings 40 → 28 on its own. Verified to resolve from the repo root (CI) and from `deploy/relay` (local run).

**2. Annotate what remains** — all inherent to a mock-injection harness, none a defect:

| Code | Count | Why it's intentional |
|---|---|---|
| SC2329 | 20 | Mocks are shadowing overrides invoked only from the code under test. Fires on every mock; can't tell a correct one from a drifted one. **File-wide.** |
| SC2319 | 4 | `$?` after `[ ... ] && [ ... ]` is the *list's* status — exactly the value asserted. **Inline**, so the check stays live elsewhere. |
| SC2030/SC2031 | 2 | The token is confined to a subshell *because* the test asserts it's unexported before preflight. **Inline.** |
| SC2209 | 1 | Real fix: quoted `SIM_FAIL_OP="rm"` (a string, not a command substitution). |

Because disabling SC2329 gives up its nominal safety net, I cross-checked by hand that **every mock name still matches** a `foundation-up.sh` function or a deliberately shadowed command (`aws`, `docker`, `sudo`, `mkdir`) — a drifted name would silently exercise the real code path. None had drifted. Worth automating; I've noted it as a follow-up rather than growing this hotfix.

## Verification

- `shellcheck -x` v0.11.0 over all 8 scripts: **clean, exit 0** — run in `ubuntu:24.04` with the real pinned binary, executing the workflow step body verbatim (`mapfile` and all).
- Source resolution confirmed from **both** the repo root and `deploy/relay`.
- **Harness behavior unchanged: 64 passed, exit 0** — identical to the pre-edit file at `origin/main`. My edits are comments plus one added quote pair.
- `actionlint`: clean.

## Note for the future (needs your call)

This class of break — two green PRs that are red together — is what GitHub's **"Require branches to be up to date before merging"** branch protection setting prevents. That's a repo settings change, so I haven't touched it; happy to walk through it if you want it on.

## Review flow

Awaiting Codex review, then user merges. **Do not merge.** (Flagging that main stays red until this lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
