### PR TITLE
Add public privacy policy for app review

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1681,6 +1681,7 @@
               <li><a href="#why" data-i18n="navWhy">Why trust it</a></li>
               <li><a href="#download" data-i18n="navDownload">Download</a></li>
               <li><a href="#faq" data-i18n="navFaq">FAQ</a></li>
+              <li><a href="/privacy/" data-i18n="footPrivacyPolicy">Privacy policy</a></li>
             </ul>
           </div>
           <div class="foot-col">
@@ -1842,6 +1843,7 @@
           footLicense: "License (GPL-3.0)",
           footIssue: "Report an issue",
           footContact: "Contact",
+          footPrivacyPolicy: "Privacy policy",
           footerRights: "© 2026 OpenRung Foundation · A nonprofit project",
           footerPrivacy: "No account required. Early-access builds collect diagnostic connection metadata for debugging; we never sell your data."
         },
@@ -1958,6 +1960,7 @@
           footLicense: "许可证（GPL-3.0）",
           footIssue: "报告问题",
           footContact: "联系",
+          footPrivacyPolicy: "隐私政策",
           footerRights: "© 2026 OpenRung Foundation · 一个非营利项目",
           footerPrivacy: "无需账号。抢先体验版本会收集连接诊断元数据用于排查问题；我们绝不会出售你的数据。"
         },
@@ -2074,6 +2077,7 @@
           footLicense: "مجوز (GPL-3.0)",
           footIssue: "گزارش مشکل",
           footContact: "تماس",
+          footPrivacyPolicy: "سیاست حفظ حریم خصوصی",
           footerRights: "© 2026 OpenRung Foundation · یک پروژهٔ غیرانتفاعی",
           footerPrivacy: "نیازی به حساب کاربری نیست. نسخه‌های دسترسی زودهنگام برای عیب‌یابی، فرادادهٔ تشخیصی اتصال را گردآوری می‌کنند؛ ما هرگز داده‌های شما را نمی‌فروشیم."
         },
@@ -2190,6 +2194,7 @@
           footLicense: "Лицензия (GPL-3.0)",
           footIssue: "Сообщить о проблеме",
           footContact: "Контакты",
