### PR TITLE
desktop: rank relay ladder by client-measured TCP latency

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -2,10 +2,10 @@ name: go-checks
 
 # Vet + test every Go module in the repo on each PR and push to main. This is
 # the compile/test gate for the module edges between the root module, the
-# nested punchcore module, and the two Wails app modules (which are only
-# compile-checked here: their release workflows package but never test, and
-# `./...` in desktop/ would require frontend/dist to exist, so only the Go
-# service subpackages are built).
+# nested punchcore module, and the two Wails app modules. The app modules are
+# gated on their Go service subpackages only, not `./...`, which would require
+# frontend/dist to exist; their release workflows package but never test, so
+# this is the only thing standing behind their suites.
 
 on:
   pull_request:
@@ -47,10 +47,11 @@ jobs:
           go vet ./...
           go test -race ./...
 
-      - name: desktop module (vet + build)
+      - name: desktop module (vet + test + build)
         working-directory: desktop
         run: |
           go vet ./vpnservice/...
+          go test -race ./vpnservice/... ./config/... ./discovery/... ./proxymode/...
           go build ./vpnservice/... ./config/... ./discovery/... ./proxymode/...
 
       - name: desktop-volunteer module (vet + build)

--- a/desktop/config/config.go
+++ b/desktop/config/config.go
@@ -56,6 +56,22 @@ const (
 	// reachability identically.
 	RelayTCPTimeout = 5 * time.Second
 
+	// Relay ranking: before the ladder runs, the client probes TCP connect
+	// latency to the head of the candidate list and reorders it by latency
+	// bucket (see vpnservice/ranker.go). Must stay in sync with the mobile
+	// RelayRanker constants so all three clients rank identically.
+	//
+	// RelayRankMaxProbes caps how many relays are probed; the rest keep broker
+	// order behind the probed head. RelayRankProbeTimeout is deliberately far
+	// shorter than RelayTCPTimeout: this probe only ranks, so it may give up
+	// early where the ladder's own 5s reachability gate would still succeed.
+	// RelayRankBucketMS is the width, in milliseconds, of the latency bucket
+	// within which broker order (and with it the broker's load balancing) still
+	// decides.
+	RelayRankMaxProbes    = 8
+	RelayRankProbeTimeout = 1500 * time.Millisecond
+	RelayRankBucketMS     = int64(30)
+
 	// Internet probe: a connect is reported CONNECTED only after an end-to-end
 	// HTTP probe through the tunnel succeeds. Sweeps of InternetProbeURLs are
 	// retried every InternetProbeRetryDelay until InternetProbeOverallTimeout,

--- a/desktop/vpnservice/connect_helpers.go
+++ b/desktop/vpnservice/connect_helpers.go
@@ -64,9 +64,11 @@ func flushOnShutdown(mgr *clienttelemetry.Manager) {
 }
 
 // usableRelays filters the broker response to usable candidates, preserving
-// broker order — the ordering IS the broker's ranking signal, so clients filter
-// without re-sorting (docs/api.md). Freshness is judged against broker server
-// time, like the CLI and mobile clients.
+// broker order — the ordering carries the broker's ranking, so filtering must
+// not disturb it (docs/api.md). Reordering it is a separate, deliberate step the
+// ranker owns, on a signal the broker cannot see (see ranker.go); filtering
+// itself stays order-preserving. Freshness is judged against broker server time,
+// like the CLI and mobile clients.
 func usableRelays(resp relay.ListResponse) []relay.Descriptor {
 	now := resp.ServerTime
 	if now.IsZero() {

--- a/desktop/vpnservice/ladder_test.go
+++ b/desktop/vpnservice/ladder_test.go
@@ -140,6 +140,57 @@ func logLines(s *Service) string {
 	return strings.Join(s.GetState().LogLines, "\n")
 }
 
+func TestLadderRankingSinksUnreachableRelay(t *testing.T) {
+	// The ranker probes before the ladder runs, so a relay that does not answer
+	// is tried last rather than costing the first rung its full reachability
+	// timeout. It is demoted, never dropped — and the winner's telemetry reports
+	// where it sat in broker order, so the reorder is auditable.
+	sink := newTelemetrySink(t)
+	fixtures := []relay.Descriptor{
+		relayAt("a", "JP", "Tokyo", "Japan", "127.0.0.10"),
+		relayAt("b", "SG", "", "Singapore", "127.0.0.11"),
+		relayAt("c", "DE", "Berlin", "Germany", "127.0.0.12"),
+	}
+	s, _ := newLadderService(t, func() []relay.Descriptor { return fixtures })
+	s.dialRelay = func(ctx context.Context, host string, port int) (int64, error) {
+		if host == "127.0.0.10" {
+			return 0, errors.New("relay 127.0.0.10:443 is not reachable: dial tcp: i/o timeout")
+		}
+		return 7, nil
+	}
+
+	if err := s.Connect(sink.srv.URL, "", ""); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if state := waitForStatus(t, s, StatusConnected); state.RelayLabel == nil || *state.RelayLabel != "Singapore" {
+		t.Fatalf("relayLabel = %v, want the first reachable relay", state.RelayLabel)
+	}
+	if err := s.Disconnect(); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	waitForStatus(t, s, StatusDisconnected)
+	waitIdle(t, s)
+
+	// a sank below the reachable relays, so the ladder never spent a rung on it.
+	if attempts := sink.named("relay_attempt_failed"); len(attempts) != 0 {
+		t.Fatalf("relay_attempt_failed = %+v, want none: the unreachable relay was ranked last", attempts)
+	}
+	succeeded := sink.named("connection_succeeded")
+	if len(succeeded) != 1 || succeeded[0].RelayID != "b" {
+		t.Fatalf("connection_succeeded = %+v, want relay b", succeeded)
+	}
+	meas := succeeded[0].Measurements
+	if meas["relay_attempts"] != 1 {
+		t.Fatalf("relay_attempts = %d, want 1: the winner was the ladder's first rung", meas["relay_attempts"])
+	}
+	if meas["relay_broker_index"] != 1 {
+		t.Fatalf("relay_broker_index = %d, want 1: b was the broker's second choice", meas["relay_broker_index"])
+	}
+	if got, ok := meas["relay_probe_ms"]; !ok || got != 7 {
+		t.Fatalf("relay_probe_ms = %d (present=%t), want 7", got, ok)
+	}
+}
+
 func TestLadderFailsOverToNextCandidate(t *testing.T) {
 	sink := newTelemetrySink(t)
 	fixtures := []relay.Descriptor{
@@ -151,8 +202,16 @@ func TestLadderFailsOverToNextCandidate(t *testing.T) {
 
 	// Relay a is unreachable; relay b starts but never passes the internet
 	// probe; relay c wins.
+	//
+	// The rank probe and the ladder's reachability gate share this seam, so a's
+	// first dial is the ranker's. Answer that one and fail the ladder's dial
+	// behind it: every relay then measures the same latency bucket, so ranking
+	// leaves broker order alone and the ladder still walks a's failed rung —
+	// which is what this test is about. A relay already unreachable when the
+	// ranker probes it is covered by TestLadderRankingSinksUnreachableRelay.
+	var aDials int32
 	s.dialRelay = func(ctx context.Context, host string, port int) (int64, error) {
-		if host == "127.0.0.10" {
+		if host == "127.0.0.10" && atomic.AddInt32(&aDials, 1) > 1 {
 			return 0, errors.New("relay 127.0.0.10:443 is not reachable: dial tcp: i/o timeout")
 		}
 		return 7, nil
@@ -320,6 +379,86 @@ func TestDisconnectMidLadderIsNotAFailure(t *testing.T) {
 	}
 	if ended := sink.named("connection_ended"); len(ended) != 1 || ended[0].Attributes["reason"] != "disconnect" {
 		t.Fatalf("connection_ended = %+v", ended)
+	}
+}
+
+func TestRecoveryRanksBeforeDemotingTheFailedRelay(t *testing.T) {
+	// A recovery ranks the fresh list and demotes the dead relay afterwards, so
+	// being fast cannot win back the place the demotion just took away. Relay a
+	// is both the client's fastest relay and the one whose tunnel died: if the
+	// demotion ran first and ranking second, the ranker would lift a straight
+	// back to the head and the ladder would retry the relay that just crashed —
+	// the loop the demotion exists to break.
+	sink := newTelemetrySink(t)
+	fixtures := []relay.Descriptor{
+		relayAt("a", "JP", "Tokyo", "Japan", "127.0.0.10"),
+		relayAt("b", "SG", "", "Singapore", "127.0.0.11"),
+	}
+	s, _ := newLadderService(t, func() []relay.Descriptor { return fixtures })
+	// Two buckets apart, so ranking genuinely reorders rather than falling back
+	// to broker order.
+	s.dialRelay = func(ctx context.Context, host string, port int) (int64, error) {
+		if host == "127.0.0.10" {
+			return 5, nil
+		}
+		return 80, nil
+	}
+
+	crash := make(chan error, 1)
+	var runs int32
+	s.runTunnel = func(ctx context.Context, configPath string) error {
+		if atomic.AddInt32(&runs, 1) == 1 {
+			select {
+			case err := <-crash:
+				return err
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		<-ctx.Done()
+		return nil
+	}
+
+	if err := s.Connect(sink.srv.URL, "", ""); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if state := waitForStatus(t, s, StatusConnected); state.RelayLabel == nil || *state.RelayLabel != "Tokyo, Japan" {
+		t.Fatalf("initial relayLabel = %v, want the fastest relay", state.RelayLabel)
+	}
+
+	crash <- errors.New("sing-box exited: exit status 1")
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		st := s.GetState()
+		if st.Status == StatusConnected && st.RelayLabel != nil && *st.RelayLabel == "Singapore" {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	state := s.GetState()
+	if state.Status != StatusConnected || state.RelayLabel == nil || *state.RelayLabel != "Singapore" {
+		t.Fatalf("failover landed on %+v, want relay b: the demoted relay must stay demoted however fast it measures", state)
+	}
+
+	if err := s.Disconnect(); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	waitForStatus(t, s, StatusDisconnected)
+	waitIdle(t, s)
+
+	// The failover reports the winner's rank view too, so a recovery is as
+	// auditable as an initial connect.
+	failovers := sink.named("relay_failover")
+	if len(failovers) != 1 || failovers[0].RelayID != "b" {
+		t.Fatalf("relay_failover = %+v, want one for relay b", failovers)
+	}
+	meas := failovers[0].Measurements
+	if meas["relay_broker_index"] != 1 {
+		t.Fatalf("relay_broker_index = %d, want 1", meas["relay_broker_index"])
+	}
+	if got, ok := meas["relay_probe_ms"]; !ok || got != 80 {
+		t.Fatalf("relay_probe_ms = %d (present=%t), want 80", got, ok)
 	}
 }
 

--- a/desktop/vpnservice/monitor.go
+++ b/desktop/vpnservice/monitor.go
@@ -127,7 +127,13 @@ func (s *Service) reladder(ctx context.Context, conn *connection, port int, targ
 	if err != nil {
 		return nil, 0, stage, err
 	}
-	cands = demoteRelay(cands, failedRelayID)
+	// Rank first, then demote: the relay that just died is demoted for having
+	// lost its tunnel, not for being slow, so ranking must not lift it back to
+	// the front. Demoting last keeps both invariants — the ladder is in client
+	// latency order, and the failed relay is still retried last. (Desktop-only:
+	// Android re-ranks by recursing into connect(), which has no demotion.)
+	order := s.rankLadder(ctx, cands, targetRelayID)
+	cands = demoteRelay(order.candidates(), failedRelayID)
 	s.mu.Lock()
 	conn.candidates = cands
 	conn.brokerURL = fetch.BrokerURL
@@ -137,6 +143,7 @@ func (s *Service) reladder(ctx context.Context, conn *connection, port int, targ
 	if err != nil {
 		return nil, 0, "relay_connect", err
 	}
+	order.annotate(res)
 	return res, fetchMS, "", nil
 }
 

--- a/desktop/vpnservice/ranker.go
+++ b/desktop/vpnservice/ranker.go
@@ -1,0 +1,220 @@
+package vpnservice
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"openrung/desktop/config"
+	"openrung/internal/relay"
+)
+
+// Client-side latency ranking for the relay connect ladder. Port of the mobile
+// RelayRanker (Android net/RelayRanker.kt, iOS Shared/RelayRanker.swift).
+//
+// The broker already orders relays by a composite score (load headroom, success
+// rate, latency, speed) from its own vantage; the one signal it cannot know is
+// THIS client's network path. The ranker probes TCP connect latency to the head
+// of the candidate list in parallel and reorders by latency BUCKET, so broker
+// order — and with it the broker's load balancing — still decides among relays
+// whose measured latency falls in the same bucket.
+//
+// Bucketing is what makes the reorder safe to ship: the broker's largest scoring
+// term is load headroom, and it has no admission control, so position in the
+// list is the only thing keeping clients off a saturated relay. Sorting on raw
+// latency would hand the ladder to the nearest relay for a 2ms win and herd
+// every client in a region onto it. Note the buckets are absolute (probeMs /
+// RelayRankBucketMS, truncating), not relative clusters: 29ms and 31ms fall in
+// different buckets while 31ms and 59ms share one. The compromise is coarse, not
+// exact — it bounds how often the client overrides the broker, rather than
+// overriding it only for differences a user could feel.
+//
+// Ranking is fail-open by design: it reorders candidates but never drops one. A
+// failed or timed-out probe sinks that relay below the reachable ones (the
+// ladder's own RelayTCPTimeout gate may still connect where the shorter probe
+// gave up), and candidates beyond RelayRankMaxProbes keep broker order after the
+// probed head. If every probe fails, the output is the broker's order unchanged.
+//
+// Caveat: the probe targets PublicHost, which is the exit only for relays with
+// transport "direct". IsUsableRelay gates on ExitMode, not Transport, so a
+// tunnel-transport relay can be a candidate today — and for one, PublicHost is
+// the relay hub, so its probe measures the path to the hub rather than to the
+// exit. The ladder's own relay_tcp_ms already dials the same endpoint, so
+// ranking acts on that existing inaccuracy rather than introducing a new one.
+
+// rankedRelay is a candidate plus what the ranker measured for it. probeMS is
+// nil when the relay was not probed (pinned connect, single candidate, or past
+// the probed head) or when its probe failed — which is distinct from a probe
+// that legitimately measured 0ms, since relayTCPReachable floors to whole
+// milliseconds and a nearby relay really can come back as 0.
+type rankedRelay struct {
+	relay   relay.Descriptor
+	probeMS *int64
+}
+
+// unranked marks every candidate as unprobed, preserving broker order. It is the
+// shape rankByTCPLatency returns when there is nothing to rank.
+func unranked(cands []relay.Descriptor) []rankedRelay {
+	out := make([]rankedRelay, 0, len(cands))
+	for _, cand := range cands {
+		out = append(out, rankedRelay{relay: cand})
+	}
+	return out
+}
+
+// rankByTCPLatency probes the head of cands in parallel and returns every
+// candidate — reachable ones first, ordered by latency bucket with broker order
+// preserved inside a bucket, then the probed-but-failed ones, then the unprobed
+// tail. Each probe is bounded by probeTimeout; ctx cancels the whole fan-out.
+//
+// The caller decides whether to rank at all (see Service.rankLadder): a pinned
+// relay is never reordered.
+func rankByTCPLatency(
+	ctx context.Context,
+	cands []relay.Descriptor,
+	maxProbes int,
+	probeTimeout time.Duration,
+	bucketMS int64,
+	probe func(context.Context, string, int) (int64, error),
+) []rankedRelay {
+	// Nothing to reorder: skip the probes entirely rather than open sockets whose
+	// result cannot change the ladder.
+	if len(cands) < 2 {
+		return unranked(cands)
+	}
+	if bucketMS < 1 {
+		bucketMS = 1 // every latency its own bucket; never divide by zero
+	}
+
+	head, tail := cands, []relay.Descriptor(nil)
+	if len(cands) > maxProbes {
+		head, tail = cands[:maxProbes], cands[maxProbes:]
+	}
+
+	// Probe the head concurrently: the ladder is a user-visible wait, so the cost
+	// of ranking must be one probe timeout, not the sum of them.
+	probed := make([]rankedRelay, len(head))
+	var wg sync.WaitGroup
+	for i, cand := range head {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			probed[i] = rankedRelay{relay: cand}
+			probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+			defer cancel()
+			// A failure, a timeout, and a racing disconnect all land here as a nil
+			// probeMS. That is fine: the relay keeps its place in the ladder, and a
+			// disconnect is caught by the ctx check runLadder does before its first
+			// rung — the ranker never decides a relay is unusable.
+			ms, err := probe(probeCtx, cand.PublicHost, cand.PublicPort)
+			if err != nil {
+				return
+			}
+			probed[i].probeMS = &ms
+		}()
+	}
+	wg.Wait()
+
+	// Sort the reachable relays on (bucket, broker index) rather than leaning on
+	// sort stability: the explicit index tiebreak is a total order, so it holds
+	// regardless of which sort a future refactor reaches for.
+	order := make([]int, 0, len(probed))
+	failed := make([]rankedRelay, 0, len(probed))
+	for i, p := range probed {
+		if p.probeMS == nil {
+			failed = append(failed, p)
+			continue
+		}
+		order = append(order, i)
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		lhs, rhs := order[a], order[b]
+		lhsBucket := *probed[lhs].probeMS / bucketMS
+		rhsBucket := *probed[rhs].probeMS / bucketMS
+		if lhsBucket != rhsBucket {
+			return lhsBucket < rhsBucket
+		}
+		return lhs < rhs
+	})
+
+	out := make([]rankedRelay, 0, len(cands))
+	for _, i := range order {
+		out = append(out, probed[i])
+	}
+	out = append(out, failed...)
+	return append(out, unranked(tail)...)
+}
+
+// rankLadder reorders (never shrinks) the ladder by this client's measured TCP
+// latency, returning the order to walk plus the view the winner's telemetry
+// needs. It is fail-open: it reports no error and no failure stage, because a
+// ranking that goes wrong must still leave a usable ladder. A racing disconnect
+// is caught by the ctx check runLadder does before its first rung.
+//
+// A pinned relay skips ranking: the user chose it, so there is nothing to
+// reorder. A country-targeted connect ranks within the filtered set.
+func (s *Service) rankLadder(ctx context.Context, cands []relay.Descriptor, targetRelayID string) ladderOrder {
+	order := ladderOrder{brokerOrder: cands}
+	if strings.TrimSpace(targetRelayID) != "" || len(cands) < 2 {
+		order.ranked = unranked(cands)
+		return order
+	}
+	probes := len(cands)
+	if probes > config.RelayRankMaxProbes {
+		probes = config.RelayRankMaxProbes
+	}
+	s.appendLog(fmt.Sprintf("measuring TCP latency to %d relays", probes))
+	order.ranked = rankByTCPLatency(
+		ctx,
+		cands,
+		config.RelayRankMaxProbes,
+		config.RelayRankProbeTimeout,
+		config.RelayRankBucketMS,
+		s.relayDialer(),
+	)
+	return order
+}
+
+// ladderOrder is the candidate list the ladder will walk plus the ranking view
+// that produced it: the broker's order before ranking, and what each probed
+// relay measured. It exists to answer the two questions the winner's telemetry
+// asks — where did this relay sit before the client reordered, and what did the
+// client measure for it.
+type ladderOrder struct {
+	brokerOrder []relay.Descriptor // post-filter, pre-ranking, as the broker served it
+	ranked      []rankedRelay      // ladder order; probeMS nil when unprobed
+}
+
+// candidates is the ladder order as plain descriptors.
+func (o ladderOrder) candidates() []relay.Descriptor {
+	out := make([]relay.Descriptor, 0, len(o.ranked))
+	for _, r := range o.ranked {
+		out = append(out, r.relay)
+	}
+	return out
+}
+
+// annotate stamps the winning candidate with its rank observability, so
+// connection_succeeded / relay_failover can report whether client ranking
+// actually beat broker order.
+func (o ladderOrder) annotate(res *candidateResult) {
+	if res == nil {
+		return
+	}
+	res.brokerIndex = -1
+	for i, cand := range o.brokerOrder {
+		if cand.ID == res.relay.ID {
+			res.brokerIndex = int64(i)
+			break
+		}
+	}
+	for _, r := range o.ranked {
+		if r.relay.ID == res.relay.ID {
+			res.rankProbeMS = r.probeMS
+			return
+		}
+	}
+}

--- a/desktop/vpnservice/ranker_test.go
+++ b/desktop/vpnservice/ranker_test.go
@@ -1,0 +1,329 @@
+package vpnservice
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"openrung/desktop/config"
+	"openrung/internal/relay"
+)
+
+// rankRelay builds a usable candidate whose public host identifies it, so a fake
+// probe can answer per-relay from a host-keyed table.
+func rankRelay(id string) relay.Descriptor {
+	return relayAt(id, "JP", "Tokyo", "Japan", "host-"+id)
+}
+
+func rankedIDs(ranked []rankedRelay) []string {
+	return candidateIDs(ladderOrder{ranked: ranked}.candidates())
+}
+
+// probeTable fakes the ranker's probe: a relay in the table measures its
+// latency, one absent from it fails to connect.
+func probeTable(latencies map[string]int64) func(context.Context, string, int) (int64, error) {
+	return func(_ context.Context, host string, _ int) (int64, error) {
+		ms, ok := latencies[host]
+		if !ok {
+			return 0, fmt.Errorf("relay %s is not reachable: connect timed out", host)
+		}
+		return ms, nil
+	}
+}
+
+func rank(cands []relay.Descriptor, maxProbes int, probe func(context.Context, string, int) (int64, error)) []rankedRelay {
+	return rankByTCPLatency(context.Background(), cands, maxProbes, time.Second, config.RelayRankBucketMS, probe)
+}
+
+func wantProbeMS(t *testing.T, r rankedRelay, want int64) {
+	t.Helper()
+	if r.probeMS == nil {
+		t.Fatalf("relay %s probeMS = nil, want %d", r.relay.ID, want)
+	}
+	if *r.probeMS != want {
+		t.Fatalf("relay %s probeMS = %d, want %d", r.relay.ID, *r.probeMS, want)
+	}
+}
+
+func TestRankByTCPLatencySortsByLatencyBucket(t *testing.T) {
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b"), rankRelay("c")}
+	probe := probeTable(map[string]int64{"host-a": 200, "host-b": 40, "host-c": 120})
+
+	ranked := rank(cands, config.RelayRankMaxProbes, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"b", "c", "a"}) {
+		t.Fatalf("ranked = %v, want [b c a]", ids)
+	}
+	wantProbeMS(t, ranked[0], 40)
+	wantProbeMS(t, ranked[1], 120)
+	wantProbeMS(t, ranked[2], 200)
+}
+
+func TestRankByTCPLatencyKeepsBrokerOrderWithinBucket(t *testing.T) {
+	// 31 and 45 share the 30ms bucket, so broker order (a before b) must survive
+	// even though b measured marginally faster — within a bucket the broker's
+	// load balancing still decides. 95 lands two buckets up and sorts last.
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b"), rankRelay("c")}
+	probe := probeTable(map[string]int64{"host-a": 45, "host-b": 31, "host-c": 95})
+
+	ranked := rank(cands, config.RelayRankMaxProbes, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"a", "b", "c"}) {
+		t.Fatalf("ranked = %v, want [a b c]", ids)
+	}
+}
+
+func TestRankByTCPLatencySinksFailedProbesWithoutDropping(t *testing.T) {
+	// Fail-open: a relay whose probe failed sinks below the reachable ones but
+	// stays in the ladder — the ladder's own 5s gate may still connect where the
+	// 1.5s probe gave up.
+	cands := []relay.Descriptor{rankRelay("dead"), rankRelay("slow"), rankRelay("fast")}
+	probe := probeTable(map[string]int64{"host-slow": 400, "host-fast": 20})
+
+	ranked := rank(cands, config.RelayRankMaxProbes, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"fast", "slow", "dead"}) {
+		t.Fatalf("ranked = %v, want [fast slow dead]", ids)
+	}
+	if ranked[2].probeMS != nil {
+		t.Fatalf("failed relay probeMS = %d, want nil", *ranked[2].probeMS)
+	}
+}
+
+func TestRankByTCPLatencyAllProbesFailingKeepsBrokerOrder(t *testing.T) {
+	// The ranker never makes things worse: if nothing answers, the ladder is the
+	// broker's list unchanged.
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b"), rankRelay("c")}
+
+	ranked := rank(cands, config.RelayRankMaxProbes, probeTable(nil))
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"a", "b", "c"}) {
+		t.Fatalf("ranked = %v, want broker order [a b c]", ids)
+	}
+}
+
+func TestRankByTCPLatencyKeepsUnprobedTailInBrokerOrder(t *testing.T) {
+	cands := []relay.Descriptor{rankRelay("r1"), rankRelay("r2"), rankRelay("r3"), rankRelay("r4"), rankRelay("r5")}
+	// Probe only the first three, reversing their latency so the head visibly
+	// reorders while the tail must not move.
+	probe := probeTable(map[string]int64{"host-r1": 300, "host-r2": 150, "host-r3": 10})
+
+	ranked := rank(cands, 3, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"r3", "r2", "r1", "r4", "r5"}) {
+		t.Fatalf("ranked = %v, want [r3 r2 r1 r4 r5]", ids)
+	}
+	if ranked[3].probeMS != nil || ranked[4].probeMS != nil {
+		t.Fatal("unprobed tail carries a probe measurement")
+	}
+}
+
+func TestRankByTCPLatencySinksFailedProbesAboveTheUnprobedTail(t *testing.T) {
+	// A relay we probed and could not reach still outranks one we never probed:
+	// the tail may be anything, while a failed probe is only evidence of
+	// slowness. Ordering the two groups the other way round would bury the tail
+	// behind relays already known to be unreachable.
+	cands := []relay.Descriptor{rankRelay("r1"), rankRelay("r2"), rankRelay("r3"), rankRelay("r4"), rankRelay("r5")}
+	probe := probeTable(map[string]int64{"host-r2": 150, "host-r3": 10}) // r1 unreachable
+
+	ranked := rank(cands, 3, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"r3", "r2", "r1", "r4", "r5"}) {
+		t.Fatalf("ranked = %v, want [r3 r2 r1 r4 r5]: failed probes above the unprobed tail", ids)
+	}
+}
+
+func TestRankByTCPLatencySingleCandidateSkipsProbe(t *testing.T) {
+	var probes int32
+	probe := func(context.Context, string, int) (int64, error) {
+		atomic.AddInt32(&probes, 1)
+		return 10, nil
+	}
+
+	ranked := rank([]relay.Descriptor{rankRelay("only")}, config.RelayRankMaxProbes, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"only"}) {
+		t.Fatalf("ranked = %v, want [only]", ids)
+	}
+	if ranked[0].probeMS != nil {
+		t.Fatal("single candidate was probed")
+	}
+	if got := atomic.LoadInt32(&probes); got != 0 {
+		t.Fatalf("probes = %d, want 0: nothing to reorder, so nothing to probe", got)
+	}
+}
+
+func TestRankByTCPLatencyZeroMillisecondProbeRanksAsReachable(t *testing.T) {
+	// relayTCPReachable floors to whole milliseconds, so a very close relay
+	// really does measure 0. It must rank as the fastest reachable relay, not be
+	// mistaken for one that was never probed.
+	cands := []relay.Descriptor{rankRelay("far"), rankRelay("near"), rankRelay("dead")}
+	probe := probeTable(map[string]int64{"host-far": 90, "host-near": 0})
+
+	ranked := rank(cands, config.RelayRankMaxProbes, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"near", "far", "dead"}) {
+		t.Fatalf("ranked = %v, want [near far dead]", ids)
+	}
+	wantProbeMS(t, ranked[0], 0)
+}
+
+func TestRankByTCPLatencyProbesConcurrently(t *testing.T) {
+	// Ranking costs the user one probe timeout, not the sum of them. The barrier
+	// asserts simultaneity directly: every probe must be in flight before any may
+	// return, which a sequential ranker can never satisfy at any duration. There
+	// is no elapsed-time assert here, so there is nothing to flake.
+	const want = 4
+	cands := []relay.Descriptor{rankRelay("r1"), rankRelay("r2"), rankRelay("r3"), rankRelay("r4")}
+
+	arrived := make(chan struct{}, want)
+	release := make(chan struct{})
+	probe := func(context.Context, string, int) (int64, error) {
+		arrived <- struct{}{}
+		<-release
+		return 10, nil
+	}
+
+	done := make(chan []rankedRelay, 1)
+	go func() { done <- rank(cands, config.RelayRankMaxProbes, probe) }()
+
+	for i := 0; i < want; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of %d probes were in flight; probes are running sequentially", i, want)
+		}
+	}
+	close(release)
+
+	select {
+	case ranked := <-done:
+		if len(ranked) != want {
+			t.Fatalf("ranked = %v, want all %d candidates", rankedIDs(ranked), want)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ranker never returned after the barrier released")
+	}
+}
+
+func TestRankByTCPLatencyBoundsEveryProbeByTheRankTimeout(t *testing.T) {
+	// A black-holed relay must not stall the connect: the rank probe carries its
+	// own deadline rather than inheriting the ladder's longer reachability
+	// budget. A probe that only returns when its ctx expires proves the bound —
+	// without it this test would hang rather than fail.
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b")}
+	probe := func(ctx context.Context, _ string, _ int) (int64, error) {
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+
+	ranked := rankByTCPLatency(context.Background(), cands, config.RelayRankMaxProbes, time.Millisecond, config.RelayRankBucketMS, probe)
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"a", "b"}) {
+		t.Fatalf("ranked = %v, want broker order [a b]", ids)
+	}
+}
+
+func TestRankByTCPLatencyCancelledContextKeepsEveryCandidate(t *testing.T) {
+	// A disconnect racing the ranker must not be read as "these relays are
+	// unusable" — the ladder still receives every candidate, and runLadder's own
+	// ctx check is what ends the connect.
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b"), rankRelay("c")}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ranked := rankByTCPLatency(ctx, cands, config.RelayRankMaxProbes, time.Second, config.RelayRankBucketMS,
+		func(ctx context.Context, _ string, _ int) (int64, error) {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		})
+
+	if ids := rankedIDs(ranked); !equalIDs(ids, []string{"a", "b", "c"}) {
+		t.Fatalf("ranked = %v, want every candidate in broker order", ids)
+	}
+}
+
+func TestRankLadderSkipsPinnedRelay(t *testing.T) {
+	// The guard keys off the pinned id, not the list length, mirroring mobile: a
+	// relay the user chose is never reordered, however many candidates the filter
+	// happened to return.
+	s := New()
+	var probes int32
+	s.dialRelay = func(context.Context, string, int) (int64, error) {
+		atomic.AddInt32(&probes, 1)
+		return 1, nil
+	}
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b")}
+
+	order := s.rankLadder(context.Background(), cands, "b")
+
+	if ids := candidateIDs(order.candidates()); !equalIDs(ids, []string{"a", "b"}) {
+		t.Fatalf("pinned ladder = %v, want broker order [a b]", ids)
+	}
+	if got := atomic.LoadInt32(&probes); got != 0 {
+		t.Fatalf("probes = %d, want 0: a pinned relay is not ranked", got)
+	}
+}
+
+func TestRankLadderRanksCountryTargetedConnect(t *testing.T) {
+	// A country target narrows the set; ranking still applies within it.
+	s := New()
+	s.dialRelay = probeTable(map[string]int64{"host-a": 200, "host-b": 20})
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b")}
+
+	order := s.rankLadder(context.Background(), cands, "")
+
+	if ids := candidateIDs(order.candidates()); !equalIDs(ids, []string{"b", "a"}) {
+		t.Fatalf("ranked ladder = %v, want [b a]", ids)
+	}
+}
+
+func TestLadderOrderAnnotateReportsBrokerIndexAndProbe(t *testing.T) {
+	// The winner's telemetry must say where it sat before the client reordered.
+	cands := []relay.Descriptor{rankRelay("a"), rankRelay("b"), rankRelay("c")}
+	order := ladderOrder{
+		brokerOrder: cands,
+		ranked:      rank(cands, config.RelayRankMaxProbes, probeTable(map[string]int64{"host-a": 200, "host-b": 40, "host-c": 120})),
+	}
+
+	res := &candidateResult{relay: rankRelay("b"), brokerIndex: -1}
+	order.annotate(res)
+
+	if res.brokerIndex != 1 {
+		t.Fatalf("brokerIndex = %d, want 1", res.brokerIndex)
+	}
+	if res.rankProbeMS == nil || *res.rankProbeMS != 40 {
+		t.Fatalf("rankProbeMS = %v, want 40", res.rankProbeMS)
+	}
+}
+
+func TestLadderOrderAnnotateLeavesProbeAbsentForUnrankedLadder(t *testing.T) {
+	// A pinned connect is not probed, so it reports its broker position and no
+	// probe measurement — never a fabricated zero.
+	cands := []relay.Descriptor{rankRelay("a")}
+	order := ladderOrder{brokerOrder: cands, ranked: unranked(cands)}
+
+	res := &candidateResult{relay: rankRelay("a"), brokerIndex: -1}
+	order.annotate(res)
+
+	if res.brokerIndex != 0 {
+		t.Fatalf("brokerIndex = %d, want 0", res.brokerIndex)
+	}
+	if res.rankProbeMS != nil {
+		t.Fatalf("rankProbeMS = %d, want nil for an unranked ladder", *res.rankProbeMS)
+	}
+}
+
+func equalIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/desktop/vpnservice/service.go
+++ b/desktop/vpnservice/service.go
@@ -88,7 +88,8 @@ type connection struct {
 	// is still trying candidates or after a teardown. Only the runConnect
 	// goroutine assigns and tears it down; mu guards the pointer for readers.
 	active *candidateResult
-	// candidates is the last fetched usable+filtered list, in broker order. A
+	// candidates is the last fetched usable+filtered list in ladder order —
+	// client-latency ranked, with a recovery's failed relay demoted last. A
 	// recovery re-ladder replaces it.
 	candidates    []relay.Descriptor
 	activeRelayID string
@@ -115,6 +116,13 @@ type candidateResult struct {
 	startMS    int64
 	probeMS    int64
 	attempt    int64 // 1-based index in the ladder that produced it
+	// brokerIndex is where this relay sat in the broker's order before client
+	// ranking reordered the ladder; -1 until ladderOrder.annotate stamps it, so
+	// an unannotated result never claims it was the broker's first choice.
+	brokerIndex int64
+	// rankProbeMS is the ranker's measured TCP latency, nil when this relay was
+	// not probed or its probe failed.
+	rankProbeMS *int64
 }
 
 // teardown releases a candidate's resources in the pinned order: cancel the
@@ -466,18 +474,21 @@ func (s *Service) connectFlow(ctx context.Context, conn *connection, brokerURL, 
 	if err != nil {
 		return stage, err
 	}
+	order := s.rankLadder(ctx, cands, targetRelayID)
+	ladder := order.candidates()
 	s.mu.Lock()
-	conn.candidates = cands
+	conn.candidates = ladder
 	conn.brokerURL = fetch.BrokerURL
 	s.mu.Unlock()
 
-	res, err := s.runLadder(ctx, conn, cands, port)
+	res, err := s.runLadder(ctx, conn, ladder, port)
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", nil
 		}
 		return "relay_connect", err
 	}
