### PR TITLE
broker: roll up application_connection events instead of storing them

### DIFF
--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -197,7 +197,11 @@ automatically) instead of the JSONL file. It uses
 needs no extra configuration; the broker refuses to start if neither is set.
 In postgres mode the admin dashboard aggregates in SQL, bounded by the
 selected time window, so dashboard cost and broker memory stay flat as event
-history grows.
+history grows. High-volume `application_connection` events are not stored as
+rows in either store: ingestion folds them into an hourly per-application
+count (`telemetry_app_counts` in postgres mode) that feeds the dashboard's
+top-applications panel, and discards the per-event destination and client
+metadata.
 
 ## Telemetry dashboard
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,6 +75,16 @@ attribution is collected on Android 10 and newer. This first implementation
 records connection starts and destinations, not per-flow byte counters or flow
 completion times.
 
+`application_connection` events are never stored as individual records — in
+either telemetry store. At ingestion the broker folds each one into an hourly
+per-application connection count (Postgres: the `telemetry_app_counts` table;
+JSONL mode: an in-memory rollup that restarts empty) and discards the rest of
+the event, so the destination IP and the per-event client metadata never reach
+disk. Only the aggregate feeds the dashboard's top-applications panel, whose
+window edge is consequently hour-granular. They are by far the highest-volume
+event (one per tunnelled flow, with a per-package fan-out on Android), so this
+also keeps dashboard queries bounded by session-grade volume.
+
 Before starting the tunnel, Android also resolves its public IP metadata and
 adds `client_ip`, `country`, `country_code`, `city`, `asn`, `isp`, and
 `organization` to subsequent session events. A failed metadata lookup does not

--- a/internal/broker/dashboard.go
+++ b/internal/broker/dashboard.go
@@ -419,11 +419,14 @@ func (a *sessionAccumulator) finalize(now time.Time) sessionSummary {
 	return summary
 }
 
