### PR TITLE
desktop: release client version 0.1.3

### DIFF
--- a/.github/workflows/desktop-frontend.yml
+++ b/.github/workflows/desktop-frontend.yml
@@ -9,11 +9,15 @@ on:
     branches: [main]
     paths:
       - "desktop/frontend/**"
+      - "desktop/scripts/**"
+      - "desktop/wails.json"
       - "LICENSE"
       - ".github/workflows/desktop-frontend.yml"
   pull_request:
     paths:
       - "desktop/frontend/**"
+      - "desktop/scripts/**"
+      - "desktop/wails.json"
       - "LICENSE"
       - ".github/workflows/desktop-frontend.yml"
 
@@ -37,6 +41,10 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Test build version wiring
+        working-directory: desktop
+        run: node --test scripts/versioned-wails-build.test.mjs
 
       - name: Typecheck and build
         run: npm run build

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -22,7 +22,40 @@ env:
   SING_BOX_VERSION: ${{ github.event.inputs.singbox_version || '1.14.0-alpha.35' }}
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      product_version: ${{ steps.version.outputs.product_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: version
+        name: Validate desktop version and release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! product_version="$(jq -er '.info.productVersion | select(type == "string")' desktop/wails.json)"; then
+            echo "desktop/wails.json info.productVersion must be a string" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$product_version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "invalid desktop/wails.json info.productVersion \"$product_version\" (want X.Y.Z)" >&2
+            exit 1
+          fi
+
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            expected_tag="v$product_version"
+            if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
+              echo "desktop release tag $GITHUB_REF_NAME disagrees with desktop/wails.json info.productVersion ($product_version); expected $expected_tag" >&2
+              exit 1
+            fi
+          fi
+
+          echo "product_version=$product_version" >> "$GITHUB_OUTPUT"
+          echo "desktop/wails.json info.productVersion -> $product_version"
+
   build:
+    needs: version
     strategy:
       fail-fast: false
       matrix:
@@ -99,10 +132,11 @@ jobs:
           if-no-files-found: error
 
   # Publish a GitHub Release with all three binaries attached. Runs only for
-  # `v*` tag pushes (not manual dispatch, which stays artifact-only for testing).
-  # Requires all three build jobs to succeed — we don't ship a partial release.
+  # desktop `vX.Y.Z` tag pushes (not manual dispatch, which stays artifact-only
+  # for testing). Requires version validation and all three build jobs to
+  # succeed — we don't ship a partial release.
   release:
-    needs: build
+    needs: [version, build]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -117,7 +151,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: OpenRung Desktop ${{ github.ref_name }}
+          name: OpenRung Desktop v${{ needs.version.outputs.product_version }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           go-version: '1.25.x'
 
+      # For the desktop version injection contract below.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Component version sources
         run: |
           for file in cmd/relay/VERSION cmd/relayhub/VERSION cmd/broker/VERSION desktop-volunteer/VERSION; do
@@ -64,6 +69,16 @@ jobs:
           go vet ./vpnservice/...
           go test -race ./vpnservice/... ./config/... ./discovery/... ./proxymode/...
           go build ./vpnservice/... ./config/... ./discovery/... ./proxymode/...
+
+      # The desktop packaging script stamps the build version by setting
+      # openrung/internal/client.appVersion with -X, but the linker silently
+      # ignores -X for a symbol it cannot resolve. Renaming that variable would
+      # otherwise leave every release reporting "dev" with this whole job green.
+      # Belongs here, not in desktop-frontend.yml: it needs Go, and it has to
+      # run when internal/client changes.
+      - name: Desktop version injection contract
+        working-directory: desktop
+        run: node --test scripts/version-injection.test.mjs
 
       - name: desktop-volunteer module (vet + test)
         working-directory: desktop-volunteer

--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "openrung-desktop-frontend",
-  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrung-desktop-frontend",
-      "version": "0.1.0",
       "dependencies": {
         "maplibre-gl": "^4.7.1",
         "react": "^19.2.0",

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,7 +1,6 @@
 {
   "name": "openrung-desktop-frontend",
   "private": true,
-  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/frontend/src/app-version.d.ts
+++ b/desktop/frontend/src/app-version.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/desktop/frontend/src/core/config.test.ts
+++ b/desktop/frontend/src/core/config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import wailsConfig from '../../../wails.json';
+import { APP_VERSION } from './config';
+
+describe('APP_VERSION', () => {
+  it('comes from the Wails product version', () => {
+    expect(APP_VERSION).toBe(wailsConfig.info.productVersion);
+  });
+});

--- a/desktop/frontend/src/core/config.ts
+++ b/desktop/frontend/src/core/config.ts
@@ -20,4 +20,4 @@ export const AppConfig = {
 } as const;
 
 /** App version shown on the About screen. */
-export const APP_VERSION = '0.1.0';
+export const APP_VERSION = __APP_VERSION__;

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -1,8 +1,30 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+interface WailsConfig {
+  info?: {
+    productVersion?: unknown;
+  };
+}
+
+const wailsConfig = JSON.parse(
+  readFileSync(new URL('../wails.json', import.meta.url), 'utf8'),
+) as WailsConfig;
+const appVersion = wailsConfig.info?.productVersion;
+
+if (
+  typeof appVersion !== 'string' ||
+  !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(appVersion)
+) {
+  throw new Error('desktop/wails.json info.productVersion must be a semantic X.Y.Z version');
+}
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   server: {
     port: 5173,
     strictPort: true,

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -1,24 +1,12 @@
-import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+// Shared with the packaging scripts, so the frontend and the Go binary cannot
+// disagree about what counts as a valid version or where it comes from. Reads
+// and validates desktop/wails.json, throwing if info.productVersion is missing
+// or not a strict X.Y.Z.
+import { readProductVersion } from '../scripts/versioned-wails-build.mjs';
 
-interface WailsConfig {
-  info?: {
-    productVersion?: unknown;
-  };
-}
-
-const wailsConfig = JSON.parse(
-  readFileSync(new URL('../wails.json', import.meta.url), 'utf8'),
-) as WailsConfig;
-const appVersion = wailsConfig.info?.productVersion;
-
-if (
-  typeof appVersion !== 'string' ||
-  !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(appVersion)
-) {
-  throw new Error('desktop/wails.json info.productVersion must be a semantic X.Y.Z version');
-}
+const appVersion: string = readProductVersion();
 
 export default defineConfig({
   plugins: [react()],

--- a/desktop/scripts/package-linux.sh
+++ b/desktop/scripts/package-linux.sh
@@ -22,8 +22,7 @@ if [[ -z "${SINGBOX}" || ! -x "${SINGBOX}" ]]; then
 fi
 
 export PATH="${PATH}:$(go env GOPATH)/bin"
-echo "==> wails build ${*:-}"
-wails build "$@"
+node scripts/versioned-wails-build.mjs "$@"
 
 BIN="build/bin/OpenRung"
 [[ -x "${BIN}" ]] || { echo "error: ${BIN} not found after build" >&2; exit 1; }

--- a/desktop/scripts/package-macos.sh
+++ b/desktop/scripts/package-macos.sh
@@ -22,8 +22,7 @@ fi
 
 export PATH="${PATH}:$(go env GOPATH)/bin"
 
-echo "==> wails build ${*:-}"
-wails build "$@"
+node scripts/versioned-wails-build.mjs "$@"
 
 APP="build/bin/OpenRung.app"
 RES="${APP}/Contents/Resources"

--- a/desktop/scripts/package-windows.ps1
+++ b/desktop/scripts/package-windows.ps1
@@ -17,8 +17,8 @@ if (-not $singbox -or -not (Test-Path $singbox)) {
 }
 
 $env:PATH = "$env:PATH;$(go env GOPATH)\bin"
-Write-Host "==> wails build $args"
-wails build @args
+& node scripts/versioned-wails-build.mjs @args
+if ($LASTEXITCODE -ne 0) { throw "wails build failed with exit code $LASTEXITCODE" }
 
 $exe = 'build\bin\OpenRung.exe'
 if (-not (Test-Path $exe)) { Write-Error "$exe not found after build"; exit 1 }

--- a/desktop/scripts/version-injection.test.mjs
+++ b/desktop/scripts/version-injection.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { versionedWailsBuildArgs } from './versioned-wails-build.mjs';
+
+const desktopDirectory = fileURLToPath(new URL('..', import.meta.url));
+
+// Lives apart from versioned-wails-build.test.mjs because it needs a Go
+// toolchain: it runs under go-checks, not the frontend workflow.
+//
+// The Go linker silently ignores -X for a symbol it cannot resolve — the build
+// still succeeds and the variable keeps its default. So renaming appVersion,
+// moving its package, or dropping the import from the desktop binary would
+// leave every release reporting "dev" to broker telemetry while the About
+// screen still showed the right number (the frontend reads wails.json
+// independently) and every other check stayed green. Link the probe with the
+// flags the packaging script really produces and read the value back.
+test('the packaging ldflags actually set the Go app version', () => {
+  const probeVersion = '9.9.9';
+  const args = versionedWailsBuildArgs([], probeVersion);
+  const ldflags = args[args.indexOf('-ldflags') + 1];
+
+  const result = spawnSync('go', ['run', '-ldflags', ldflags, './scripts/versionprobe'], {
+    cwd: desktopDirectory,
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.error, undefined, `could not run go: ${result.error?.message}`);
+  assert.equal(result.status, 0, `go run failed: ${result.stderr}`);
+  assert.equal(
+    result.stdout.trim(),
+    probeVersion,
+    'the injected -X flag did not reach client.AppVersion(); the symbol path in ' +
+      'versioned-wails-build.mjs no longer resolves, so releases would report "dev"',
+  );
+});

--- a/desktop/scripts/versioned-wails-build.mjs
+++ b/desktop/scripts/versioned-wails-build.mjs
@@ -1,6 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const configPath = fileURLToPath(new URL('../wails.json', import.meta.url));
@@ -76,7 +75,23 @@ function main() {
   process.exitCode = result.status ?? 1;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+// Realpath both sides: Node resolves symlinks for the ESM entry point but not
+// for argv[1], so through a symlinked checkout this would silently skip main()
+// and exit 0 — leaving the packaging scripts to ship whatever stale binary was
+// already in build/bin.
+function isEntryPoint() {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(entry)).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isEntryPoint()) {
   try {
     main();
   } catch (error) {

--- a/desktop/scripts/versioned-wails-build.mjs
+++ b/desktop/scripts/versioned-wails-build.mjs
@@ -1,0 +1,86 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const configPath = fileURLToPath(new URL('../wails.json', import.meta.url));
+const semanticVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const appVersionVariable = 'openrung/internal/client.appVersion';
+
+export function productVersionFromConfig(config, source = 'desktop/wails.json') {
+  const version = config?.info?.productVersion;
+  if (typeof version !== 'string' || !semanticVersion.test(version)) {
+    throw new Error(`${source} info.productVersion must be a semantic X.Y.Z version`);
+  }
+  return version;
+}
+
+export function readProductVersion(source = configPath) {
+  let config;
+  try {
+    config = JSON.parse(readFileSync(source, 'utf8'));
+  } catch (error) {
+    throw new Error(`cannot read ${source}: ${error.message}`, { cause: error });
+  }
+  return productVersionFromConfig(config, source);
+}
+
+export function versionedWailsBuildArgs(args, version) {
+  productVersionFromConfig({ info: { productVersion: version } }, 'build version');
+
+  const passthrough = [];
+  const callerLdflags = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '-ldflags' || argument === '--ldflags') {
+      if (index + 1 >= args.length) {
+        throw new Error(`${argument} requires a value`);
+      }
+      callerLdflags.push(args[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    const equalsForm = ['-ldflags=', '--ldflags='].find((prefix) => argument.startsWith(prefix));
+    if (equalsForm !== undefined) {
+      callerLdflags.push(argument.slice(equalsForm.length));
+      continue;
+    }
+
+    passthrough.push(argument);
+  }
+
+  // Keep caller flags, but append the source-of-truth assignment last so a
+  // caller cannot accidentally replace the version from wails.json.
+  const versionLdflag = `-X ${appVersionVariable}=${version}`;
+  const ldflags = [...callerLdflags.filter((value) => value.trim() !== ''), versionLdflag].join(' ');
+  return [...passthrough, '-ldflags', ldflags];
+}
+
+function displayArgument(argument) {
+  return /\s/.test(argument) ? JSON.stringify(argument) : argument;
+}
+
+function main() {
+  const version = readProductVersion();
+  const args = versionedWailsBuildArgs(process.argv.slice(2), version);
+  console.log(`==> wails build ${args.map(displayArgument).join(' ')}`);
+
+  const result = spawnSync('wails', ['build', ...args], { stdio: 'inherit' });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.signal !== null) {
+    throw new Error(`wails build terminated by ${result.signal}`);
+  }
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/desktop/scripts/versioned-wails-build.test.mjs
+++ b/desktop/scripts/versioned-wails-build.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  productVersionFromConfig,
+  readProductVersion,
+  versionedWailsBuildArgs,
+} from './versioned-wails-build.mjs';
+
+test('reads the product version from wails.json', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'openrung-version-'));
+  const source = join(directory, 'wails.json');
+  try {
+    writeFileSync(source, JSON.stringify({ info: { productVersion: '4.5.6' } }));
+    assert.equal(readProductVersion(source), '4.5.6');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('accepts only canonical X.Y.Z product versions', () => {
+  assert.equal(productVersionFromConfig({ info: { productVersion: '0.1.3' } }), '0.1.3');
+
+  for (const productVersion of [undefined, 13, '', 'v0.1.3', '0.1', '0.1.3-beta.1', '01.2.3', ' 0.1.3']) {
+    assert.throws(
+      () => productVersionFromConfig({ info: { productVersion } }),
+      /info\.productVersion must be a semantic X\.Y\.Z version/,
+    );
+  }
+});
+
+test('injects the product version while preserving other build arguments', () => {
+  assert.deepEqual(versionedWailsBuildArgs(['-tags', 'webkit2_41'], '0.1.3'), [
+    '-tags',
+    'webkit2_41',
+    '-ldflags',
+    '-X openrung/internal/client.appVersion=0.1.3',
+  ]);
+});
+
+test('merges separate and equals-form caller ldflags before the product version', () => {
+  assert.deepEqual(
+    versionedWailsBuildArgs(
+      ['-ldflags', '-s -w', '-debug', '-ldflags=-X openrung/internal/client.appVersion=custom'],
+      '0.1.3',
+    ),
+    [
+      '-debug',
+      '-ldflags',
+      '-s -w -X openrung/internal/client.appVersion=custom -X openrung/internal/client.appVersion=0.1.3',
+    ],
+  );
+});
+
+test('rejects a caller ldflags option without a value', () => {
+  assert.throws(() => versionedWailsBuildArgs(['-ldflags'], '0.1.3'), /-ldflags requires a value/);
+});

--- a/desktop/scripts/versionprobe/main.go
+++ b/desktop/scripts/versionprobe/main.go
@@ -1,0 +1,14 @@
+// Command versionprobe prints the app version linked into it, and exists only
+// so CI can prove the -X symbol path in scripts/versioned-wails-build.mjs
+// still resolves. See scripts/version-injection.test.mjs.
+package main
+
+import (
+	"fmt"
+
+	"openrung/internal/client"
+)
+
+func main() {
+	fmt.Println(client.AppVersion())
+}

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -11,6 +11,7 @@
   },
   "info": {
     "productName": "OpenRung",
+    "productVersion": "0.1.3",
     "copyright": "OpenRung contributors. GPL-3.0-or-later."
   }
 }

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -9,14 +9,20 @@ implies that two components must be deployed together.
 | Relay hub | `cmd/relayhub/VERSION` | `relayhub-vX.Y.Z` | `relayhub/X.Y.Z` |
 | Broker | `cmd/broker/VERSION` | `broker-vX.Y.Z` | `broker/X.Y.Z` |
 | Volunteer desktop | `desktop-volunteer/VERSION` | `volunteer-vX.Y.Z` | `desktop-volunteer/X.Y.Z` |
-| Desktop client | `desktop/frontend/src/core/config.ts` | `vX.Y.Z` | — |
+| Desktop client | `desktop/wails.json` → `info.productVersion` | `vX.Y.Z` | `X.Y.Z` in the About UI, native metadata, and broker telemetry |
 
-The desktop client is not on a `VERSION` file yet: its About-screen version is
-a literal in `config.ts` and is never reported to the broker. It keeps the
-unprefixed `vX.Y.Z` tag it released under, so its workflow matches `v[0-9]*`
-rather than `v*` — a bare `v*` also matches `volunteer-v0.1.0` and would
-publish a desktop release onto the volunteer app's tag. A new component tag
-must therefore not begin with `v` followed by a digit.
+The desktop client uses Wails' `info.productVersion` as its single version
+source. The frontend build and Go linker flags consume that value so the About
+screen, native package metadata, HTTP headers, and broker telemetry all report
+the same identity. The desktop release workflow validates it as strict `X.Y.Z`
+before starting the platform build matrix. For a tag build, the tag must be
+exactly `vX.Y.Z` for that configured version.
+
+The desktop client keeps the unprefixed `vX.Y.Z` tag namespace it originally
+released under, so its workflow matches `v[0-9]*` rather than `v*` — a bare
+`v*` also matches `volunteer-v0.1.0` and would publish a desktop release onto
+the volunteer app's tag. A new component tag must therefore not begin with `v`
+followed by a digit.
 
 Server image workflows reject release tags that do not exactly match their
 component's `VERSION` file. Release builds publish the `X.Y.Z` image tag.
@@ -39,6 +45,15 @@ To release a server component:
    `relay-v0.1.0`.
 4. Deploy the exact semantic image tag or digest. Keep `main` for development
    and explicitly managed rolling deployments.
+
+To release the desktop client:
+
+1. Set `desktop/wails.json` → `info.productVersion` to the next strict semantic
+   version, such as `0.1.3`, and merge the change after CI passes.
+2. Tag that exact commit with `vX.Y.Z`, such as `v0.1.3`.
+3. The desktop release workflow validates that the tag is exactly `v` plus the
+   configured product version before building. A mismatch stops the release
+   before any platform jobs start.
 
 Application versions identify builds for operations and rollback. They do not
 replace compatibility contracts:


### PR DESCRIPTION
## Summary
- make desktop/wails.json info.productVersion (0.1.3) the canonical desktop version
- inject it into the frontend, native macOS/Windows metadata, and packaged client telemetry
- validate exact vX.Y.Z release tags before the platform build matrix

## Verification
- npm test
- npm run build
- node --test desktop/scripts/versioned-wails-build.test.mjs
- go test ./... and go vet ./... (desktop module)
- go test/go vet internal client and telemetry packages
- macOS arm64 package build, code-sign verification, and bundle version check

After merge, tag the merged commit as v0.1.3 to publish the GitHub release.