+          footPrivacyPolicy: "Политика конфиденциальности",
           footerRights: "© 2026 OpenRung Foundation · Некоммерческий проект",
           footerPrivacy: "Аккаунт не нужен. Версии раннего доступа собирают диагностические метаданные соединений для отладки; мы никогда не продаём ваши данные."
         }

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -1,0 +1,356 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Privacy Policy — OpenRung</title>
+    <meta name="description" content="How OpenRung collects, uses, shares, retains, and protects information when you use the OpenRung app and network.">
+    <link rel="canonical" href="https://www.openrung.org/privacy">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Privacy Policy — OpenRung">
+    <meta property="og:description" content="How OpenRung handles information when you use the app and network.">
+    <meta property="og:url" content="https://www.openrung.org/privacy">
+    <meta name="theme-color" content="#12241b">
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #12241b;
+        --ink-soft: #2f4a3a;
+        --paper: #f4f1e8;
+        --paper-deep: #e9e3d5;
+        --line: #d7d0c0;
+        --accent: #1d8a4f;
+        --accent-dark: #12663a;
+        --accent-soft: #e1f1e7;
+        --warning: #8c4a22;
+        --warning-soft: #f6e8dc;
+        --max: 780px;
+      }
+
+      * { box-sizing: border-box; }
+
+      html { scroll-behavior: smooth; }
+
+      body {
+        margin: 0;
+        background: var(--paper);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 17px;
+        line-height: 1.7;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a { color: var(--accent-dark); }
+      a:hover { color: var(--accent); }
+
+      a:focus-visible {
+        outline: 3px solid #35d07f;
+        outline-offset: 3px;
+        border-radius: 4px;
+      }
+
+      .skip-link {
+        position: absolute;
+        left: -9999px;
+        top: 0;
+        z-index: 10;
+        padding: 10px 16px;
+        background: #fff;
+        color: var(--ink);
+      }
+
+      .skip-link:focus { left: 12px; }
+
+      header {
+        background: var(--ink);
+        color: #eef7f1;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      }
+
+      .nav {
+        width: min(calc(100% - 40px), 1080px);
+        min-height: 72px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+      }
+
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 11px;
+        color: #eef7f1;
+        text-decoration: none;
+        font-weight: 800;
+        letter-spacing: 0.01em;
+      }
+
+      .brand-mark {
+        width: 36px;
+        height: 36px;
+        display: grid;
+        place-items: center;
+        border-radius: 10px;
+        background: var(--accent);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+      }
+
+      .brand-mark img { width: 25px; height: 25px; }
+
+      .back-link {
+        color: #bcd1c4;
+        font-size: 0.92rem;
+        font-weight: 650;
+        text-decoration: none;
+      }
+
+      .back-link:hover { color: #fff; }
+
+      main {
+        width: min(calc(100% - 40px), var(--max));
+        margin: 0 auto;
+        padding: 76px 0 96px;
+      }
+
+      .eyebrow {
+        margin: 0 0 12px;
+        color: var(--accent-dark);
+        font-size: 0.78rem;
+        font-weight: 800;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      h1, h2 { text-wrap: balance; }
+
+      h1 {
+        margin: 0;
+        max-width: 680px;
+        font-family: Georgia, "Times New Roman", serif;
+        font-size: clamp(2.7rem, 8vw, 4.7rem);
+        line-height: 0.98;
+        letter-spacing: -0.045em;
+      }
+
+      .effective {
+        margin: 24px 0 0;
+        color: var(--ink-soft);
+        font-size: 0.95rem;
+      }
+
+      .summary {
+        margin: 42px 0 54px;
+        padding: 24px 26px;
+        border: 1px solid #b8d7c4;
+        border-radius: 16px;
+        background: var(--accent-soft);
+      }
+
+      .summary strong { color: var(--accent-dark); }
+
+      section {
+        padding: 32px 0;
+        border-top: 1px solid var(--line);
+      }
+
+      h2 {
+        margin: 0 0 14px;
+        font-family: Georgia, "Times New Roman", serif;
+        font-size: clamp(1.55rem, 4vw, 2rem);
+        line-height: 1.2;
+        letter-spacing: -0.02em;
+      }
+
+      h3 {
+        margin: 26px 0 8px;
+        font-size: 1rem;
+        line-height: 1.4;
+      }
+
+      p { margin: 0 0 16px; }
+      p:last-child { margin-bottom: 0; }
+
+      ul {
+        margin: 12px 0 18px;
+        padding-left: 1.35em;
+      }
+
+      li { margin: 8px 0; padding-left: 0.25em; }
+      li::marker { color: var(--accent); }
+
+      .plain-language {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-left: 4px solid var(--warning);
+        border-radius: 0 10px 10px 0;
+        background: var(--warning-soft);
+      }
+
+      .plain-language strong { color: var(--warning); }
+
+      .contact {
+        padding: 26px;
+        border-radius: 16px;
+        background: var(--ink);
+        color: #dce9e0;
+      }
+
+      .contact h2 { color: #fff; }
+      .contact a { color: #6fe2a5; font-weight: 700; }
+
+      footer {
+        background: var(--paper-deep);
+        border-top: 1px solid var(--line);
+      }
+
+      .footer-inner {
+        width: min(calc(100% - 40px), var(--max));
+        margin: 0 auto;
+        padding: 26px 0;
+        color: var(--ink-soft);
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 560px) {
+        .nav { width: min(calc(100% - 28px), 1080px); }
+        .back-link { font-size: 0; }
+        .back-link::after { content: "Back"; font-size: 0.9rem; }
+        main { width: min(calc(100% - 28px), var(--max)); padding: 52px 0 72px; }
+        .summary { margin-top: 34px; padding: 20px; }
+        .footer-inner { width: min(calc(100% - 28px), var(--max)); }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#content">Skip to main content</a>
+    <header>
+      <nav class="nav" aria-label="Privacy policy navigation">
+        <a class="brand" href="/" aria-label="OpenRung home">
+          <span class="brand-mark" aria-hidden="true"><img src="/openrung-mark.svg" alt=""></span>
+          <span>OpenRung</span>
+        </a>
+        <a class="back-link" href="/">Back to OpenRung</a>
+      </nav>
+    </header>
+
+    <main id="content">
+      <p class="eyebrow">OpenRung Foundation</p>
+      <h1>Privacy Policy</h1>
+      <p class="effective"><strong>Effective and last updated:</strong> July 17, 2026</p>
+
+      <div class="summary">
+        <strong>The short version:</strong> OpenRung does not require an account, show ads, sell personal information, or track you across apps. During beta testing, the app does collect connection diagnostics—including IP-based network information and a random installation identifier—to keep the network reliable and debug failures. Those diagnostics are retained for up to seven days.
+      </div>
+
+      <section aria-labelledby="scope">
+        <h2 id="scope">1. Scope</h2>
+        <p>This policy explains how OpenRung Foundation ("OpenRung," "we," "us," or "our") handles information when you use the OpenRung mobile or desktop apps, the OpenRung relay network, or openrung.org.</p>
+        <p>OpenRung is a nonprofit project that helps people reach the open internet through Foundation-operated and volunteer-run relays.</p>
+      </section>
+
+      <section aria-labelledby="collect">
+        <h2 id="collect">2. Information we collect</h2>
+
+        <h3>No account information</h3>
+        <p>You can use OpenRung without creating an account or providing your name, phone number, or email address. We receive your email address only if you choose to contact us or request beta access or support.</p>
+
+        <h3>Beta connection diagnostics</h3>
+        <p>When you use the app or connect to the OpenRung network, the app and broker automatically process diagnostic information that may include:</p>
+        <ul>
+          <li>a random, persistent installation identifier; a new session identifier for each connection; event identifiers; and timestamps;</li>
+          <li>your public or source IP address and IP-derived country, city, network provider, organization, and autonomous system number (ASN);</li>
+          <li>app version, operating-system version, device model and manufacturer, locale, time zone, network type, and whether the network is metered or expensive;</li>
+          <li>the relay selected, connection attempts and outcomes, failure stage and error details, connection and session duration, heartbeat status, latency, and other performance timings;</li>
+          <li>cumulative bytes sent and received during a connection, without recording the content of those bytes; and</li>
+          <li>results of a relay speed test that you start, including download size, duration, time to first byte, and calculated speed.</li>
+        </ul>
+
+        <h3>Browsing metadata by platform</h3>
+        <p>The current iOS beta does not include website URLs, DNS names, destination IP addresses or ports, or the names of other apps in the diagnostic events it sends to OpenRung.</p>
+        <p>Some early-access builds on other platforms may collect connection-start metadata such as destination IP address, destination port, protocol, and the application package or identifier that opened the connection. We disclose this difference so this policy remains accurate across OpenRung platforms.</p>
+
+        <h3>Website and locally stored information</h3>
+        <p>Our website stores your language preference in your browser. The app stores settings, recent relay choices, its random installation identifier, and a short-lived queue of unsent diagnostic events on your device. Website and network infrastructure may also process ordinary request information such as IP address, browser type, requested page, and request time.</p>
+      </section>
+
+      <section aria-labelledby="use">
+        <h2 id="use">3. How we use information</h2>
+        <p>We use the information described above only to:</p>
+        <ul>
+          <li>provide the app, select and connect to relays, and keep connections working;</li>
+          <li>measure reliability, capacity, and performance;</li>
+          <li>diagnose connection failures and improve beta builds;</li>
+          <li>protect the service, investigate abuse, and enforce reasonable technical limits;</li>
+          <li>respond to support or beta-access requests; and</li>
+          <li>comply with law and protect users, volunteers, the Foundation, and the public.</li>
+        </ul>
+        <p>We do not use this information for advertising, data brokerage, or tracking you across other companies' apps or websites.</p>
+      </section>
+
+      <section aria-labelledby="share">
+        <h2 id="share">4. When information is shared or visible</h2>
+
+        <h3>Infrastructure and service providers</h3>
+        <p>We use providers that help deliver the app and network, including hosting and content-delivery providers, IP geolocation services, map-tile services, and Apple for TestFlight or App Store distribution. These providers may process IP addresses and request or device information as needed to provide their service. We do not authorize providers acting for OpenRung to use OpenRung diagnostic data for advertising or cross-service tracking, and we require them to protect data consistently with this policy and applicable law.</p>
+
+        <h3>Foundation-operated and volunteer-run relays</h3>
+        <p>Your internet traffic exits through the relay you connect to. Relay operators do not receive OpenRung's diagnostic database, but operating a relay can inherently expose connection-level information such as your source IP address, connection timing and volume, and destination IP addresses or domain names when the network protocol reveals them.</p>
+        <div class="plain-language">
+          <strong>Important:</strong> The tunnel between your device and the relay is encrypted. HTTPS content remains encrypted between your app or browser and the destination website, but a relay operator may be able to see connection metadata and any traffic that is not separately protected by HTTPS or another end-to-end encryption protocol. Volunteer relay operators are independent participants, not employees of OpenRung Foundation.
+        </div>
+
+        <h3>Legal and safety reasons</h3>
+        <p>We may disclose information if we reasonably believe disclosure is required by law or necessary to protect the rights, safety, or integrity of users, relay operators, OpenRung, or the public. We do not sell or rent personal information.</p>
+      </section>
+
+      <section aria-labelledby="retention">
+        <h2 id="retention">5. Retention and deletion</h2>
+        <p>OpenRung's broker retains beta diagnostic telemetry for up to seven days from the time it is received. Storage limits may remove older records sooner. We may retain support correspondence until the request is resolved and for a reasonable period afterward if needed for security, legal, or recordkeeping purposes.</p>
+        <p>The random installation identifier and local preferences remain on your device until you clear the app's data or uninstall it. Browser language preferences remain until you clear your browser storage.</p>
+        <p>You may request access to or deletion of information we can reasonably identify as yours by emailing <a href="mailto:admin@openrung.org">admin@openrung.org</a>. Because OpenRung has no user accounts, we may need your installation or session identifier and an approximate connection time to find a record, and in some cases we may be unable to link a record to you. We will honor verified requests as required by applicable law.</p>
+      </section>
+
+      <section aria-labelledby="choices">
+        <h2 id="choices">6. Your choices</h2>
+        <ul>
+          <li>You can stop future network diagnostics by disconnecting and stopping use of the app. During beta testing, connection diagnostics are part of operating the service and there is not currently an in-app diagnostic opt-out.</li>
+          <li>You can reset locally stored app information by clearing the app's data or uninstalling it.</li>
+          <li>You can clear the website language preference through your browser settings.</li>
+          <li>You can contact us to exercise privacy rights available where you live, including access, correction, deletion, or objection.</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="security">
+        <h2 id="security">7. Security</h2>
+        <p>We use technical and organizational safeguards designed to protect information, including encrypted transport to OpenRung services, restricted access to the telemetry dashboard, short diagnostic retention, and bounded storage. No system is completely secure, and we cannot guarantee that information will never be accessed, disclosed, altered, or lost.</p>
+      </section>
+
+      <section aria-labelledby="children">
+        <h2 id="children">8. Children</h2>
+        <p>OpenRung is not directed to children under 13, and we do not knowingly collect personal information from a child under 13. If you believe a child has provided personal information to us, contact us so we can review and delete it where appropriate.</p>
+      </section>
+
+      <section aria-labelledby="international">
+        <h2 id="international">9. International processing</h2>
+        <p>OpenRung is used internationally. Information may be processed in the United States and in other countries where our infrastructure and providers operate. Those countries may have data-protection rules different from the rules where you live.</p>
+      </section>
+
+      <section aria-labelledby="changes">
+        <h2 id="changes">10. Changes to this policy</h2>
+        <p>We may update this policy as the beta and network change. We will post the revised policy here and update the effective date. If a change materially affects how the app handles information, we will provide additional notice where appropriate.</p>
+      </section>
+
+      <section class="contact" aria-labelledby="contact">
+        <h2 id="contact">Contact us</h2>
+        <p>For privacy questions or requests, email the OpenRung Foundation at <a href="mailto:admin@openrung.org">admin@openrung.org</a>.</p>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">© 2026 OpenRung Foundation · A nonprofit project</div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a branded privacy policy at /privacy covering the current iOS beta diagnostics, seven-day retention, providers, relay visibility, and deletion requests
- distinguish current iOS diagnostics from Android-only browsing metadata
- link the policy from the multilingual homepage footer

## Validation
- served docs locally and confirmed 200 responses for /privacy/, /, and the logo asset
- parsed the new HTML and ran git diff --check

## Follow-up outside this repo
- add an easily accessible privacy-policy link inside the iOS app
- align the iOS privacy manifest and App Store Connect privacy answers with the telemetry the beta sends