-func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window time.Duration) telemetryOverview {
+// buildTelemetryOverview aggregates stored records; appCounts is the hourly
+// application-connection rollup slice for the window (top-apps comes only from
+// there — application_connection events are never stored as records, and any
+// legacy stored ones are skipped to match the SQL path's filter).
+func buildTelemetryOverview(records []TelemetryRecord, appCounts map[string]int, now time.Time, window time.Duration) telemetryOverview {
 	start := now.Add(-window)
 	clients := make(map[string]struct{})
 	sessions := make(map[string]*sessionAccumulator)
-	apps := make(map[string]int)
 	failures := make(map[string]int)
 	failureReasons := make(map[string]int)
 	relays := make(map[string]*relaySummary)
@@ -442,6 +445,9 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 	for _, record := range records {
 		event := record.Event
 		if event.OccurredAt.Before(start) || event.OccurredAt.After(now) {
+			continue
+		}
+		if event.Event == telemetryAppConnectionEvent {
 			continue
 		}
 		clients[event.ClientID] = struct{}{}
@@ -508,9 +514,6 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 		}
 		if isp := event.Attributes["isp"]; isp != "" {
 			session.isp = isp
-		}
-		if event.Application != "" {
-			apps[event.Application]++
 		}
 		// bytes_sent / bytes_received are cumulative per session (heartbeats carry
 		// the running totals, connection_ended the final ones), so the largest
@@ -662,7 +665,7 @@ func buildTelemetryOverview(records []TelemetryRecord, now time.Time, window tim
 	if len(overview.TopRelays) > 10 {
 		overview.TopRelays = overview.TopRelays[:10]
 	}
-	overview.TopApps = sortedCounts(apps, 10)
+	overview.TopApps = sortedCounts(appCounts, 10)
 	overview.TopCountries = sortedCounts(countryCounts, 10)
 	overview.TopCities = sortedCounts(cityCounts, 10)
 	overview.TopISPs = sortedCounts(ispCounts, 10)

--- a/internal/broker/dashboard_test.go
+++ b/internal/broker/dashboard_test.go
@@ -13,11 +13,27 @@ import (
 	"openrung/internal/relay"
 )
 
-type dashboardTelemetryStore struct{ records []TelemetryRecord }
+type dashboardTelemetryStore struct {
+	records   []TelemetryRecord
+	appRollup telemetryAppRollup
+}
 
+// WriteTelemetry mirrors the real sinks: application_connection events fold
+// into the hourly rollup instead of being stored, so parity tests that feed
+// both backends the same batch exercise identical top-apps semantics.
 func (s *dashboardTelemetryStore) WriteTelemetry(_ context.Context, records []TelemetryRecord) error {
-	s.records = append(s.records, records...)
+	for _, record := range records {
+		if record.Event.Event == telemetryAppConnectionEvent {
+			s.appRollup.add(telemetryAppRollupHour(record, time.Now().UTC()), record.Event.Application, 1)
+			continue
+		}
+		s.records = append(s.records, record)
+	}
 	return nil
+}
+
+func (s *dashboardTelemetryStore) AppConnectionCounts(now time.Time, window time.Duration) map[string]int {
+	return s.appRollup.countsIn(now, window)
 }
 
 func (s *dashboardTelemetryStore) TelemetryRecords(since time.Time) []TelemetryRecord {
@@ -174,14 +190,16 @@ func TestBuildTelemetryOverview(t *testing.T) {
 		dashboardRecord(now.Add(-30*time.Minute), "attempt-1", "connection_attempted", "client-1", "session-1", "", clientOneAttributes, nil),
 		dashboardRecord(now.Add(-29*time.Minute), "success-1", "connection_succeeded", "client-1", "session-1", "relay-1", clientOneAttributes, nil),
 		dashboardRecord(now.Add(-15*time.Minute), "failover-1", "relay_failover", "client-1", "session-1", "relay-2", clientOneAttributes, map[string]int64{"relay_tcp_ms": 25}),
-		dashboardRecord(now.Add(-20*time.Minute), "app-1", "application_connection", "client-1", "session-1", "relay-1", clientOneAttributes, nil),
+		// A legacy stored application_connection record under its own client and
+		// session: it must be skipped entirely (not stored anymore, and skipped
+		// when read back from old files), so neither total below counts it.
+		dashboardRecord(now.Add(-20*time.Minute), "app-1", "application_connection", "client-legacy", "session-legacy", "relay-1", clientOneAttributes, nil),
 		dashboardRecord(now.Add(-time.Minute), "heartbeat-1", "session_heartbeat", "client-1", "session-1", "relay-1", clientOneAttributes, map[string]int64{"connected_duration_ms": 60_000, "session_duration_ms": 1_740_000}),
 		dashboardRecord(now.Add(-10*time.Minute), "attempt-2", "connection_attempted", "client-2", "session-2", "", map[string]string{"android_api": "35", "country": "CA", "city": "Toronto", "organization": "Fallback Network", "asn": "AS64500"}, nil),
 		dashboardRecord(now.Add(-9*time.Minute), "failure-2", "connection_failed", "client-2", "session-2", "", map[string]string{"failure_stage": "broker_fetch", "country": "CA", "city": "Toronto", "organization": "Fallback Network", "asn": "AS64500"}, nil),
 		dashboardRecord(now.Add(-5*time.Minute), "speed-1", "speed_test_completed", "client-1", "session-1", "relay-1", nil, map[string]int64{"download_mbps_milli": 42500, "time_to_first_byte_ms": 100}),
 	}
-	records[2].Event.Application = "com.example.app"
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, map[string]int{"com.example.app": 1}, now, time.Hour)
 	if overview.Totals.Clients != 2 || overview.Totals.Sessions != 2 || overview.Totals.Attempts != 2 || overview.Totals.Successes != 1 || overview.Totals.Failures != 1 {
 		t.Fatalf("unexpected totals: %+v", overview.Totals)
 	}
@@ -285,7 +303,7 @@ func TestBuildTelemetryOverviewDerivesiOSDeviceInfo(t *testing.T) {
 	records := []TelemetryRecord{
 		dashboardRecord(now.Add(-time.Minute), "attempt", "connection_attempted", "client-ios", "session-ios", "", attrs, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	if len(overview.Recent) != 1 {
 		t.Fatalf("expected one session, got %d", len(overview.Recent))
 	}
@@ -305,7 +323,7 @@ func TestBuildTelemetryOverviewExpiresAndTerminatesHeartbeatSessions(t *testing.
 	terminalHeartbeat := dashboardRecord(now.Add(-time.Minute), "terminal-heartbeat", "session_heartbeat", "client-3", "session-terminal", "relay-1", nil, nil)
 	terminal := dashboardRecord(now.Add(-30*time.Second), "terminal", "connection_ended", "client-3", "session-terminal", "relay-1", nil, nil)
 
-	overview := buildTelemetryOverview([]TelemetryRecord{expired, active, terminalHeartbeat, terminal}, now, time.Hour)
+	overview := buildTelemetryOverview([]TelemetryRecord{expired, active, terminalHeartbeat, terminal}, nil, now, time.Hour)
 	if overview.Totals.ActiveSessions != 1 || overview.Totals.ActiveClients != 1 {
 		t.Fatalf("expected only one active session: %+v", overview.Totals)
 	}
@@ -322,7 +340,7 @@ func TestBuildTelemetryOverviewHandlesMissingMetadataAndASNFallback(t *testing.T
 		dashboardRecord(now.Add(-time.Minute), "missing", "connection_attempted", "client-1", "session-missing", "", nil, nil),
 		dashboardRecord(now.Add(-time.Minute), "asn", "connection_attempted", "client-2", "session-asn", "", map[string]string{"asn": "AS64501"}, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	if len(overview.TopCities) != 0 || len(overview.TopISPs) != 1 || overview.TopISPs[0].Name != "AS64501" {
 		t.Fatalf("unexpected missing metadata aggregation: cities=%+v isps=%+v", overview.TopCities, overview.TopISPs)
 	}
@@ -342,7 +360,7 @@ func TestBuildTelemetryOverviewTracksSessionBytes(t *testing.T) {
 		dashboardRecord(now.Add(-time.Minute), "ended", "connection_ended", "client-1", "session-1", "relay-1", nil, map[string]int64{"bytes_sent": 2_500, "bytes_received": 9_500}),
 		dashboardRecord(now.Add(-time.Minute), "no-bytes", "session_heartbeat", "client-2", "session-2", "relay-1", nil, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	byID := make(map[string]sessionSummary)
 	for _, session := range overview.Recent {
 		byID[session.SessionID] = session
@@ -428,7 +446,7 @@ func TestBuildTelemetryOverviewPrefersClientIPOverRelayTransportIP(t *testing.T)
 	upload := dashboardRecord(now, "connected", "connection_succeeded", "client-1", "session-1", "relay-1", map[string]string{"client_ip": "198.51.100.20"}, nil)
 	upload.SourceIP = "203.0.113.50"
 
-	overview := buildTelemetryOverview([]TelemetryRecord{clientSeen, upload}, now, time.Hour)
+	overview := buildTelemetryOverview([]TelemetryRecord{clientSeen, upload}, nil, now, time.Hour)
 	if got := overview.Recent[0].SourceIP; got != "198.51.100.20" {
 		t.Fatalf("expected pre-tunnel client IP, got %q", got)
 	}
@@ -441,7 +459,7 @@ func TestBuildTelemetryOverviewSourceIPFallbacks(t *testing.T) {
 	transport := dashboardRecord(now, "transport", "connection_succeeded", "client-2", "session-transport", "relay-1", nil, nil)
 	transport.SourceIP = "198.51.100.22"
 
-	overview := buildTelemetryOverview([]TelemetryRecord{reported, transport}, now, time.Hour)
+	overview := buildTelemetryOverview([]TelemetryRecord{reported, transport}, nil, now, time.Hour)
 	got := make(map[string]string)
 	for _, session := range overview.Recent {
 		got[session.SessionID] = session.SourceIP
@@ -459,7 +477,7 @@ func TestBuildTelemetryOverviewSurfacesFailureDiagnostics(t *testing.T) {
 			"failure_stage": "handshake", "failure_reason": "timeout", "failure_detail": "dial tcp 10.0.0.1:443: i/o timeout",
 		}, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	session := recentByID(overview.Recent)["session-1"]
 	if session.FailureStage != "handshake" || session.FailureReason != "timeout" || session.FailureDetail != "dial tcp 10.0.0.1:443: i/o timeout" {
 		t.Fatalf("unexpected failure fields: %+v", session)
@@ -479,7 +497,7 @@ func TestBuildTelemetryOverviewFailureReasonFallsBackToErrorType(t *testing.T) {
 			"failure_stage": "broker_fetch", "error_type": "connection_refused",
 		}, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	session := recentByID(overview.Recent)["session-1"]
 	if session.FailureStage != "broker_fetch" || session.FailureReason != "connection_refused" {
 		t.Fatalf("expected error_type fallback, got %+v", session)
@@ -497,7 +515,7 @@ func TestBuildTelemetryOverviewFailureWithoutAttributes(t *testing.T) {
 	records := []TelemetryRecord{
 		dashboardRecord(now.Add(-time.Minute), "failed", "connection_failed", "client-1", "session-1", "", nil, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	session := recentByID(overview.Recent)["session-1"]
 	if session.FailureStage != "" || session.FailureReason != "" || session.FailureDetail != "" {
 		t.Fatalf("failure fields should stay empty, got %+v", session)
@@ -526,7 +544,7 @@ func TestBuildTelemetryOverviewRelayTopFailureReason(t *testing.T) {
 		// relay-clean only succeeded, so it has no failure reason to report.
 		dashboardRecord(now.Add(-time.Minute), "ok", "connection_succeeded", "client-6", "session-6", "relay-clean", nil, nil),
 	}
-	overview := buildTelemetryOverview(records, now, time.Hour)
+	overview := buildTelemetryOverview(records, nil, now, time.Hour)
 	byRelay := make(map[string]relaySummary)
 	for _, relay := range overview.TopRelays {
 		byRelay[relay.RelayID] = relay
@@ -655,7 +673,7 @@ func TestRecordedRelayClassSurvivesMissingActiveDescriptor(t *testing.T) {
 		record("success", "connection_succeeded", now.Add(-2*time.Minute), nil),
 		record("heartbeat", "session_heartbeat", now.Add(-time.Minute), nil),
 		record("speed", "speed_test_completed", now.Add(-30*time.Second), map[string]int64{"download_mbps_milli": 50_000}),
-	}, now, 24*time.Hour)
+	}, nil, now, 24*time.Hour)
 
 	// The active descriptor map no longer contains relay-expired. Including a
 	// different relay makes applyRelayDisplays traverse every row; it must not

--- a/internal/broker/postgres_telemetry.go
+++ b/internal/broker/postgres_telemetry.go
@@ -214,6 +214,7 @@ func (s *PostgresTelemetrySink) WriteTelemetry(ctx context.Context, records []Te
 		s.mu.Unlock()
 		return errors.New("telemetry storage is closed")
 	}
+	evictedBefore := s.pendingAppCounts.evictedEntries
 	for _, record := range records {
 		if record.Event.Event == telemetryAppConnectionEvent {
 			// Rolled up, never inserted as a row — see telemetryAppConnectionEvent.
@@ -227,9 +228,13 @@ func (s *PostgresTelemetrySink) WriteTelemetry(ctx context.Context, records []Te
 		s.pendingBytes += size
 	}
 	shouldFlush := len(s.pending) >= postgresTelemetryFlushThreshold
+	evicted := s.pendingAppCounts.evictedEntries - evictedBefore
 	s.mu.Unlock()
 	if dropped > 0 {
 		slog.Warn("dropped application-connection counts over rollup entry cap", "dropped", dropped)
+	}
+	if evicted > 0 {
+		slog.Warn("evicted oldest application-connection rollup entries to preserve current counts", "evicted", evicted, "store", "postgres-buffer")
 	}
 
 	// The insert itself is asynchronous (buffered like the JSONL sink's
@@ -381,6 +386,7 @@ func (s *PostgresTelemetrySink) flush() error {
 		if err := s.upsertAppCounts(ctx, counts); err != nil {
 			s.mu.Lock()
 			dropped := 0
+			evictedBefore := s.pendingAppCounts.evictedEntries
 			for hour, apps := range counts.hours {
 				for application, count := range apps {
 					if !s.pendingAppCounts.add(hour, application, count) {
@@ -388,9 +394,13 @@ func (s *PostgresTelemetrySink) flush() error {
 					}
 				}
 			}
+			evicted := s.pendingAppCounts.evictedEntries - evictedBefore
 			s.mu.Unlock()
 			if dropped > 0 {
 				slog.Warn("dropped application-connection counts over rollup entry cap", "dropped", dropped)
+			}
+			if evicted > 0 {
+				slog.Warn("evicted oldest application-connection rollup entries while restoring a failed flush", "evicted", evicted, "store", "postgres-buffer")
 			}
 			errs = append(errs, err)
 		}

--- a/internal/broker/postgres_telemetry.go
+++ b/internal/broker/postgres_telemetry.go
@@ -79,6 +79,17 @@ CREATE INDEX IF NOT EXISTS telemetry_events_received_at_idx
 
 CREATE INDEX IF NOT EXISTS telemetry_events_session_occurred_idx
 	ON telemetry_events (session_id, occurred_at);
+
+-- application_connection events are never stored as telemetry_events rows —
+-- only this hourly per-application rollup survives ingestion (see
+-- telemetryAppConnectionEvent). It is what the dashboard's top-apps panel
+-- reads, and it is tiny: one row per (hour, application) seen.
+CREATE TABLE IF NOT EXISTS telemetry_app_counts (
+	hour timestamptz NOT NULL,
+	application text NOT NULL,
+	connections bigint NOT NULL,
+	PRIMARY KEY (hour, application)
+);
 `
 
 const telemetryInsertColumns = `received_at, source_ip, event_id, event, occurred_at, client_id, session_id, relay_id, relay_node_class, payload`
@@ -110,6 +121,11 @@ type PostgresTelemetrySink struct {
 	pending      []storedTelemetryRecord
 	pendingBytes int64
 	pendingLimit int64
+	// pendingAppCounts buffers the hourly application-connection rollup between
+	// flushes (see telemetryAppConnectionEvent); flush upserts it into
+	// telemetry_app_counts. The telemetryAppRollup entry cap bounds it while
+	// Postgres is unreachable, the analog of the pending byte cap for records.
+	pendingAppCounts telemetryAppRollup
 	// partitions caches the daily partitions this process has already ensured
 	// so steady-state flushes skip the DDL round-trip.
 	partitions map[string]struct{}
@@ -191,18 +207,30 @@ func telemetryRecordSize(record TelemetryRecord) int64 {
 }
 
 func (s *PostgresTelemetrySink) WriteTelemetry(ctx context.Context, records []TelemetryRecord) error {
+	now := s.now().UTC()
+	dropped := 0
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
 		return errors.New("telemetry storage is closed")
 	}
 	for _, record := range records {
+		if record.Event.Event == telemetryAppConnectionEvent {
+			// Rolled up, never inserted as a row — see telemetryAppConnectionEvent.
+			if !s.pendingAppCounts.add(telemetryAppRollupHour(record, now), record.Event.Application, 1) {
+				dropped++
+			}
+			continue
+		}
 		size := telemetryRecordSize(record)
 		s.pending = append(s.pending, storedTelemetryRecord{record: record, bytes: size})
 		s.pendingBytes += size
 	}
 	shouldFlush := len(s.pending) >= postgresTelemetryFlushThreshold
 	s.mu.Unlock()
+	if dropped > 0 {
+		slog.Warn("dropped application-connection counts over rollup entry cap", "dropped", dropped)
+	}
 
 	// The insert itself is asynchronous (buffered like the JSONL sink's
 	// bufio writer): a failed flush is retried by the ticker, so the handler
@@ -235,6 +263,7 @@ func (s *PostgresTelemetrySink) TelemetryRecords(since time.Time) []TelemetryRec
 			COALESCE(relay_id, ''), COALESCE(relay_node_class, ''), payload
 		FROM telemetry_events
 		WHERE received_at > $1 AND occurred_at >= $2
+			AND event <> 'application_connection'
 		ORDER BY received_at
 	`, since.Add(-maxTelemetryFutureSkew), since)
 	if err != nil {
@@ -311,11 +340,13 @@ func (s *PostgresTelemetrySink) flushLoop(flushInterval time.Duration) {
 	}
 }
 
-// flush inserts the pending buffer. On failure the batch is put back at the
-// front of the buffer (capped by pendingLimit) so the next flush retries it —
-// a chunk that had already been inserted before a later chunk failed is
-// retried too and may duplicate rows, which the schema tolerates by design
-// (no unique constraint spans partitions).
+// flush inserts the pending buffer and upserts the pending app-count rollup.
+// On failure each is put back (records at the front of the buffer, capped by
+// pendingLimit; counts re-merged into the rollup, capped by its entry limit)
+// so the next flush retries it — a chunk that had already been written before
+// a later chunk failed is retried too and may duplicate rows or double-count,
+// which the store tolerates by design (no unique constraint spans partitions,
+// and the counts are dashboard-grade aggregates).
 func (s *PostgresTelemetrySink) flush() error {
 	s.flushMu.Lock()
 	defer s.flushMu.Unlock()
@@ -323,23 +354,80 @@ func (s *PostgresTelemetrySink) flush() error {
 	s.mu.Lock()
 	batch, batchBytes := s.pending, s.pendingBytes
 	s.pending, s.pendingBytes = nil, 0
+	counts := s.pendingAppCounts
+	s.pendingAppCounts = telemetryAppRollup{}
 	s.mu.Unlock()
-	if len(batch) == 0 {
+	if len(batch) == 0 && counts.entries == 0 {
 		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryFlushTimeout)
 	defer cancel()
-	if err := s.insertBatch(ctx, batch); err != nil {
-		s.mu.Lock()
-		s.pending = append(batch, s.pending...)
-		s.pendingBytes += batchBytes
-		dropped := s.dropOldestPendingOverCapLocked()
-		s.mu.Unlock()
-		if dropped > 0 {
-			slog.Warn("dropped buffered telemetry records over pending cap", "dropped", dropped)
+	var errs []error
+	if len(batch) > 0 {
+		if err := s.insertBatch(ctx, batch); err != nil {
+			s.mu.Lock()
+			s.pending = append(batch, s.pending...)
+			s.pendingBytes += batchBytes
+			dropped := s.dropOldestPendingOverCapLocked()
+			s.mu.Unlock()
+			if dropped > 0 {
+				slog.Warn("dropped buffered telemetry records over pending cap", "dropped", dropped)
+			}
+			errs = append(errs, err)
 		}
-		return err
+	}
+	if counts.entries > 0 {
+		if err := s.upsertAppCounts(ctx, counts); err != nil {
+			s.mu.Lock()
+			dropped := 0
+			for hour, apps := range counts.hours {
+				for application, count := range apps {
+					if !s.pendingAppCounts.add(hour, application, count) {
+						dropped++
+					}
+				}
+			}
+			s.mu.Unlock()
+			if dropped > 0 {
+				slog.Warn("dropped application-connection counts over rollup entry cap", "dropped", dropped)
+			}
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// upsertAppCounts adds the flushed rollup into telemetry_app_counts, chunked
+// like record inserts so a giant rollup cannot approach the parameter cap.
+func (s *PostgresTelemetrySink) upsertAppCounts(ctx context.Context, counts telemetryAppRollup) error {
+	type appCountRow struct {
+		hour        time.Time
+		application string
+		connections int64
+	}
+	rows := make([]appCountRow, 0, counts.entries)
+	for hour, apps := range counts.hours {
+		for application, count := range apps {
+			rows = append(rows, appCountRow{hour: hour, application: application, connections: count})
+		}
+	}
+	for start := 0; start < len(rows); start += postgresTelemetryInsertChunk {
+		chunk := rows[start:min(start+postgresTelemetryInsertChunk, len(rows))]
+		var b strings.Builder
+		b.WriteString(`INSERT INTO telemetry_app_counts (hour, application, connections) VALUES `)
+		args := make([]any, 0, len(chunk)*3)
+		for i, row := range chunk {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			fmt.Fprintf(&b, "($%d,$%d,$%d)", i*3+1, i*3+2, i*3+3)
+			args = append(args, row.hour, row.application, row.connections)
+		}
+		b.WriteString(` ON CONFLICT (hour, application) DO UPDATE SET connections = telemetry_app_counts.connections + EXCLUDED.connections`)
+		if _, err := s.pool.Exec(ctx, b.String(), args...); err != nil {
+			return fmt.Errorf("upsert telemetry app counts: %w", err)
+		}
 	}
 	return nil
 }
@@ -544,6 +632,12 @@ func (s *PostgresTelemetrySink) PruneTelemetry(now time.Time) ([]string, error) 
 		s.mu.Lock()
 		delete(s.partitions, name)
 		s.mu.Unlock()
+	}
+	// The app-count rollup ages out with the same cutoff as the partitions its
+	// events would have landed in; hour-truncating mirrors the in-memory
+	// rollup's prune so an hour bucket straddling the cutoff survives.
+	if _, err := s.pool.Exec(ctx, `DELETE FROM telemetry_app_counts WHERE hour < $1`, cutoff.UTC().Truncate(time.Hour)); err != nil {
+		return dropped, fmt.Errorf("prune telemetry app counts: %w", err)
 	}
 	return dropped, nil
 }

--- a/internal/broker/postgres_telemetry_query.go
+++ b/internal/broker/postgres_telemetry_query.go
@@ -37,7 +37,6 @@ events AS (
 		COALESCE(relay_id, '') AS relay_id,
 		COALESCE(relay_node_class, '') AS relay_node_class,
 		host(source_ip) AS source_ip,
-		NULLIF(payload->>'application_package', '') AS application,
 		-- failure_stage/detail use NULLIF so the sessions CTE IS NOT NULL
 		-- filter mirrors the accumulator's plain != "" test (a present-but-
 		-- empty later connection_failed must not clobber an earlier non-empty
@@ -75,7 +74,12 @@ events AS (
 		(payload->'measurements'->>'download_mbps_milli')::bigint AS download_mbps_milli,
 		(payload->'measurements'->>'time_to_first_byte_ms')::bigint AS ttfb_ms
 	FROM telemetry_events
+	-- application_connection is excluded belt-and-braces: since the hourly
+	-- rollup landed those events are never inserted as rows, but partitions
+	-- written before the rollup (or by an older broker) may still hold them,
+	-- and at production volume they were ~95% of all rows.
 	WHERE received_at > $1 AND occurred_at >= $2 AND occurred_at <= $3
+		AND event <> 'application_connection'
 )`
 
 // The `latest non-empty wins` aggregations order by (received_at, occurred_at)
@@ -168,11 +172,18 @@ FROM events
 WHERE event IN ('connection_attempted', 'connection_succeeded', 'connection_failed')
 GROUP BY 4
 UNION ALL
--- top_applications through relay_failures: the event-level count groups, each a
--- (name, count) pair that sortedCounts / topRelaySummaries rank and truncate.
-SELECT 'top_applications', application, NULL::text, COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
-FROM events WHERE application IS NOT NULL GROUP BY application
+-- top_applications reads the hourly rollup, not the events CTE:
+-- application_connection events are folded into telemetry_app_counts at
+-- ingestion and never stored as rows. The window edge is hour-granular (the
+-- truncated start hour is included whole), matching telemetryAppRollup's
+-- countsIn; the date_trunc runs in UTC like the trend buckets.
+SELECT 'top_applications', application, NULL::text, SUM(connections)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+FROM telemetry_app_counts
+WHERE hour >= date_trunc('hour', $2::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AND hour <= $3
+GROUP BY application
 UNION ALL
+-- failure_stages through relay_failures: the event-level count groups, each a
+-- (name, count) pair that sortedCounts / topRelaySummaries rank and truncate.
 SELECT 'failure_stages',
 	CASE WHEN btrim(COALESCE(failure_stage, '')) <> '' THEN failure_stage ELSE 'unknown' END,
 	NULL::text, COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint

--- a/internal/broker/postgres_telemetry_query_test.go
+++ b/internal/broker/postgres_telemetry_query_test.go
@@ -148,6 +148,21 @@ func parityTelemetryRecords(now time.Time) []TelemetryRecord {
 			map[string]string{"error_type": "beta"}, nil),
 		record(33, 33, "relay_attempt_failed", "client-relayfail", "session-relayfail", "relay-4", "192.0.2.71",
 			map[string]string{"error_type": "gamma"}, nil),
+
+		// application_connection events: stored by neither backend — both fold
+		// them into the hourly top-apps rollup keyed by receipt hour and drop
+		// the record. session-apponly/client-apponly exist only here, so they
+		// must appear in no total or panel besides top_applications. With
+		// now=12:30, the two events received 3–4 minutes ago bucket to 12:00
+		// and the one received 70 minutes ago buckets to 11:00 — inside the 1h
+		// window's truncated start hour even though it was received before the
+		// window opened, pinning the hour-granular window edge in both paths.
+		record(3, 3, "application_connection", "client-apponly", "session-apponly", "relay-1", "203.0.113.10",
+			map[string]string{"_app": "com.instagram.android", "country": "IR", "client_ip": "203.0.113.77"}, nil),
+		record(4, 4, "application_connection", "client-apponly", "session-apponly", "relay-1", "203.0.113.10",
+			map[string]string{"_app": "com.instagram.android"}, nil),
+		record(70, 70, "application_connection", "client-apponly", "session-apponly", "", "192.0.2.50",
+			map[string]string{"_app": "org.telegram.messenger"}, nil),
 	}
 }
 
@@ -174,7 +189,11 @@ func TestPostgresTelemetryQuerierMatchesInMemoryOverview(t *testing.T) {
 	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
 		t.Fatalf("write telemetry: %v", err)
 	}
-	memory := newTelemetryReaderQuerier(&dashboardTelemetryStore{records: records})
+	memoryStore := &dashboardTelemetryStore{}
+	if err := memoryStore.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatalf("write telemetry to in-memory store: %v", err)
+	}
+	memory := newTelemetryReaderQuerier(memoryStore)
 
 	for _, window := range []time.Duration{time.Hour, 24 * time.Hour, telemetryRetention} {
 		want, err := memory.TelemetryOverview(now, window)
@@ -196,7 +215,11 @@ func TestPostgresTelemetryQuerierMatchesInMemorySessions(t *testing.T) {
 	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
 		t.Fatalf("write telemetry: %v", err)
 	}
-	memory := newTelemetryReaderQuerier(&dashboardTelemetryStore{records: records})
+	memoryStore := &dashboardTelemetryStore{}
+	if err := memoryStore.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatalf("write telemetry to in-memory store: %v", err)
+	}
+	memory := newTelemetryReaderQuerier(memoryStore)
 
 	window := 24 * time.Hour
 	for _, page := range []struct{ offset, limit int }{

--- a/internal/broker/postgres_telemetry_test.go
+++ b/internal/broker/postgres_telemetry_test.go
@@ -411,9 +411,13 @@ func cleanupPostgresTelemetry(t *testing.T, sink *PostgresTelemetrySink) {
 	if _, err := sink.pool.Exec(context.Background(), `TRUNCATE telemetry_events`); err != nil {
 		t.Fatalf("cleanup telemetry events: %v", err)
 	}
+	if _, err := sink.pool.Exec(context.Background(), `TRUNCATE telemetry_app_counts`); err != nil {
+		t.Fatalf("cleanup telemetry app counts: %v", err)
+	}
 	sink.mu.Lock()
 	sink.pending = nil
 	sink.pendingBytes = 0
+	sink.pendingAppCounts = telemetryAppRollup{}
 	sink.mu.Unlock()
 }
 
@@ -469,4 +473,73 @@ func telemetryPartitionExists(t *testing.T, sink *PostgresTelemetrySink, day str
 		t.Fatalf("check partition: %v", err)
 	}
 	return exists != nil
+}
+
+func TestPostgresTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
+	sink := newTestPostgresTelemetrySink(t, now)
+	ctx := context.Background()
+
+	records := []TelemetryRecord{
+		telemetryRecordAt(now.Add(-time.Minute), "kept-1"),
+		appConnectionRecordAt(now.Add(-2*time.Minute), "app-1", "com.instagram.android"),
+		appConnectionRecordAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android"),
+		appConnectionRecordAt(now.Add(-70*time.Minute), "app-3", "org.telegram.messenger"),
+	}
+	if err := sink.WriteTelemetry(ctx, records); err != nil {
+		t.Fatalf("write telemetry: %v", err)
+	}
+	if err := sink.flush(); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
+
+	var eventRows int
+	if err := sink.pool.QueryRow(ctx, `SELECT COUNT(*) FROM telemetry_events`).Scan(&eventRows); err != nil {
+		t.Fatalf("count telemetry events: %v", err)
+	}
+	if eventRows != 1 {
+		t.Fatalf("application_connection events must not be inserted as rows, got %d rows", eventRows)
+	}
+
+	// A second batch in the same hour must increment via the upsert's conflict
+	// arm, not insert a second (hour, application) row.
+	if err := sink.WriteTelemetry(ctx, []TelemetryRecord{
+		appConnectionRecordAt(now.Add(-time.Minute), "app-4", "com.instagram.android"),
+	}); err != nil {
+		t.Fatalf("write second batch: %v", err)
+	}
+	if err := sink.flush(); err != nil {
+		t.Fatalf("flush second batch: %v", err)
+	}
+
+	overview, err := sink.TelemetryOverview(now, time.Hour)
+	if err != nil {
+		t.Fatalf("overview: %v", err)
+	}
+	// The telegram event was received 70 minutes ago — before the window
+	// opened, but inside the truncated start hour, so the hour-granular window
+	// edge keeps it (matching telemetryAppRollup.countsIn).
+	if len(overview.TopApps) != 2 || overview.TopApps[0].Name != "com.instagram.android" || overview.TopApps[0].Count != 3 || overview.TopApps[1].Count != 1 {
+		t.Fatalf("unexpected top apps: %+v", overview.TopApps)
+	}
+	// The app-only events created no session rows.
+	if overview.Totals.Sessions != 1 || overview.Totals.Clients != 1 {
+		t.Fatalf("application_connection must not create sessions: %+v", overview.Totals)
+	}
+
+	// Retention: counts age out with the same cutoff as partitions.
+	if _, err := sink.pool.Exec(ctx, `INSERT INTO telemetry_app_counts (hour, application, connections) VALUES ($1, 'com.aged.app', 7)`,
+		now.Add(-telemetryRetention-2*time.Hour).Truncate(time.Hour)); err != nil {
+		t.Fatalf("insert aged count: %v", err)
+	}
+	if _, err := sink.PruneTelemetry(now); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	var agedRows int
+	if err := sink.pool.QueryRow(ctx, `SELECT COUNT(*) FROM telemetry_app_counts WHERE application = 'com.aged.app'`).Scan(&agedRows); err != nil {
+		t.Fatalf("count aged rows: %v", err)
+	}
+	if agedRows != 0 {
+		t.Fatalf("expected aged app counts to be pruned, %d rows remain", agedRows)
+	}
 }

--- a/internal/broker/telemetry.go
+++ b/internal/broker/telemetry.go
@@ -160,8 +160,9 @@ const telemetryAppConnectionEvent = "application_connection"
 
 // maxTelemetryAppRollupEntries bounds the distinct (hour, application) pairs a
 // rollup holds in memory so a flood of fabricated package names cannot grow
-// broker memory without bound. Real fleets sit far below it: the retention
-// window holds 168 hours, and devices carry a few hundred packages at most.
+// broker memory without bound. When the cap is full, a count from a newer hour
+// evicts the oldest complete hour bucket; this preserves the most recent data
+// instead of starving every new hour until an old bucket reaches retention.
 const maxTelemetryAppRollupEntries = 10000
 
 // telemetryAppRollupHour is the bucket an application_connection event counts
@@ -177,12 +178,15 @@ func telemetryAppRollupHour(record TelemetryRecord, now time.Time) time.Time {
 // telemetryAppRollup accumulates hourly application-connection counts. None of
 // its methods lock — the owning sink's lock guards all access.
 type telemetryAppRollup struct {
-	hours   map[time.Time]map[string]int64
-	entries int
+	hours          map[time.Time]map[string]int64
+	entries        int
+	evictedEntries int64
 }
 
-// add counts one bucket increment, reporting false when the entry cap forced
-// it to drop a new (hour, application) pair. Existing pairs always increment.
+// add counts one bucket increment. Existing pairs always increment. At the
+// entry cap, a newer hour evicts the oldest complete bucket to make room; add
+// reports false only when the cap is saturated entirely by the incoming hour
+// or newer hours, as can happen during a fabricated-package flood.
 func (r *telemetryAppRollup) add(hour time.Time, application string, count int64) bool {
 	if application == "" || count <= 0 {
 		return true
@@ -190,18 +194,48 @@ func (r *telemetryAppRollup) add(hour time.Time, application string, count int64
 	if r.hours == nil {
 		r.hours = make(map[time.Time]map[string]int64)
 	}
+	if apps := r.hours[hour]; apps != nil {
+		if _, ok := apps[application]; ok {
+			apps[application] += count
+			return true
+		}
+	}
+	for r.entries >= maxTelemetryAppRollupEntries {
+		if !r.evictOldestHourBefore(hour) {
+			return false
+		}
+	}
 	apps := r.hours[hour]
 	if apps == nil {
 		apps = make(map[string]int64)
 		r.hours[hour] = apps
 	}
-	if _, ok := apps[application]; !ok {
-		if r.entries >= maxTelemetryAppRollupEntries {
-			return false
-		}
-		r.entries++
-	}
+	r.entries++
 	apps[application] += count
+	return true
+}
+
+// evictOldestHourBefore removes the oldest complete bucket strictly before
+// hour. Keeping eviction hour-granular makes the rollup's degraded behavior
+// predictable under cardinality pressure and guarantees current data wins over
+// older data without ever exceeding the global memory bound.
+func (r *telemetryAppRollup) evictOldestHourBefore(hour time.Time) bool {
+	var oldest time.Time
+	found := false
+	for candidate := range r.hours {
+		if !candidate.Before(hour) || (found && !candidate.Before(oldest)) {
+			continue
+		}
+		oldest = candidate
+		found = true
+	}
+	if !found {
+		return false
+	}
+	evicted := len(r.hours[oldest])
+	r.entries -= evicted
+	r.evictedEntries += int64(evicted)
+	delete(r.hours, oldest)
 	return true
 }
 
@@ -342,12 +376,18 @@ func newJSONLTelemetrySinkWithLimits(path string, now func() time.Time, flushInt
 		path: path, file: file, now: now, stop: make(chan struct{}), done: make(chan struct{}),
 		telemetryRetained: telemetryRetained{memoryLimit: memoryLimit}, fileLimit: fileLimit,
 	}
-	if err := sink.loadRecent(); err != nil {
+	needsPrivacyCompaction, err := sink.loadRecent()
+	if err != nil {
 		_ = file.Close()
 		return nil, err
 	}
 	sink.writer = bufio.NewWriter(file)
-	if err := sink.maybeCompactLocked(); err != nil {
+	if needsPrivacyCompaction {
+		err = sink.compactLocked()
+	} else {
+		err = sink.maybeCompactLocked()
+	}
+	if err != nil {
 		_ = sink.file.Close()
 		return nil, fmt.Errorf("compact telemetry file: %w", err)
 	}
@@ -355,35 +395,36 @@ func newJSONLTelemetrySinkWithLimits(path string, now func() time.Time, flushInt
 	return sink, nil
 }
 
-func (s *JSONLTelemetrySink) loadRecent() error {
+func (s *JSONLTelemetrySink) loadRecent() (bool, error) {
 	info, err := s.file.Stat()
 	if err != nil {
-		return fmt.Errorf("stat telemetry file: %w", err)
+		return false, fmt.Errorf("stat telemetry file: %w", err)
 	}
 	s.fileBytes = info.Size()
 
 	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek telemetry file: %w", err)
+		return false, fmt.Errorf("seek telemetry file: %w", err)
 	}
 	cutoff := s.now().UTC().Add(-telemetryRetention)
 	scanner := bufio.NewScanner(s.file)
 	scanner.Buffer(make([]byte, 64<<10), maxTelemetryBodyBytes*2)
 	line := 0
+	needsPrivacyCompaction := false
 	for scanner.Scan() {
 		line++
 		var record TelemetryRecord
 		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
-			return fmt.Errorf("decode telemetry record on line %d: %w", line, err)
-		}
-		if retentionTime(record).Before(cutoff) {
-			continue
+			return false, fmt.Errorf("decode telemetry record on line %d: %w", line, err)
 		}
 		// Legacy files may hold raw application_connection rows from before the
-		// rollup existed. Skip them entirely — compaction then sheds them from
-		// the file. They are not folded into the rollup either: whether the file
-		// still holds a row depends on compaction timing, so counting them here
-		// would make restart counts nondeterministic.
+		// rollup existed. Skip every such row, including one already outside
+		// retention, and force a startup compaction so its browsing metadata is
+		// physically removed even when the file is below the normal size limit.
 		if record.Event.Event == telemetryAppConnectionEvent {
+			needsPrivacyCompaction = true
+			continue
+		}
+		if retentionTime(record).Before(cutoff) {
 			continue
 		}
 		size := int64(len(scanner.Bytes()) + 1)
@@ -400,11 +441,11 @@ func (s *JSONLTelemetrySink) loadRecent() error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read telemetry file: %w", err)
+		return false, fmt.Errorf("read telemetry file: %w", err)
 	}
 	s.dropOldestOverBudget()
 	_, err = s.file.Seek(0, io.SeekEnd)
-	return err
+	return needsPrivacyCompaction, err
 }
 
 // retentionTime is the timestamp retention decisions key off: the
@@ -446,12 +487,20 @@ func (s *JSONLTelemetrySink) WriteTelemetry(_ context.Context, records []Telemet
 	}
 
 	now := s.now().UTC()
+	cutoff := now.Add(-telemetryRetention)
+	// Free expired app buckets before accepting this batch so stale entries can
+	// never make the cap reject the first count after a quiet period.
+	s.appRollup.prune(cutoff)
+	droppedAppCounts := 0
+	evictedAppCountsBefore := s.appRollup.evictedEntries
 	for _, record := range records {
 		if record.Event.Event == telemetryAppConnectionEvent {
 			// Rolled up, never persisted — see telemetryAppConnectionEvent. The
 			// in-memory rollup is this sink's only copy, so top-apps counts
 			// restart empty; the Postgres store persists its rollup instead.
-			s.appRollup.add(telemetryAppRollupHour(record, now), record.Event.Application, 1)
+			if !s.appRollup.add(telemetryAppRollupHour(record, now), record.Event.Application, 1) {
+				droppedAppCounts++
+			}
 			continue
 		}
 		line, err := json.Marshal(record)
@@ -467,13 +516,21 @@ func (s *JSONLTelemetrySink) WriteTelemetry(_ context.Context, records []Telemet
 		s.append(record, size)
 		s.fileBytes += size
 	}
-	cutoff := now.Add(-telemetryRetention)
 	s.prune(cutoff)
+	// Programmatic callers can supply records with an old ReceivedAt even though
+	// the HTTP handler always stamps the current time. Remove any such bucket
+	// added by this batch as well as pruning before it for capacity.
 	s.appRollup.prune(cutoff)
 	s.dropOldestOverBudget()
 	if err := s.maybeCompactLocked(); err != nil {
 		s.writeErr = fmt.Errorf("compact telemetry file: %w", err)
 		return s.writeErr
+	}
+	if droppedAppCounts > 0 {
+		slog.Warn("dropped application-connection counts over rollup entry cap", "dropped", droppedAppCounts, "store", "jsonl")
+	}
+	if evicted := s.appRollup.evictedEntries - evictedAppCountsBefore; evicted > 0 {
+		slog.Warn("evicted oldest application-connection rollup entries to preserve current counts", "evicted", evicted, "store", "jsonl")
 	}
 	return nil
 }
@@ -554,7 +611,7 @@ func (s *JSONLTelemetrySink) compactLocked() error {
 	if err := s.flushLocked(false); err != nil {
 		return err
 	}
-	dir, base := filepath.Split(s.path)
+	dir, base := filepath.Dir(s.path), filepath.Base(s.path)
 	temp, err := os.CreateTemp(dir, base+".compact-*")
 	if err != nil {
 		return fmt.Errorf("create compaction file: %w", err)

--- a/internal/broker/telemetry.go
+++ b/internal/broker/telemetry.go
@@ -149,6 +149,91 @@ type storedTelemetryRecord struct {
 	bytes  int64
 }
 
+// application_connection events are one row per tunnelled flow (with a
+// per-package fan-out on Android) — at production volume they were ~95% of all
+// telemetry rows while feeding exactly one dashboard panel, and their payload
+// pairs the client's IP with every destination it visited. No sink stores them
+// as records: every sink folds them into an hourly per-application count and
+// discards the rest of the event, so the destination/client-IP browsing log
+// never reaches disk. The dashboard's top-apps panel reads these rollups.
+const telemetryAppConnectionEvent = "application_connection"
+
+// maxTelemetryAppRollupEntries bounds the distinct (hour, application) pairs a
+// rollup holds in memory so a flood of fabricated package names cannot grow
+// broker memory without bound. Real fleets sit far below it: the retention
+// window holds 168 hours, and devices carry a few hundred packages at most.
+const maxTelemetryAppRollupEntries = 10000
+
+// telemetryAppRollupHour is the bucket an application_connection event counts
+// into: the server-assigned receipt hour (falling back like retentionTime, so
+// a bucket can never be client-controlled).
+func telemetryAppRollupHour(record TelemetryRecord, now time.Time) time.Time {
+	if at := retentionTime(record); !at.IsZero() {
+		return at.UTC().Truncate(time.Hour)
+	}
+	return now.UTC().Truncate(time.Hour)
+}
+
+// telemetryAppRollup accumulates hourly application-connection counts. None of
+// its methods lock — the owning sink's lock guards all access.
+type telemetryAppRollup struct {
+	hours   map[time.Time]map[string]int64
+	entries int
+}
+
+// add counts one bucket increment, reporting false when the entry cap forced
+// it to drop a new (hour, application) pair. Existing pairs always increment.
+func (r *telemetryAppRollup) add(hour time.Time, application string, count int64) bool {
+	if application == "" || count <= 0 {
+		return true
+	}
+	if r.hours == nil {
+		r.hours = make(map[time.Time]map[string]int64)
+	}
+	apps := r.hours[hour]
+	if apps == nil {
+		apps = make(map[string]int64)
+		r.hours[hour] = apps
+	}
+	if _, ok := apps[application]; !ok {
+		if r.entries >= maxTelemetryAppRollupEntries {
+			return false
+		}
+		r.entries++
+	}
+	apps[application] += count
+	return true
+}
+
+// prune drops whole hour buckets that have aged out of the retention window,
+// mirroring the Postgres store's DELETE on its counts table.
+func (r *telemetryAppRollup) prune(cutoff time.Time) {
+	cutoffHour := cutoff.UTC().Truncate(time.Hour)
+	for hour, apps := range r.hours {
+		if hour.Before(cutoffHour) {
+			r.entries -= len(apps)
+			delete(r.hours, hour)
+		}
+	}
+}
+
+// countsIn sums the buckets the dashboard window touches: every hour from the
+// truncated window start through now. The window edge is hour-granular by
+// design — the SQL path filters its counts table the same way.
+func (r *telemetryAppRollup) countsIn(now time.Time, window time.Duration) map[string]int {
+	startHour := now.Add(-window).UTC().Truncate(time.Hour)
+	counts := make(map[string]int)
+	for hour, apps := range r.hours {
+		if hour.Before(startHour) || hour.After(now) {
+			continue
+		}
+		for application, count := range apps {
+			counts[application] += int(count)
+		}
+	}
+	return counts
+}
+
 // telemetryRetained is the bounded in-memory record set that serves the
 // dashboard's TelemetryReader queries; it is shared by every sink that keeps
 // dashboard reads in memory. None of its methods lock — the owning sink's
@@ -213,6 +298,7 @@ type JSONLTelemetrySink struct {
 	file   *os.File
 	writer *bufio.Writer
 	telemetryRetained
+	appRollup telemetryAppRollup
 	fileBytes int64
 	fileLimit int64
 	now       func() time.Time
@@ -292,6 +378,14 @@ func (s *JSONLTelemetrySink) loadRecent() error {
 		if retentionTime(record).Before(cutoff) {
 			continue
 		}
+		// Legacy files may hold raw application_connection rows from before the
+		// rollup existed. Skip them entirely — compaction then sheds them from
+		// the file. They are not folded into the rollup either: whether the file
+		// still holds a row depends on compaction timing, so counting them here
+		// would make restart counts nondeterministic.
+		if record.Event.Event == telemetryAppConnectionEvent {
+			continue
+		}
 		size := int64(len(scanner.Bytes()) + 1)
 		s.append(record, size)
 		// Keep memory bounded during the scan, but trim only after overshooting the
@@ -351,7 +445,15 @@ func (s *JSONLTelemetrySink) WriteTelemetry(_ context.Context, records []Telemet
 		return s.writeErr
 	}
 
+	now := s.now().UTC()
 	for _, record := range records {
+		if record.Event.Event == telemetryAppConnectionEvent {
+			// Rolled up, never persisted — see telemetryAppConnectionEvent. The
+			// in-memory rollup is this sink's only copy, so top-apps counts
+			// restart empty; the Postgres store persists its rollup instead.
+			s.appRollup.add(telemetryAppRollupHour(record, now), record.Event.Application, 1)
+			continue
+		}
 		line, err := json.Marshal(record)
 		if err != nil {
 			return fmt.Errorf("encode telemetry record: %w", err)
@@ -365,7 +467,9 @@ func (s *JSONLTelemetrySink) WriteTelemetry(_ context.Context, records []Telemet
 		s.append(record, size)
 		s.fileBytes += size
 	}
-	s.prune(s.now().UTC().Add(-telemetryRetention))
+	cutoff := now.Add(-telemetryRetention)
+	s.prune(cutoff)
+	s.appRollup.prune(cutoff)
 	s.dropOldestOverBudget()
 	if err := s.maybeCompactLocked(); err != nil {
 		s.writeErr = fmt.Errorf("compact telemetry file: %w", err)
@@ -433,6 +537,14 @@ func (s *JSONLTelemetrySink) TelemetryRecords(since time.Time) []TelemetryRecord
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.recordsSince(since)
+}
+
+// AppConnectionCounts serves the dashboard's top-apps panel from the in-memory
+// hourly rollup (see telemetryAppConnectionEvent).
+func (s *JSONLTelemetrySink) AppConnectionCounts(now time.Time, window time.Duration) map[string]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.appRollup.countsIn(now, window)
 }
 
 // compactLocked rewrites the JSONL file to contain only the records still

--- a/internal/broker/telemetry_query.go
+++ b/internal/broker/telemetry_query.go
@@ -13,23 +13,39 @@ type TelemetryQuerier interface {
 	TelemetrySessions(now time.Time, window time.Duration, offset, limit int) ([]sessionSummary, int, error)
 }
 
+// telemetryAppCounter is the optional capability a TelemetryReader exposes
+// when it keeps an hourly application-connection rollup (the JSONL sink does);
+// the dashboard's top-apps panel is fed from it, never from stored records.
+type telemetryAppCounter interface {
+	AppConnectionCounts(now time.Time, window time.Duration) map[string]int
+}
+
 // telemetryReaderQuerier adapts any TelemetryReader (the JSONL sink's bounded
 // in-memory record set) to the dashboard's query interface by aggregating in
 // Go on every request.
 type telemetryReaderQuerier struct {
 	reader TelemetryReader
+	apps   telemetryAppCounter
 }
 
 func newTelemetryReaderQuerier(reader TelemetryReader) telemetryReaderQuerier {
-	return telemetryReaderQuerier{reader: reader}
+	querier := telemetryReaderQuerier{reader: reader}
+	if counter, ok := reader.(telemetryAppCounter); ok {
+		querier.apps = counter
+	}
+	return querier
 }
 
 func (q telemetryReaderQuerier) TelemetryOverview(now time.Time, window time.Duration) (telemetryOverview, error) {
-	return buildTelemetryOverview(q.reader.TelemetryRecords(now.Add(-window)), now, window), nil
+	var appCounts map[string]int
+	if q.apps != nil {
+		appCounts = q.apps.AppConnectionCounts(now, window)
+	}
+	return buildTelemetryOverview(q.reader.TelemetryRecords(now.Add(-window)), appCounts, now, window), nil
 }
 
 func (q telemetryReaderQuerier) TelemetrySessions(now time.Time, window time.Duration, offset, limit int) ([]sessionSummary, int, error) {
-	overview := buildTelemetryOverview(q.reader.TelemetryRecords(now.Add(-window)), now, window)
+	overview := buildTelemetryOverview(q.reader.TelemetryRecords(now.Add(-window)), nil, now, window)
 	total := len(overview.Recent)
 	if offset > total {
 		offset = total

--- a/internal/broker/telemetry_test.go
+++ b/internal/broker/telemetry_test.go
@@ -681,3 +681,155 @@ func TestTelemetryRetainedBudgetPruneAndSince(t *testing.T) {
 		t.Fatalf("unexpected recordsSince result: %+v", since)
 	}
 }
+
+func appConnectionRecordAt(receivedAt time.Time, eventID, application string) TelemetryRecord {
+	record := telemetryRecordAt(receivedAt, eventID)
+	record.Event.Event = telemetryAppConnectionEvent
+	record.Event.Application = application
+	record.Event.DestinationIP = "198.51.100.9"
+	record.Event.DestinationPort = 443
+	return record
+}
+
+func TestTelemetryAppRollupBucketsPrunesAndCaps(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
+	var rollup telemetryAppRollup
+
+	rollup.add(now.Truncate(time.Hour), "app-a", 1)
+	rollup.add(now.Truncate(time.Hour), "app-a", 2)
+	rollup.add(now.Add(-70*time.Minute).Truncate(time.Hour), "app-b", 1)
+	rollup.add(now.Add(-30*time.Hour).Truncate(time.Hour), "app-old", 5)
+	rollup.add(now.Truncate(time.Hour), "", 9) // empty package names never count
+
+	// The 1h window's start (11:30) truncates to the 11:00 bucket, so app-b —
+	// received before the window opened — still counts: the edge is
+	// hour-granular by design, matching the SQL rollup filter.
+	counts := rollup.countsIn(now, time.Hour)
+	if counts["app-a"] != 3 || counts["app-b"] != 1 || len(counts) != 2 {
+		t.Fatalf("unexpected 1h counts: %+v", counts)
+	}
+	counts = rollup.countsIn(now, 48*time.Hour)
+	if counts["app-old"] != 5 || len(counts) != 3 {
+		t.Fatalf("unexpected 48h counts: %+v", counts)
+	}
+
+	rollup.prune(now.Add(-24 * time.Hour))
+	if counts = rollup.countsIn(now, 48*time.Hour); counts["app-old"] != 0 || len(counts) != 2 {
+		t.Fatalf("expected pruned rollup to drop app-old: %+v", counts)
+	}
+	if rollup.entries != 2 {
+		t.Fatalf("expected 2 entries after prune, got %d", rollup.entries)
+	}
+
+	var capped telemetryAppRollup
+	hour := now.Truncate(time.Hour)
+	for i := 0; i < maxTelemetryAppRollupEntries; i++ {
+		if !capped.add(hour, fmt.Sprintf("app-%05d", i), 1) {
+			t.Fatalf("unexpected cap refusal at entry %d", i)
+		}
+	}
+	if capped.add(hour, "app-overflow", 1) {
+		t.Fatal("expected the entry cap to refuse a new application")
+	}
+	if !capped.add(hour, "app-00000", 1) {
+		t.Fatal("existing applications must keep counting at the cap")
+	}
+}
+
+func TestJSONLTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
+	sink, err := newJSONLTelemetrySink(path, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := []TelemetryRecord{
+		telemetryRecordAt(now.Add(-time.Minute), "kept-1"),
+		appConnectionRecordAt(now.Add(-2*time.Minute), "app-1", "com.instagram.android"),
+		appConnectionRecordAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android"),
+		appConnectionRecordAt(now.Add(-70*time.Minute), "app-3", "org.telegram.messenger"),
+	}
+	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sink.TelemetryRecords(now.Add(-telemetryRetention)); len(got) != 1 || got[0].Event.EventID != "kept-1" {
+		t.Fatalf("application_connection records must not be retained: %+v", got)
+	}
+	counts := sink.AppConnectionCounts(now, time.Hour)
+	if counts["com.instagram.android"] != 2 || counts["org.telegram.messenger"] != 1 {
+		t.Fatalf("unexpected rollup counts: %+v", counts)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), telemetryAppConnectionEvent) || strings.Contains(string(data), "198.51.100.9") {
+		t.Fatalf("application_connection payloads must never reach disk: %s", data)
+	}
+}
+
+func TestJSONLTelemetrySinkSkipsLegacyApplicationConnectionRows(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoder := json.NewEncoder(file)
+	for _, record := range []TelemetryRecord{
+		appConnectionRecordAt(now.Add(-time.Hour), "legacy-app", "com.instagram.android"),
+		telemetryRecordAt(now.Add(-time.Minute), "kept-1"),
+	} {
+		if err := encoder.Encode(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sink, err := newJSONLTelemetrySink(path, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+	if got := sink.TelemetryRecords(now.Add(-telemetryRetention)); len(got) != 1 || got[0].Event.EventID != "kept-1" {
+		t.Fatalf("legacy application_connection rows must be skipped at load: %+v", got)
+	}
+	// Legacy rows are not folded into the rollup either — whether the file
+	// still holds one depends on compaction timing, so counting them would
+	// make restart counts nondeterministic.
+	if counts := sink.AppConnectionCounts(now, telemetryRetention); len(counts) != 0 {
+		t.Fatalf("legacy rows must not seed the rollup: %+v", counts)
+	}
+}
+
+func TestTelemetryReaderQuerierServesTopAppsFromRollup(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
+	store := &dashboardTelemetryStore{}
+	err := store.WriteTelemetry(context.Background(), []TelemetryRecord{
+		telemetryRecordAt(now.Add(-time.Minute), "session-event"),
+		appConnectionRecordAt(now.Add(-2*time.Minute), "app-1", "com.instagram.android"),
+		appConnectionRecordAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android"),
+		appConnectionRecordAt(now.Add(-4*time.Minute), "app-3", "org.telegram.messenger"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	overview, err := newTelemetryReaderQuerier(store).TelemetryOverview(now, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(overview.TopApps) != 2 || overview.TopApps[0].Name != "com.instagram.android" || overview.TopApps[0].Count != 2 {
+		t.Fatalf("unexpected top apps: %+v", overview.TopApps)
+	}
+	// The app-connection events created no sessions or clients: only the
+	// stored record's session counts.
+	if overview.Totals.Sessions != 1 || overview.Totals.Clients != 1 {
+		t.Fatalf("application_connection must not create sessions: %+v", overview.Totals)
+	}
+}

--- a/internal/broker/telemetry_test.go
+++ b/internal/broker/telemetry_test.go
@@ -736,6 +736,57 @@ func TestTelemetryAppRollupBucketsPrunesAndCaps(t *testing.T) {
 	}
 }
 
+func TestTelemetryAppRollupEvictsOldestHourForCurrentCounts(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	const appsPerHour = 100
+	hours := maxTelemetryAppRollupEntries / appsPerHour
+	var rollup telemetryAppRollup
+	for hoursAgo := hours; hoursAgo > 0; hoursAgo-- {
+		hour := now.Add(-time.Duration(hoursAgo) * time.Hour)
+		for app := 0; app < appsPerHour; app++ {
+			if !rollup.add(hour, fmt.Sprintf("app-%03d", app), 1) {
+				t.Fatalf("unexpected cap refusal with %d hours ago and app %d", hoursAgo, app)
+			}
+		}
+	}
+	oldest := now.Add(-time.Duration(hours) * time.Hour)
+	for app := 0; app < appsPerHour; app++ {
+		if !rollup.add(now, fmt.Sprintf("current-app-%03d", app), 1) {
+			t.Fatalf("current-hour count %d must evict the oldest hour instead of being dropped", app)
+		}
+	}
+	if _, ok := rollup.hours[oldest]; ok {
+		t.Fatal("expected the oldest complete hour to be evicted")
+	}
+	if got, want := rollup.entries, maxTelemetryAppRollupEntries; got != want {
+		t.Fatalf("unexpected entry count after eviction: got %d, want %d", got, want)
+	}
+	if got, want := rollup.evictedEntries, int64(appsPerHour); got != want {
+		t.Fatalf("unexpected reported eviction count: got %d, want %d", got, want)
+	}
+	if counts := rollup.countsIn(now, telemetryRetention); counts["current-app-000"] != 1 || counts["current-app-099"] != 1 {
+		t.Fatalf("current-hour count was not retained: %+v", counts)
+	}
+}
+
+func TestJSONLTelemetrySinkPrunesOldAppCountFromCurrentBatch(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
+	sink, err := newJSONLTelemetrySink(path, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+	if err := sink.WriteTelemetry(context.Background(), []TelemetryRecord{
+		appConnectionRecordAt(now.Add(-telemetryRetention-time.Hour), "expired-app", "com.expired.example"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if counts := sink.AppConnectionCounts(now, telemetryRetention); len(counts) != 0 {
+		t.Fatalf("expired app count from current batch must not survive retention pruning: %+v", counts)
+	}
+}
+
 func TestJSONLTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
 	path := filepath.Join(t.TempDir(), "telemetry.jsonl")
@@ -781,6 +832,7 @@ func TestJSONLTelemetrySinkSkipsLegacyApplicationConnectionRows(t *testing.T) {
 	}
 	encoder := json.NewEncoder(file)
 	for _, record := range []TelemetryRecord{
+		appConnectionRecordAt(now.Add(-telemetryRetention-time.Hour), "legacy-expired-app", "com.expired.example"),
 		appConnectionRecordAt(now.Add(-time.Hour), "legacy-app", "com.instagram.android"),
 		telemetryRecordAt(now.Add(-time.Minute), "kept-1"),
 	} {
@@ -800,11 +852,21 @@ func TestJSONLTelemetrySinkSkipsLegacyApplicationConnectionRows(t *testing.T) {
 	if got := sink.TelemetryRecords(now.Add(-telemetryRetention)); len(got) != 1 || got[0].Event.EventID != "kept-1" {
 		t.Fatalf("legacy application_connection rows must be skipped at load: %+v", got)
 	}
-	// Legacy rows are not folded into the rollup either — whether the file
-	// still holds one depends on compaction timing, so counting them would
-	// make restart counts nondeterministic.
+	// Legacy rows are not folded into the rollup either: pre-rollup files may
+	// already have been compacted, so reconstructing only the rows that happen
+	// to remain would make restart counts incomplete and nondeterministic.
 	if counts := sink.AppConnectionCounts(now, telemetryRetention); len(counts) != 0 {
 		t.Fatalf("legacy rows must not seed the rollup: %+v", counts)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), telemetryAppConnectionEvent) || strings.Contains(string(data), "198.51.100.9") {
+		t.Fatalf("legacy application_connection payloads must be scrubbed during startup: %s", data)
+	}
+	if !strings.Contains(string(data), "kept-1") {
+		t.Fatalf("startup privacy compaction dropped the retained record: %s", data)
 	}
 }
 


### PR DESCRIPTION
## Problem

The telemetry dashboard's **24h and 7d windows fail** with "Could not load telemetry": both dashboard queries hit their 30s timeout (`could not build telemetry overview … context deadline exceeded` on every load since ~Jul 18).

Root cause, measured on prod:

- Daily volume jumped from ~560k rows (Jul 13) to **3.42M rows / 1.4 GB payload (Jul 19)** — real growth, 1,429 distinct clients/day.
- **`application_connection` is 95% of all rows** (3.28M of 3.44M in 24h): one event per tunnelled flow — including every DNS query (50% of events are port 53) — multiplied by a per-package fan-out on Android (one system connection emits one event per package sharing the UID).
- The dashboard queries scan every event in the window; the box is I/O-bound on the fat partitions (a single-field count over one day takes >2 minutes).
- All those rows feed exactly **one** panel (top applications), and their payload pairs the client's real IP with every destination IP they visit — a browsing log we never wanted to hold (see telemetry review 2026-07-12).

## Change

`application_connection` events are no longer stored as records in either telemetry store. Ingestion folds each one into an **hourly per-application count** and discards the rest of the event (destination IP, per-event geo/client IP):

- **Postgres**: new tiny `telemetry_app_counts (hour, application, connections)` table, upserted on flush (chunked, `ON CONFLICT … DO UPDATE`), pruned in `PruneTelemetry` with the same cutoff as the partitions.
- **JSONL mode**: an equivalent in-memory rollup (restarts empty; documented). Legacy raw rows in existing files are skipped at load and shed by compaction.
- **Dashboard**: the top-apps panel reads the rollup (window edge is hour-granular by design); the events CTE additionally filters `event <> 'application_connection'` belt-and-braces so pre-existing fat partitions stay cheap to aggregate over once rewritten (below).
- Both backends implement identical semantics, so the byte-parity tests keep holding; the parity fixture now includes app-connection records that pin the hour-edge and exclusion behaviour. A bounded entry cap (10k distinct hour×app pairs) keeps a fabricated-package flood from growing memory.

The dashboard's geo/country/ISP panels are unaffected: geo attributes ride on heartbeats and connection events too (measured: 87k of 99k heartbeats carry country).

Client-side follow-up (separate repo, next app release): skip DNS/NTP flows, dedupe the per-package fan-out, aggregate before upload. Old clients keep working against this broker unchanged.

## Deploy runbook (after merge)

1. Deploy the new broker image (normal blue-green roll). From this moment no new `application_connection` rows are written.
2. **Backfill** the rollup from the raw rows still in the table (one-time, minutes-long scan, run off-peak):
   ```sql
   INSERT INTO telemetry_app_counts (hour, application, connections)
   SELECT date_trunc('hour', received_at), payload->>'application_package', count(*)
   FROM telemetry_events
   WHERE event = 'application_connection' AND payload->>'application_package' <> ''
   GROUP BY 1, 2
   ON CONFLICT (hour, application) DO UPDATE
     SET connections = telemetry_app_counts.connections + EXCLUDED.connections;
   ```
3. **Rewrite the closed fat partitions** (Jul 18/19 — and Jul 20 the day after) so the 24h/7d windows are fast immediately instead of after 7 days of retention aging. A `DELETE` alone doesn't shrink the heap, so swap each partition for a filtered copy, e.g. for the 19th (repeat per closed day; never the current day):
   ```sql
   BEGIN;
   CREATE TABLE telemetry_events_20260719_new (LIKE telemetry_events INCLUDING DEFAULTS);
   INSERT INTO telemetry_events_20260719_new
     SELECT * FROM telemetry_events_20260719 WHERE event <> 'application_connection';
   ALTER TABLE telemetry_events DETACH PARTITION telemetry_events_20260719;
   ALTER TABLE telemetry_events ATTACH PARTITION telemetry_events_20260719_new
     FOR VALUES FROM ('2026-07-19') TO ('2026-07-20');
   DROP TABLE telemetry_events_20260719;
   ALTER TABLE telemetry_events_20260719_new RENAME TO telemetry_events_20260719;
   COMMIT;
   ```
   (~70 MB kept of ~1.4 GB per fat day.) I can run these against prod on request once the deploy lands.

## Testing

- Full suite green, including the Postgres-gated tests (run locally against a postgres:16 container): parity (overview + sessions + empty), new sink tests for both stores (no rows written, upsert conflict arm, retention prune, legacy-row skip, cap behaviour), and the hourly-edge semantics pinned in both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)