+	order.annotate(res)
 	// The OS proxy is pointed at the tunnel only once a candidate is proven, so
 	// a fully failing ladder never blackholes the user's traffic — it falls
 	// back to the normal network instead (contract: availability over leak).
@@ -541,10 +552,12 @@ func (s *Service) candidatesFor(resp relay.ListResponse, targetCountry, targetRe
 	return cands, "", nil
 }
 
-// runLadder walks the candidates in broker order, fully tearing down each
-// failed candidate before trying the next — sequential by construction, since
-// the shared loopback port cannot be rebound until the previous sing-box is
-// reaped. Mirrors the mobile connectFirstAvailable.
+// runLadder walks the candidates in the order it is given — ladder order, which
+// rankLadder decides (see ranker.go); broker order only survives where ranking
+// does not apply. Each failed candidate is fully torn down before the next is
+// tried: sequential by construction, since the shared loopback port cannot be
+// rebound until the previous sing-box is reaped. Mirrors the mobile
+// connectFirstAvailable.
 func (s *Service) runLadder(ctx context.Context, conn *connection, cands []relay.Descriptor, port int) (*candidateResult, error) {
 	var lastErr error
 	for i, cand := range cands {
@@ -581,7 +594,7 @@ func (s *Service) attemptCandidate(ctx context.Context, conn *connection, cand r
 	}
 
 	candCtx, cancel := context.WithCancel(ctx)
-	res := &candidateResult{relay: cand, ctx: candCtx, cancel: cancel, proxyPort: port, tcpMS: tcpMS, attempt: int64(attempt)}
+	res := &candidateResult{relay: cand, ctx: candCtx, cancel: cancel, proxyPort: port, tcpMS: tcpMS, attempt: int64(attempt), brokerIndex: -1}
 
 	// Try a direct NAT-punched path first; on any failure fall back to the
 	// relay hub endpoint so the outcome is never worse than not punching.
@@ -639,13 +652,23 @@ func (s *Service) attemptCandidate(ctx context.Context, conn *connection, cand r
 // initial connection_succeeded or a recovery relay_failover so the broker's
 // relay ranking credits the relay that actually carried the connection.
 func connectMeasurements(res *candidateResult, brokerFetchMS int64) map[string]int64 {
-	return map[string]int64{
+	m := map[string]int64{
 		"broker_fetch_ms":   brokerFetchMS,
 		"relay_tcp_ms":      res.tcpMS,
 		"tunnel_start_ms":   res.startMS,
 		"internet_probe_ms": res.probeMS,
 		"relay_attempts":    res.attempt,
+		// Rank observability: where the winning relay sat in broker order before
+		// ranking, and what the ranker measured for it — the pair that shows
+		// whether client-side ranking actually beats broker order on
+		// tunnel_start_ms. relay_probe_ms is absent, never zero, when the relay
+		// was not probed: 0ms is a legitimate measurement.
+		"relay_broker_index": res.brokerIndex,
 	}
+	if res.rankProbeMS != nil {
+		m["relay_probe_ms"] = *res.rankProbeMS
+	}
+	return m
 }
 
 // promote adopts a winning candidate as the live tunnel: it marks CONNECTED with

--- a/docs/api.md
+++ b/docs/api.md
@@ -384,9 +384,18 @@ GET /api/v1/relays?limit=5
 
 The order of `relays` is the broker's candidate ranking. In global ranking mode,
 the broker uses recent active sessions, connection successes/failures, observed
-client latency, and speed-test telemetry. IPv6 is only a final tie-breaker after
-score and heartbeat recency. Clients should filter unusable descriptors without
-reordering the broker-ranked list.
+client latency, and speed-test telemetry. The latency it scores is aggregated
+across all clients, so it cannot describe any one client's path. IPv6 is only a
+final tie-breaker after score and heartbeat recency. `limit` truncates *after*
+ranking, so membership of the returned set — unlike the order within it — is
+decided entirely by the broker.
+
+Clients should filter unusable descriptors without reordering the broker-ranked
+list. A client may reorder on a signal the broker cannot observe — notably the
+connecting client's own network path — provided broker order is preserved among
+candidates that measure comparably (for example, within one latency bucket), so
+the broker's load-balancing term still decides between them. Ranking must
+reorder, never exclude: a client must not drop a relay on a local measurement.
 
 The PostgreSQL relay-state schema also keeps JSONB escape hatches for fields
 that are still experimental: `relay_descriptors.attributes`,


### PR DESCRIPTION
Ports the mobile `RelayRanker` ([openrung-mobile-app 7939fba, PR #45](https://github.com/openrung/openrung-mobile-app/pull/45)) to the desktop client, so all three clients pick a relay the same way.

## What it does

The broker orders relays by a composite score (load headroom, success rate, latency, speed) from *its* vantage. The one signal it cannot know is the connecting client's network path. On connect, the client now probes TCP latency to the head of the candidate ladder in parallel and reorders it — then the ladder runs as before.

| | |
|---|---|
| Probes | head of the ladder, max 8, in parallel |
| Probe timeout | 1500ms (the ladder's own gate stays 5s) |
| Bucket | 30ms |

Constants live in `desktop/config` and must stay in sync with mobile.

**Reordering is by latency *bucket*, not raw latency.** Load headroom is the broker's largest scoring term (0.45) and there is *no admission control*, so position in the list is the only thing keeping clients off a saturated relay. Sorting on raw latency would hand the ladder to the nearest relay for a 2ms win and herd a region onto it. Within a bucket, broker order — and its load balancing — still decides.

**Fail-open**: ranking reorders, never drops. Failed probes sink below reachable relays but stay (the 5s gate may still connect where a 1.5s probe gave up); candidates past the probed head keep broker order; if every probe fails the ladder is broker order unchanged. Pinned connects skip ranking; country-targeted connects rank within the filtered set.

## Decisions worth a look

**Recovery ranks, and demotes *after* ranking.** Desktop-only — Android re-ranks by recursing into `connect()`, which has no demotion concept. Demoting first would let the relay that just lost its tunnel measure fastest and win its place straight back, retrying the crash loop the demotion exists to break. `TestRecoveryRanksBeforeDemotingTheFailedRelay` pins it; with the steps inverted it fails with `failed over from relay a to a`.

**`docs/api.md` is updated.** It said clients "should filter unusable descriptors without reordering the broker-ranked list". That's a SHOULD (the doc reserves MUST for signature/freshness), so ranking is within the contract — but the sentence no longer describes what any client does; mobile has deviated since 7939fba without a doc change. It now documents the actual rule: a client may reorder on a signal the broker cannot observe, provided broker order survives among comparable candidates, and must never *exclude* on a local measurement. The `usableRelays` comment, which had hardened that SHOULD into a flat prohibition it attributed to the doc, is corrected too.

**Two mobile comments were corrected rather than copied.** Mobile says no tunnel-transport relay can reach the ranker — counterfactual: `IsUsableRelay` gates on `ExitMode`, not `Transport`, so one can be a candidate today, and for it `PublicHost` is the hub. The ladder's existing `relay_tcp_ms` already dials that same endpoint, so ranking acts on a pre-existing inaccuracy rather than a new one. Mobile's "only humanly meaningful differences override the broker" is also false pairwise: buckets are absolute, so 29ms/31ms split while 31ms/59ms share.

**`relay_probe_ms` is absent, not zero, when unprobed.** `relayTCPReachable` floors to whole milliseconds, so a nearby relay genuinely measures 0 — a `> 0` guard would silently drop the fastest relays.

## Telemetry

`connection_succeeded` and `relay_failover` gain `relay_broker_index` + `relay_probe_ms` — the pair that shows whether client ranking actually beats broker order on `tunnel_start_ms`, before we tune the bucket width. Both flow through the broker's free-form measurements map: **no ingest, migration, or dashboard change needed** to land them or query them.

## Out of scope, but included

`go-checks.yml` now runs the desktop suite. It was vet+build only, so the entire `vpnservice` suite — this ranker included — would never have run in CI. Scoped to the Go service subpackages, since `./...` needs `frontend/dist`.

## Verification

- `go vet` + `go test -race` green across the desktop and root modules; `gofmt` clean.
- 16 new tests mirroring the 6 Android cases, plus desktop-specific ones (0ms probe, probe-timeout bound, cancellation, failed-vs-tail ordering, the recovery invariant).
- The new tests were **mutation-checked** — `demote-then-rank`, `tail-before-failed`, and `raw-latency-sort` each make them fail.
- `TestLadderFailsOverToNextCandidate` needed a touch: the rank probe and the ladder's gate share the `dialRelay` seam, so relay `a`'s first dial is now the ranker's. It answers that one and fails the dial behind it, which keeps every original assertion intact. The case where a relay is already unreachable when the ranker probes it — where ranking now saves the ladder a wasted rung — is covered by the new `TestLadderRankingSinksUnreachableRelay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)