### PR TITLE
Stable relay identity: derive relay_id from a proven Ed25519 key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ openrung-telemetry.jsonl
 # Claude Code local worktrees (may contain absolute paths / local branch content)
 .claude/agents/
 .claude/worktrees/
+relay
+broker
+openrung-*

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,6 @@ openrung-telemetry.jsonl
 # Claude Code local worktrees (may contain absolute paths / local branch content)
 .claude/agents/
 .claude/worktrees/
-relay
-broker
-openrung-*
+/relay
+/broker
+/openrung-*

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
 	"crypto/tls"
 	_ "embed"
 	"flag"
@@ -51,6 +53,7 @@ func main() {
 	flag.StringVar(&cfg.RealityPrivateKey, "reality-private-key", "", "Reality private key; generated with xray x25519 when empty")
 	flag.StringVar(&cfg.RealityPublicKey, "reality-public-key", "", "Reality public key; generated with xray x25519 when empty")
 	flag.StringVar(&cfg.ShortID, "short-id", "", "Reality short ID; generated when empty")
+	flag.StringVar(&cfg.IdentitySeed, "identity-seed", "", "base64 32-byte Ed25519 seed for the relay's stable identity (spec openrung-relay-identity-v1); the broker derives the relay ID from it, so a pinned seed keeps the same ID across restarts. Generated per process when empty")
 	flag.IntVar(&cfg.MaxSessions, "max-sessions", 8, "advertised max client sessions")
 	flag.IntVar(&cfg.MaxMbps, "max-mbps", 20, "advertised max Mbps")
 	flag.DurationVar(&cfg.HeartbeatInterval, "heartbeat-interval", 30*time.Second, "broker heartbeat interval")
@@ -105,6 +108,7 @@ type cliConfig struct {
 	RealityPrivateKey string
 	RealityPublicKey  string
 	ShortID           string
+	IdentitySeed      string
 	MaxSessions       int
 	MaxMbps           int
 	HeartbeatInterval time.Duration
@@ -520,25 +524,33 @@ func runTunnelMode(parent context.Context, cfg cliConfig) error {
 		slog.Info("started xray", "pid", xrayCmd.Process.Pid, "listen", net.JoinHostPort(loopHost, strconv.Itoa(loopPort)))
 	}
 
+	hello := tunnel.HelloFrame{
+		Token:            cfg.RegistrationToken,
+		RealityPublicKey: prepared.RealityPublicKey,
+		ShortID:          prepared.ShortID,
+		ServerName:       cfg.ServerName,
+		ClientID:         prepared.ClientID,
+		Flow:             relay.FlowVision,
+		ExitMode:         relay.ExitModeDirect,
+		MaxSessions:      cfg.MaxSessions,
+		MaxMbps:          cfg.MaxMbps,
+		Label:            cfg.Label,
+		RelayVersion:     reportedRelayVersion(),
+		// A current relay always understands the stream-type discriminator;
+		// PunchCapable additionally asks the hub to advertise a direct path.
+		StreamTyping: true,
+		PunchCapable: cfg.Punch,
+	}
 	client := &tunnel.Client{
 		HubAddr:   cfg.HubAddr,
 		TLSConfig: hubTLSConfig(cfg),
-		Hello: tunnel.HelloFrame{
-			Token:            cfg.RegistrationToken,
-			RealityPublicKey: prepared.RealityPublicKey,
-			ShortID:          prepared.ShortID,
-			ServerName:       cfg.ServerName,
-			ClientID:         prepared.ClientID,
-			Flow:             relay.FlowVision,
-			ExitMode:         relay.ExitModeDirect,
-			MaxSessions:      cfg.MaxSessions,
-			MaxMbps:          cfg.MaxMbps,
-			Label:            cfg.Label,
-			RelayVersion:     reportedRelayVersion(),
-			// A current relay always understands the stream-type discriminator;
-			// PunchCapable additionally asks the hub to advertise a direct path.
-			StreamTyping: true,
-			PunchCapable: cfg.Punch,
+		Hello:     hello,
+		// Each reconnect signs a fresh identity proof, so the hub always holds
+		// one with the full tunnel TTL ahead of it.
+		RefreshHello: func() tunnel.HelloFrame {
+			signed := hello
+			tunnel.SignHello(prepared.IdentityKey, &signed, time.Now().Add(relay.IdentityProofTTLTunnel))
+			return signed
 		},
 		TargetHost: loopHost,
 		TargetPort: loopPort,
@@ -626,6 +638,7 @@ type preparedRuntime struct {
 	ClientID         string
 	RealityPublicKey string
 	ShortID          string
+	IdentityKey      ed25519.PrivateKey
 	XrayConfig       []byte
 }
 
@@ -659,6 +672,26 @@ func prepareRuntime(cfg cliConfig) (preparedRuntime, error) {
 		publicKey = keyPair.PublicKey
 	}
 
+	// The identity key outlives individual registrations: within this process
+	// every register call — including a re-register after the broker forgot
+	// the lease — signs with the same key and keeps the same relay ID. Pin the
+	// seed (-identity-seed / OPENRUNG_IDENTITY_SEED) to also keep it across
+	// restarts.
+	var identityKey ed25519.PrivateKey
+	if cfg.IdentitySeed != "" {
+		parsed, err := relay.ParseIdentitySeed(cfg.IdentitySeed)
+		if err != nil {
+			return preparedRuntime{}, fmt.Errorf("parse identity seed: %w", err)
+		}
+		identityKey = parsed
+	} else {
+		_, generated, err := ed25519.GenerateKey(cryptorand.Reader)
+		if err != nil {
+			return preparedRuntime{}, fmt.Errorf("generate identity key: %w", err)
+		}
+		identityKey = generated
+	}
+
 	xrayConfig, err := relayruntime.BuildXrayConfig(relayruntime.XrayConfigInput{
 		ListenHost:        cfg.ListenHost,
 		ListenPort:        cfg.ListenPort,
@@ -677,6 +710,7 @@ func prepareRuntime(cfg cliConfig) (preparedRuntime, error) {
 		ClientID:         clientID,
 		RealityPublicKey: publicKey,
 		ShortID:          shortID,
+		IdentityKey:      identityKey,
 		XrayConfig:       xrayConfig,
 	}, nil
 }
@@ -701,6 +735,9 @@ func register(ctx context.Context, broker *relayruntime.BrokerClient, cfg cliCon
 		Label:            cfg.Label,
 		NodeClass:        cfg.NodeClass,
 	}
+	// Signed after every other field is final: the statement binds them.
+	req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt =
+		relay.SignIdentity(prepared.IdentityKey, req, time.Now().Add(relay.IdentityProofTTLDirect))
 	desc, err := broker.Register(ctx, req)
 	if err != nil {
 		return relay.Descriptor{}, err

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -36,6 +36,14 @@ var (
 
 func main() {
 	var cfg cliConfig
+	identitySeed := os.Getenv(relayruntime.IdentitySeedEnvironmentVariable)
+	// Retain environment-based configuration without leaving the long-lived
+	// identity seed available to Xray or any other child process. Explicit
+	// -identity-seed still takes precedence when flags are parsed below.
+	if err := os.Unsetenv(relayruntime.IdentitySeedEnvironmentVariable); err != nil {
+		slog.Error("clear relay identity seed from environment", "error", err)
+		os.Exit(1)
+	}
 	showVersion := flag.Bool("version", false, "print relay version and exit")
 	flag.StringVar(&cfg.BrokerURL, "broker", "http://localhost:8080", "broker base URL")
 	flag.StringVar(&cfg.RegistrationToken, "registration-token", os.Getenv("OPENRUNG_VOLUNTEER_TOKEN"), "volunteer-class relay registration token")
@@ -53,7 +61,7 @@ func main() {
 	flag.StringVar(&cfg.RealityPrivateKey, "reality-private-key", "", "Reality private key; generated with xray x25519 when empty")
 	flag.StringVar(&cfg.RealityPublicKey, "reality-public-key", "", "Reality public key; generated with xray x25519 when empty")
 	flag.StringVar(&cfg.ShortID, "short-id", "", "Reality short ID; generated when empty")
-	flag.StringVar(&cfg.IdentitySeed, "identity-seed", os.Getenv("OPENRUNG_IDENTITY_SEED"), "base64 32-byte Ed25519 seed for the relay's stable identity (spec openrung-relay-identity-v1); the broker derives the relay ID from it, so a pinned seed keeps the same ID across restarts. Generated per process when empty")
+	flag.StringVar(&cfg.IdentitySeed, "identity-seed", identitySeed, "base64 32-byte Ed25519 seed for the relay's stable identity (spec openrung-relay-identity-v1); the broker derives the relay ID from it, so a pinned seed keeps the same ID across restarts. Generated per process when empty")
 	flag.IntVar(&cfg.MaxSessions, "max-sessions", 8, "advertised max client sessions")
 	flag.IntVar(&cfg.MaxMbps, "max-mbps", 20, "advertised max Mbps")
 	flag.DurationVar(&cfg.HeartbeatInterval, "heartbeat-interval", 30*time.Second, "broker heartbeat interval")
@@ -374,7 +382,7 @@ func run(cfg cliConfig) error {
 	var errCh <-chan error
 	var observerErrCh <-chan error
 	if !cfg.SkipXrayRun {
-		xrayCmd = exec.CommandContext(ctx, cfg.XrayPath, "run", "-config", configPath)
+		xrayCmd = relayruntime.NewXrayCommand(ctx, cfg.XrayPath, "run", "-config", configPath)
 		xrayCmd.Stdout = os.Stdout
 		xrayCmd.Stderr = os.Stderr
 		if err := xrayCmd.Start(); err != nil {
@@ -514,7 +522,7 @@ func runTunnelMode(parent context.Context, cfg cliConfig) error {
 	var xrayCmd *exec.Cmd
 	xrayErr := make(chan error, 1)
 	if !cfg.SkipXrayRun {
-		xrayCmd = exec.CommandContext(ctx, cfg.XrayPath, "run", "-config", configPath)
+		xrayCmd = relayruntime.NewXrayCommand(ctx, cfg.XrayPath, "run", "-config", configPath)
 		xrayCmd.Stdout = os.Stdout
 		xrayCmd.Stderr = os.Stderr
 		if err := xrayCmd.Start(); err != nil {
@@ -614,7 +622,7 @@ func boolEnv(key string) bool {
 }
 
 func heartbeatOrRegister(ctx context.Context, broker *relayruntime.BrokerClient, cfg cliConfig, prepared preparedRuntime, desc relay.Descriptor) (relay.Descriptor, bool, error) {
-	if err := heartbeat(ctx, broker, desc.ID); err != nil {
+	if err := heartbeat(ctx, broker, desc.ID, desc.LeaseToken); err != nil {
 		if !relayruntime.IsRelayNotFound(err) {
 			return desc, false, err
 		}
@@ -776,8 +784,8 @@ func versionInfo() string {
 	return fmt.Sprintf("%s revision=%s", reportedRelayVersion(), resolvedRevision())
 }
 
-func heartbeat(ctx context.Context, broker *relayruntime.BrokerClient, id string) error {
-	return broker.Heartbeat(ctx, id)
+func heartbeat(ctx context.Context, broker *relayruntime.BrokerClient, id, leaseToken string) error {
+	return broker.Heartbeat(ctx, id, leaseToken)
 }
 
 func (c cliConfig) brokerClient() *relayruntime.BrokerClient {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -53,7 +53,7 @@ func main() {
 	flag.StringVar(&cfg.RealityPrivateKey, "reality-private-key", "", "Reality private key; generated with xray x25519 when empty")
 	flag.StringVar(&cfg.RealityPublicKey, "reality-public-key", "", "Reality public key; generated with xray x25519 when empty")
 	flag.StringVar(&cfg.ShortID, "short-id", "", "Reality short ID; generated when empty")
-	flag.StringVar(&cfg.IdentitySeed, "identity-seed", "", "base64 32-byte Ed25519 seed for the relay's stable identity (spec openrung-relay-identity-v1); the broker derives the relay ID from it, so a pinned seed keeps the same ID across restarts. Generated per process when empty")
+	flag.StringVar(&cfg.IdentitySeed, "identity-seed", os.Getenv("OPENRUNG_IDENTITY_SEED"), "base64 32-byte Ed25519 seed for the relay's stable identity (spec openrung-relay-identity-v1); the broker derives the relay ID from it, so a pinned seed keeps the same ID across restarts. Generated per process when empty")
 	flag.IntVar(&cfg.MaxSessions, "max-sessions", 8, "advertised max client sessions")
 	flag.IntVar(&cfg.MaxMbps, "max-mbps", 20, "advertised max Mbps")
 	flag.DurationVar(&cfg.HeartbeatInterval, "heartbeat-interval", 30*time.Second, "broker heartbeat interval")

--- a/cmd/relay/main_test.go
+++ b/cmd/relay/main_test.go
@@ -12,6 +12,17 @@ import (
 	"openrung/internal/relay"
 )
 
+// testPreparedRuntime supplies the identity key prepareRuntime would have
+// generated; tests construct preparedRuntime directly and bypass it.
+func testPreparedRuntime(t *testing.T) preparedRuntime {
+	t.Helper()
+	identityKey, err := relay.ParseIdentitySeed("QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=")
+	if err != nil {
+		t.Fatalf("parse identity seed: %v", err)
+	}
+	return preparedRuntime{IdentityKey: identityKey}
+}
+
 func TestVersionInfoAndReportedVersion(t *testing.T) {
 	originalVersion, originalRevision := version, revision
 	version, revision = " 1.2.3 ", " abcdef0 "
@@ -43,7 +54,7 @@ func TestHeartbeatOrRegisterRecoversForgottenRelay(t *testing.T) {
 
 	cfg := cliConfig{BrokerURL: "http://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client}
 	broker := cfg.brokerClient()
-	desc, reRegistered, err := heartbeatOrRegister(context.Background(), broker, cfg, preparedRuntime{}, relay.Descriptor{ID: "relay_old"})
+	desc, reRegistered, err := heartbeatOrRegister(context.Background(), broker, cfg, testPreparedRuntime(t), relay.Descriptor{ID: "relay_old"})
 	if err != nil {
 		t.Fatalf("heartbeatOrRegister() error = %v", err)
 	}
@@ -70,7 +81,7 @@ func TestHeartbeatOrRegisterDoesNotRegisterOnOtherErrors(t *testing.T) {
 	cfg := cliConfig{BrokerURL: "http://broker.test", HTTPClient: client}
 	broker := cfg.brokerClient()
 	original := relay.Descriptor{ID: "relay_old"}
-	desc, reRegistered, err := heartbeatOrRegister(context.Background(), broker, cfg, preparedRuntime{}, original)
+	desc, reRegistered, err := heartbeatOrRegister(context.Background(), broker, cfg, testPreparedRuntime(t), original)
 	if err == nil {
 		t.Fatal("heartbeatOrRegister() error = nil, want an error")
 	}
@@ -194,7 +205,7 @@ func TestRegisterRejectsUnattestedFoundationClass(t *testing.T) {
 	})}
 
 	cfg := cliConfig{BrokerURL: "http://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client, NodeClass: relay.NodeClassFoundation}
-	if _, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{}); err == nil {
+	if _, err := register(context.Background(), cfg.brokerClient(), cfg, testPreparedRuntime(t)); err == nil {
 		t.Fatal("register() error = nil, want an unattested-node-class error")
 	}
 }
@@ -205,7 +216,7 @@ func TestRegisterAcceptsAttestedFoundationClass(t *testing.T) {
 	})}
 
 	cfg := cliConfig{BrokerURL: "https://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client, NodeClass: relay.NodeClassFoundation}
-	desc, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{})
+	desc, err := register(context.Background(), cfg.brokerClient(), cfg, testPreparedRuntime(t))
 	if err != nil {
 		t.Fatalf("register() error = %v", err)
 	}
@@ -224,7 +235,7 @@ func TestRegisterRefusesFoundationOverPlaintext(t *testing.T) {
 		return jsonResponse(http.StatusCreated, `{"id":"relay_new","node_class":"foundation"}`), nil
 	})}
 	cfg := cliConfig{BrokerURL: "http://broker.test", PublicHost: "relay.example", PublicPort: 443, HTTPClient: client, NodeClass: relay.NodeClassFoundation}
-	if _, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{}); err == nil {
+	if _, err := register(context.Background(), cfg.brokerClient(), cfg, testPreparedRuntime(t)); err == nil {
 		t.Fatal("register() error = nil, want a cleartext-broker error")
 	}
 	if sent.Load() != 0 {
@@ -283,7 +294,7 @@ func TestFoundationTokenRegistersAsFoundationWithoutNodeClass(t *testing.T) {
 	if cfg.Mode != "direct" {
 		t.Fatalf("mode = %q, want direct (forced by the token)", cfg.Mode)
 	}
-	desc, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{})
+	desc, err := register(context.Background(), cfg.brokerClient(), cfg, testPreparedRuntime(t))
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -349,7 +360,7 @@ func TestFoundationTokenRefusesPlaintextBroker(t *testing.T) {
 	if err := cfg.ApplyDefaults(); err != nil {
 		t.Fatalf("ApplyDefaults: %v", err)
 	}
-	if _, err := register(context.Background(), cfg.brokerClient(), cfg, preparedRuntime{}); err == nil {
+	if _, err := register(context.Background(), cfg.brokerClient(), cfg, testPreparedRuntime(t)); err == nil {
 		t.Fatal("register() error = nil, want a cleartext-broker refusal")
 	}
 	if sent.Load() != 0 {

--- a/cmd/relay/main_test.go
+++ b/cmd/relay/main_test.go
@@ -4,13 +4,78 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"openrung/internal/relay"
+	"openrung/internal/relayruntime"
 )
+
+func TestRelayEntrypointKeepsIdentitySeedOutOfArgv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relay container entrypoint requires a POSIX shell")
+	}
+
+	original, err := os.ReadFile(filepath.Join("..", "..", "deploy", "relay", "entrypoint.sh"))
+	if err != nil {
+		t.Fatalf("read relay entrypoint: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	argsPath := filepath.Join(tempDir, "args")
+	envPath := filepath.Join(tempDir, "identity-seed")
+	fakeRelayPath := filepath.Join(tempDir, "relay")
+	fakeRelay := `#!/bin/sh
+printf '%s\n' "$@" > "$OPENRUNG_TEST_ARGS_OUT"
+printf '%s' "${OPENRUNG_IDENTITY_SEED-}" > "$OPENRUNG_TEST_ENV_OUT"
+`
+	if err := os.WriteFile(fakeRelayPath, []byte(fakeRelay), 0o700); err != nil {
+		t.Fatalf("write fake relay: %v", err)
+	}
+
+	entrypoint := strings.Replace(string(original), "/usr/local/bin/relay", fakeRelayPath, 1)
+	if entrypoint == string(original) {
+		t.Fatal("entrypoint relay path was not replaced")
+	}
+	entrypointPath := filepath.Join(tempDir, "entrypoint.sh")
+	if err := os.WriteFile(entrypointPath, []byte(entrypoint), 0o700); err != nil {
+		t.Fatalf("write test entrypoint: %v", err)
+	}
+
+	const seed = "test-long-lived-identity-seed"
+	cmd := exec.Command("sh", entrypointPath)
+	cmd.Env = append(os.Environ(),
+		"OPENRUNG_MODE=tunnel",
+		"OPENRUNG_HUB_ADDR=hub.example:9443",
+		relayruntime.IdentitySeedEnvironmentVariable+"="+seed,
+		"OPENRUNG_TEST_ARGS_OUT="+argsPath,
+		"OPENRUNG_TEST_ENV_OUT="+envPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run relay entrypoint: %v\n%s", err, output)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read relay argv: %v", err)
+	}
+	if strings.Contains(string(args), "-identity-seed") || strings.Contains(string(args), seed) {
+		t.Fatalf("entrypoint exposed identity seed in relay argv: %q", args)
+	}
+	inheritedSeed, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read relay environment capture: %v", err)
+	}
+	if string(inheritedSeed) != seed {
+		t.Fatalf("relay received identity seed %q, want environment-provided seed", inheritedSeed)
+	}
+}
 
 // testPreparedRuntime supplies the identity key prepareRuntime would have
 // generated; tests construct preparedRuntime directly and bypass it.
@@ -257,7 +322,7 @@ func TestHeartbeatRefusesFoundationOverPlaintext(t *testing.T) {
 		HTTPClient:        client,
 		NodeClass:         relay.NodeClassFoundation,
 	}
-	if err := heartbeat(context.Background(), cfg.brokerClient(), "relay_foundation"); err == nil {
+	if err := heartbeat(context.Background(), cfg.brokerClient(), "relay_foundation", ""); err == nil {
 		t.Fatal("heartbeat() error = nil, want a cleartext-broker error")
 	}
 	if sent.Load() != 0 {

--- a/deploy/relay/entrypoint.sh
+++ b/deploy/relay/entrypoint.sh
@@ -104,12 +104,12 @@ if [ -n "${OPENRUNG_CLIENT_ID:-}" ]; then set -- "$@" -client-id "${OPENRUNG_CLI
 if [ -n "${OPENRUNG_REALITY_PRIVATE_KEY:-}" ]; then set -- "$@" -reality-private-key "${OPENRUNG_REALITY_PRIVATE_KEY}"; fi
 if [ -n "${OPENRUNG_REALITY_PUBLIC_KEY:-}" ]; then set -- "$@" -reality-public-key "${OPENRUNG_REALITY_PUBLIC_KEY}"; fi
 if [ -n "${OPENRUNG_SHORT_ID:-}" ]; then set -- "$@" -short-id "${OPENRUNG_SHORT_ID}"; fi
-if [ -n "${OPENRUNG_IDENTITY_SEED:-}" ]; then set -- "$@" -identity-seed "${OPENRUNG_IDENTITY_SEED}"; fi
 if [ -n "${OPENRUNG_MAX_SESSIONS:-}" ]; then set -- "$@" -max-sessions "${OPENRUNG_MAX_SESSIONS}"; fi
 if [ -n "${OPENRUNG_MAX_MBPS:-}" ]; then set -- "$@" -max-mbps "${OPENRUNG_MAX_MBPS}"; fi
 
 # The registration tokens (OPENRUNG_VOLUNTEER_TOKEN, OPENRUNG_FOUNDATION_TOKEN),
-# label (OPENRUNG_LABEL), and node class (OPENRUNG_NODE_CLASS) are read natively
-# from the environment by the binary, so they need no flag mapping.
+# stable identity seed (OPENRUNG_IDENTITY_SEED), label (OPENRUNG_LABEL), and node
+# class (OPENRUNG_NODE_CLASS) are read natively from the environment by the
+# binary. Keep secrets out of argv by not mapping them to flags here.
 
 exec "$@"

--- a/deploy/relay/entrypoint.sh
+++ b/deploy/relay/entrypoint.sh
@@ -104,6 +104,7 @@ if [ -n "${OPENRUNG_CLIENT_ID:-}" ]; then set -- "$@" -client-id "${OPENRUNG_CLI
 if [ -n "${OPENRUNG_REALITY_PRIVATE_KEY:-}" ]; then set -- "$@" -reality-private-key "${OPENRUNG_REALITY_PRIVATE_KEY}"; fi
 if [ -n "${OPENRUNG_REALITY_PUBLIC_KEY:-}" ]; then set -- "$@" -reality-public-key "${OPENRUNG_REALITY_PUBLIC_KEY}"; fi
 if [ -n "${OPENRUNG_SHORT_ID:-}" ]; then set -- "$@" -short-id "${OPENRUNG_SHORT_ID}"; fi
+if [ -n "${OPENRUNG_IDENTITY_SEED:-}" ]; then set -- "$@" -identity-seed "${OPENRUNG_IDENTITY_SEED}"; fi
 if [ -n "${OPENRUNG_MAX_SESSIONS:-}" ]; then set -- "$@" -max-sessions "${OPENRUNG_MAX_SESSIONS}"; fi
 if [ -n "${OPENRUNG_MAX_MBPS:-}" ]; then set -- "$@" -max-mbps "${OPENRUNG_MAX_MBPS}"; fi
 

--- a/deploy/relay/hetzner-up.sh
+++ b/deploy/relay/hetzner-up.sh
@@ -115,6 +115,10 @@ docker rm -f openrung-relay 2>/dev/null || true
 # Minted once per instance: the broker derives the relay ID from this seed
 # (spec openrung-relay-identity-v1), so the relay keeps one identity across
 # container restarts instead of fragmenting its dashboard/ranking history.
+# The seed IS the relay's Ed25519 private key; disable xtrace before touching
+# it so a future 'set -x' here can never trace it into the persisted
+# /var/log/openrung-init.log (this block currently runs under 'set -eu').
+set +x
 IDENTITY_SEED="\$(head -c 32 /dev/urandom | base64)"
 docker run -d --name openrung-relay --restart unless-stopped \\
   --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\

--- a/deploy/relay/hetzner-up.sh
+++ b/deploy/relay/hetzner-up.sh
@@ -112,12 +112,17 @@ systemctl enable --now docker
 PUBLIC_IP="\$(curl -fsS http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
 docker pull ${IMAGE}
 docker rm -f openrung-relay 2>/dev/null || true
+# Minted once per instance: the broker derives the relay ID from this seed
+# (spec openrung-relay-identity-v1), so the relay keeps one identity across
+# container restarts instead of fragmenting its dashboard/ranking history.
+IDENTITY_SEED="\$(head -c 32 /dev/urandom | base64)"
 docker run -d --name openrung-relay --restart unless-stopped \\
   --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\
   -e OPENRUNG_BROKER_URL=${BROKER_URL} \\
   -e OPENRUNG_PUBLIC_HOST="\$PUBLIC_IP" \\
   -e OPENRUNG_LISTEN_HOST=0.0.0.0 \\
   -e OPENRUNG_LABEL=${NAME} \\
+  -e OPENRUNG_IDENTITY_SEED="\$IDENTITY_SEED" \\
   ${IMAGE}
 EOF
 

--- a/deploy/relay/lightsail-up.sh
+++ b/deploy/relay/lightsail-up.sh
@@ -79,6 +79,11 @@ docker rm -f openrung-relay 2>/dev/null || true
 # Minted once per instance: the broker derives the relay ID from this seed
 # (spec openrung-relay-identity-v1), so the relay keeps one identity across
 # container restarts instead of fragmenting its dashboard/ranking history.
+# The seed IS the relay's Ed25519 private key, so disable xtrace first — this
+# block runs under 'set -eux' and the trace lands in the persisted
+# /var/log/openrung-init.log (and Lightsail retains it), exactly the exposure
+# lines 14-18 refuse for the registration tokens.
+set +x
 IDENTITY_SEED="\$(head -c 32 /dev/urandom | base64)"
 docker run -d --name openrung-relay --restart unless-stopped \\
   --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\

--- a/deploy/relay/lightsail-up.sh
+++ b/deploy/relay/lightsail-up.sh
@@ -76,12 +76,17 @@ apt-get -o DPkg::Lock::Timeout=300 install -y docker.io
 systemctl enable --now docker
 docker pull ${IMAGE}
 docker rm -f openrung-relay 2>/dev/null || true
+# Minted once per instance: the broker derives the relay ID from this seed
+# (spec openrung-relay-identity-v1), so the relay keeps one identity across
+# container restarts instead of fragmenting its dashboard/ranking history.
+IDENTITY_SEED="\$(head -c 32 /dev/urandom | base64)"
 docker run -d --name openrung-relay --restart unless-stopped \\
   --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \\
   -e OPENRUNG_BROKER_URL=${BROKER_URL} \\
   -e OPENRUNG_PUBLIC_HOST=${STATIC_IP} \\
   -e OPENRUNG_LISTEN_HOST=0.0.0.0 \\
   -e OPENRUNG_LABEL=${NAME} \\
+  -e OPENRUNG_IDENTITY_SEED="\$IDENTITY_SEED" \\
   ${IMAGE}
 EOF
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -350,21 +350,35 @@ dated more than 48 hours out, or — for a direct relay — pointed at a differe
 endpoint. A captured **tunnel** proof, however, can within its lifetime
 re-register the same relay ID at an attacker-chosen endpoint, because the
 tunnel statement binds no endpoint (the relay signs before the hub assigns
-one). That is bounded: it cannot serve traffic, since the bound
-`reality_public_key`'s private half never leaves the real relay, so it can at
-most point the ID at a dead endpoint until the real relay's next
-re-registration restores it — a transient denial, not interception, and only
-against relays whose registration traffic an attacker can observe (the
-plaintext volunteer broker origin; the TLS front and origin-TLS close this).
-Binding is deferred rather than nonce-based because the hub re-registers the
-stored request verbatim when the broker forgets the lease, and recycles the
-tunnel session for a fresh HELLO when the broker answers `401` `relay identity
-proof expired`.
+one). It cannot serve traffic, since the bound `reality_public_key`'s private
+half never leaves the real relay, so the result is denial rather than
+interception.
+
+That denial cannot be perpetuated by the real relay's heartbeats. Every
+successful identity-bearing registration mints a fresh, unlisted
+`lease_token`, and a heartbeat for that stable ID must present the token for
+the current registration. A replay (or stale tunnel session) rotates the
+token; the live relay or hub's next heartbeat is rejected as not found, which
+drives it to re-register its genuine request and restore the endpoint. While
+the genuine relay or hub remains connected, one replay therefore buys at most
+a transient overwrite; sustaining the denial requires repeated registration
+replays until the proof expires. Passive capture requires observable
+registration traffic (the plaintext volunteer broker origin); the TLS front
+and origin-TLS close that path.
+
+An already-authorized stale hub session is a separate case: TLS does not remove
+credentials the hub legitimately holds. The hub checks local registry
+ownership before re-registering and retires a stale session once a newer one
+owns the ID. A narrow overlap with publication of the new session can still
+briefly overwrite its endpoint, but the new session's next token-scoped
+heartbeat restores it. The hub also recycles a tunnel session for a fresh
+HELLO when the broker answers `401` `relay identity proof expired`.
 
 All three fields travel together; a malformed, tampered, or expired proof
 fails the registration with `401` — never a silent fall back to a random ID.
-Requests without the fields keep the legacy random-ID behavior, and the
-identity public key is never served through any public endpoint.
+Requests without the fields keep the legacy random-ID behavior and do not
+require a lease token on heartbeat. The identity public key and lease token
+are never served through any public relay-list endpoint.
 
 The identity grants nothing beyond ID continuity: node class is still attested
 per registration by the token, the foundation endpoint guard applies
@@ -381,6 +395,7 @@ Response:
 ```json
 {
   "id": "relay_...",
+  "lease_token": "lease_<opaque random token>",
   "public_host": "2001:db8::1",
   "public_port": 443,
   "city": "Tokyo",
@@ -418,6 +433,11 @@ resolves.
 ```http
 POST /api/v1/relays/{id}/heartbeat
 Authorization: Bearer <registration-token>
+
+{
+  "ok": true,
+  "lease_token": "lease_<token from registration>"
+}
 ```
 
 Response:
@@ -438,6 +458,13 @@ keeping an orphaned foundation label alive (e.g. after an endpoint takeover
 through a pre-`node_class` broker binary) or interfering with a foundation
 relay: a refused heartbeat changes nothing, and an unattended foundation row
 expires from the origin store within one lease TTL.
+
+An identity-bearing registration also requires its current `lease_token` on
+heartbeat. The broker rotates this opaque token on every successful
+registration and returns `404 relay not found` for a missing or superseded
+token, causing the relay or hub to re-register. Legacy random-ID registrations
+may omit it for rolling compatibility. The token is registration-private and
+must not be logged or copied into relay-list data.
 
 The one-TTL bound applies to the live origin row, not to copies already signed.
 An ordinary API snapshot has a 30-minute `not_after` window. On an origin

--- a/docs/api.md
+++ b/docs/api.md
@@ -336,20 +336,35 @@ three fields to the registration:
 The broker then derives the relay ID from the key — `relay_` + lowercase hex
 of the first 16 bytes of SHA-256 over `"openrung-relay-identity-v1:id:"` plus
 the raw key — so the same key always yields the same ID, with no broker-side
-state. The proof signs a canonical newline-joined statement binding the
-identity-relevant registration fields (endpoint for direct transport, always
-the transport itself, the VLESS/Reality parameters, capacities, label, node
-class) plus the relay-chosen `identity_expires_at`, so a captured proof cannot
-be replayed with altered content, across transports, after expiry, or more
-than 48 hours out. Tunnel-transport statements bind an empty endpoint — the
-hub assigns it after the relay signs — which is also why the proof carries an
-expiry rather than a nonce: the hub re-registers the stored request verbatim
-when the broker forgets the lease, and recycles the tunnel session for a fresh
-HELLO when the broker answers `401` `relay identity proof expired`. All three
-fields travel together; a malformed, tampered, or expired proof fails the
-registration with `401` — never a silent fall back to a random ID. Requests
-without the fields keep the legacy random-ID behavior, and the identity public
-key is never served through any public endpoint.
+state. The proof signs a canonical newline-joined statement binding: the spec
+tag, `identity_expires_at`, `transport`, the VLESS/Reality parameters
+(`client_id`, `reality_public_key`, `short_id`, `server_name`, `flow`,
+`exit_mode`), `max_sessions`, `max_mbps`, `label`, `node_class`, and — for
+direct transport only — `public_host`/`public_port`. It deliberately does not
+bind fields the relay cannot know or that the hub sets: the tunnel endpoint,
+`punch_capable`/`punch_endpoint`, `exit_host`, and `relay_version`.
+
+What this buys, and its limits: a captured proof cannot be re-signed with a
+different identity key (the ID is the key), used after `identity_expires_at`,
+dated more than 48 hours out, or — for a direct relay — pointed at a different
+endpoint. A captured **tunnel** proof, however, can within its lifetime
+re-register the same relay ID at an attacker-chosen endpoint, because the
+tunnel statement binds no endpoint (the relay signs before the hub assigns
+one). That is bounded: it cannot serve traffic, since the bound
+`reality_public_key`'s private half never leaves the real relay, so it can at
+most point the ID at a dead endpoint until the real relay's next
+re-registration restores it — a transient denial, not interception, and only
+against relays whose registration traffic an attacker can observe (the
+plaintext volunteer broker origin; the TLS front and origin-TLS close this).
+Binding is deferred rather than nonce-based because the hub re-registers the
+stored request verbatim when the broker forgets the lease, and recycles the
+tunnel session for a fresh HELLO when the broker answers `401` `relay identity
+proof expired`.
+
+All three fields travel together; a malformed, tampered, or expired proof
+fails the registration with `401` — never a silent fall back to a random ID.
+Requests without the fields keep the legacy random-ID behavior, and the
+identity public key is never served through any public endpoint.
 
 The identity grants nothing beyond ID continuity: node class is still attested
 per registration by the token, the foundation endpoint guard applies

--- a/docs/api.md
+++ b/docs/api.md
@@ -317,6 +317,50 @@ and never exposes it through any public endpoint, so the relay host's observed
 exit IP stays private. `exit_host` is rejected for direct transport, where
 `public_host` already is the exit.
 
+### Stable relay identity (spec `openrung-relay-identity-v1`)
+
+By default the broker mints a fresh random `relay_id` on every registration,
+so a relay's ID churns whenever it restarts or the broker forgets its lease —
+fragmenting dashboard history and ranking state across orphaned IDs. A relay
+may instead prove possession of a long-lived Ed25519 identity key by adding
+three fields to the registration:
+
+```json
+{
+  "identity_public_key": "<base64 raw 32-byte Ed25519 public key>",
+  "identity_proof": "<base64 Ed25519 signature>",
+  "identity_expires_at": "2026-07-21T12:00:00Z"
+}
+```
+
+The broker then derives the relay ID from the key — `relay_` + lowercase hex
+of the first 16 bytes of SHA-256 over `"openrung-relay-identity-v1:id:"` plus
+the raw key — so the same key always yields the same ID, with no broker-side
+state. The proof signs a canonical newline-joined statement binding the
+identity-relevant registration fields (endpoint for direct transport, always
+the transport itself, the VLESS/Reality parameters, capacities, label, node
+class) plus the relay-chosen `identity_expires_at`, so a captured proof cannot
+be replayed with altered content, across transports, after expiry, or more
+than 48 hours out. Tunnel-transport statements bind an empty endpoint — the
+hub assigns it after the relay signs — which is also why the proof carries an
+expiry rather than a nonce: the hub re-registers the stored request verbatim
+when the broker forgets the lease, and recycles the tunnel session for a fresh
+HELLO when the broker answers `401` `relay identity proof expired`. All three
+fields travel together; a malformed, tampered, or expired proof fails the
+registration with `401` — never a silent fall back to a random ID. Requests
+without the fields keep the legacy random-ID behavior, and the identity public
+key is never served through any public endpoint.
+
+The identity grants nothing beyond ID continuity: node class is still attested
+per registration by the token, the foundation endpoint guard applies
+unchanged, and a valid proof for a different key confers no authority over an
+endpoint. When an identity re-registers from a new endpoint, its previous row
+is atomically abandoned (one row per identity). The shipped relay pins the key
+with `-identity-seed` / `OPENRUNG_IDENTITY_SEED` (base64 32-byte seed, minted
+per instance by the deploy scripts), the desktop volunteer app persists it in
+`identity.json`, and an unpinned relay generates one per process — which still
+keeps the ID stable across broker outages within the process lifetime.
+
 Response:
 
 ```json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,10 @@ volunteer-run relays online:
   changes.
 - Descriptor liveness is tied to the tunnel: the hub heartbeats while the tunnel
   is healthy and stops when it drops, so the relay expires via the broker's normal
-  lease TTL.
+  lease TTL. Stable-identity registrations also receive a per-registration lease
+  token. The hub presents it on each heartbeat, so a stale session or replay that
+  replaces the descriptor cannot be kept alive by the current tunnel; its next
+  heartbeat fails and drives a genuine re-registration.
 
 The hub is a **data-plane** component, deliberately distinct from the control-plane
 broker — the broker stays out of the data path (see Goals). The hub only copies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,6 +291,12 @@ The broker should treat relay registrations as untrusted input:
 - Require authentication for relay operators outside local development.
 - Validate ports, hostnames, protocol fields, and advertised capabilities.
 - Expire inactive relays aggressively.
+- Relay identity continuity (spec `openrung-relay-identity-v1`, see the API
+  doc) is proven, never asserted: the relay ID is derived from an Ed25519 key
+  the registrant demonstrates possession of, so identity-bound history (labels,
+  ranking, dashboard attribution) cannot be claimed from the public relay list.
+  The identity carries no authority beyond ID continuity — classes and
+  endpoint protections are enforced exactly as for anonymous registrations.
 
 The current scaffold advertises one generated VLESS client ID per relay process.
 That is acceptable for early private testing, but public versions should issue

--- a/internal/broker/identity_handler_test.go
+++ b/internal/broker/identity_handler_test.go
@@ -1,0 +1,88 @@
+package broker
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+// TestRegisterHandlerIdentityFlow covers the HTTP surface of stable identity:
+// a valid proof registers with the derived ID, re-registration keeps it, and
+// a tampered or expired proof is a loud 401 — never a silent random-ID
+// fallback. The expired 401 body is the exact string the relay hub matches to
+// recycle a tunnel session, so it is pinned here.
+func TestRegisterHandlerIdentityFlow(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+	priv, err := relay.ParseIdentitySeed(identityStoreSeedA)
+	if err != nil {
+		t.Fatalf("parse seed: %v", err)
+	}
+
+	register := func(req relay.RegisterRequest) *httptest.ResponseRecorder {
+		body, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
+		return recorder
+	}
+	signed := func() relay.RegisterRequest {
+		req := validRegisterRequest()
+		req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt =
+			relay.SignIdentity(priv, req, time.Now().Add(relay.IdentityProofTTLDirect))
+		return req
+	}
+
+	first := register(signed())
+	if first.Code != http.StatusCreated {
+		t.Fatalf("identity register: expected 201, got %d: %s", first.Code, first.Body.String())
+	}
+	var firstDesc relay.Descriptor
+	if err := json.Unmarshal(first.Body.Bytes(), &firstDesc); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+
+	second := register(signed())
+	if second.Code != http.StatusCreated {
+		t.Fatalf("identity re-register: expected 201, got %d: %s", second.Code, second.Body.String())
+	}
+	var secondDesc relay.Descriptor
+	if err := json.Unmarshal(second.Body.Bytes(), &secondDesc); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+	if secondDesc.ID != firstDesc.ID {
+		t.Fatalf("relay ID churned across HTTP re-registration: %s -> %s", firstDesc.ID, secondDesc.ID)
+	}
+
+	// The identity public key must not leak through the public descriptor JSON.
+	if bytes.Contains(second.Body.Bytes(), []byte("identity")) {
+		t.Fatalf("identity material leaked into the register response: %s", second.Body.String())
+	}
+
+	tampered := signed()
+	tampered.Label = "evil-otter"
+	if recorder := register(tampered); recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("tampered proof: expected 401, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	expired := validRegisterRequest()
+	expired.IdentityPublicKey, expired.IdentityProof, expired.IdentityExpiresAt =
+		relay.SignIdentity(priv, expired, time.Now().Add(-time.Minute))
+	recorder := register(expired)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expired proof: expected 401, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var apiErr relay.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &apiErr); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if apiErr.Error != "relay identity proof expired" {
+		t.Fatalf("the hub matches this message verbatim; got %q", apiErr.Error)
+	}
+}

--- a/internal/broker/identity_store_test.go
+++ b/internal/broker/identity_store_test.go
@@ -80,7 +80,7 @@ func TestStoreIdentityRegistrationKeepsRelayIDAcrossReRegistration(t *testing.T)
 		}
 
 		// Heartbeat works against the derived ID like any other.
-		if _, err := store.Heartbeat(first.ID, relay.NodeClassVolunteer, later.Add(time.Minute), 3*time.Minute); err != nil {
+		if _, err := store.Heartbeat(first.ID, second.LeaseToken, relay.NodeClassVolunteer, later.Add(time.Minute), 3*time.Minute); err != nil {
 			t.Fatalf("heartbeat derived ID: %v", err)
 		}
 	})
@@ -120,6 +120,139 @@ func TestStoreIdentityEndpointMoveAbandonsOldRow(t *testing.T) {
 	})
 }
 
+func TestStoreIdentityHeartbeatCannotRenewDifferentRegistration(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+		originalReq := signedIdentityRequest(t, identityStoreSeedA, func(r *relay.RegisterRequest) {
+			r.Transport = relay.TransportTunnel
+			r.PublicHost = "hub-a.example"
+			r.PublicPort = 20001
+		}, now)
+
+		legitimate, err := store.Register(originalReq, now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register legitimate tunnel: %v", err)
+		}
+		if legitimate.LeaseToken == "" {
+			t.Fatal("stable registration returned an empty lease token")
+		}
+
+		// A tunnel proof intentionally does not bind the hub-assigned endpoint,
+		// so model a captured proof (or stale hub session) moving the stable ID.
+		replayedReq := originalReq
+		replayedReq.PublicHost = "hub-b.example"
+		replayedReq.PublicPort = 20002
+		replayed, err := store.Register(replayedReq, now.Add(time.Minute), 3*time.Minute)
+		if err != nil {
+			t.Fatalf("replay registration: %v", err)
+		}
+		if replayed.ID != legitimate.ID || replayed.LeaseToken == legitimate.LeaseToken {
+			t.Fatalf("registration incarnation did not rotate cleanly: first=%+v replayed=%+v", legitimate, replayed)
+		}
+
+		// The displaced session must receive not-found and must not extend the
+		// endpoint written by the replay. That response drives re-registration.
+		if _, err := store.Heartbeat(legitimate.ID, legitimate.LeaseToken, relay.NodeClassVolunteer, now.Add(2*time.Minute), 3*time.Minute); !errors.Is(err, ErrRelayNotFound) {
+			t.Fatalf("displaced heartbeat error = %v, want ErrRelayNotFound", err)
+		}
+		listed, err := store.List(now.Add(2*time.Minute), 20)
+		if err != nil {
+			t.Fatalf("list replayed relay: %v", err)
+		}
+		if len(listed) != 1 || listed[0].PublicHost != replayedReq.PublicHost || !listed[0].ExpiresAt.Equal(replayed.ExpiresAt) {
+			t.Fatalf("displaced heartbeat changed replayed registration: %+v", listed)
+		}
+
+		recovered, err := store.Register(originalReq, now.Add(2*time.Minute), 3*time.Minute)
+		if err != nil {
+			t.Fatalf("legitimate re-registration: %v", err)
+		}
+		if recovered.LeaseToken == replayed.LeaseToken {
+			t.Fatal("legitimate re-registration reused replay's lease token")
+		}
+		if _, err := store.Heartbeat(replayed.ID, replayed.LeaseToken, relay.NodeClassVolunteer, now.Add(3*time.Minute), 3*time.Minute); !errors.Is(err, ErrRelayNotFound) {
+			t.Fatalf("stale replay heartbeat error = %v, want ErrRelayNotFound", err)
+		}
+		if _, err := store.Heartbeat(recovered.ID, recovered.LeaseToken, relay.NodeClassVolunteer, now.Add(3*time.Minute), 3*time.Minute); err != nil {
+			t.Fatalf("recovered registration heartbeat: %v", err)
+		}
+
+		listed, err = store.List(now.Add(3*time.Minute), 20)
+		if err != nil {
+			t.Fatalf("list recovered relay: %v", err)
+		}
+		if len(listed) != 1 || listed[0].PublicHost != originalReq.PublicHost || listed[0].PublicPort != originalReq.PublicPort {
+			t.Fatalf("stale heartbeat displaced recovered endpoint: %+v", listed)
+		}
+	})
+}
+
+func TestStoreStableFoundationHeartbeatChecksClassBeforeLease(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+		req := signedIdentityRequest(t, identityStoreSeedA, func(r *relay.RegisterRequest) {
+			r.NodeClass = relay.NodeClassFoundation
+		}, now)
+		desc, err := store.Register(req, now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register stable foundation relay: %v", err)
+		}
+		if _, err := store.Heartbeat(desc.ID, "wrong-token", relay.NodeClassVolunteer, now.Add(time.Minute), 3*time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
+			t.Fatalf("unprivileged wrong-token heartbeat = %v, want ErrNodeClassForbidden", err)
+		}
+		if _, err := store.Heartbeat(desc.ID, "wrong-token", relay.NodeClassFoundation, now.Add(time.Minute), 3*time.Minute); !errors.Is(err, ErrRelayNotFound) {
+			t.Fatalf("authorized wrong-token heartbeat = %v, want ErrRelayNotFound", err)
+		}
+	})
+}
+
+func TestStoreIdentityStaleGeoCannotUpdateReplacement(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+		firstReq := signedIdentityRequest(t, identityStoreSeedA, func(r *relay.RegisterRequest) {
+			r.Transport = relay.TransportTunnel
+			r.PublicHost = "hub-a.example"
+			r.PublicPort = 20001
+		}, now)
+		first, err := store.Register(firstReq, now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register first endpoint: %v", err)
+		}
+
+		secondReq := firstReq
+		secondReq.PublicHost = "hub-b.example"
+		secondReq.PublicPort = 20002
+		second, err := store.Register(secondReq, now.Add(time.Minute), 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register replacement endpoint: %v", err)
+		}
+
+		staleGeo := relay.GeoLocation{City: "Old City", Country: "Old Country", CountryCode: "OC"}
+		if err := store.UpdateGeo(first.ID, first.LeaseToken, staleGeo); !errors.Is(err, ErrRelayNotFound) {
+			t.Fatalf("stale geo update = %v, want ErrRelayNotFound", err)
+		}
+		listed, err := store.List(now.Add(time.Minute), 20)
+		if err != nil {
+			t.Fatalf("list replacement after stale geo: %v", err)
+		}
+		if len(listed) != 1 || listed[0].PublicHost != secondReq.PublicHost || listed[0].GeoLocation != (relay.GeoLocation{}) {
+			t.Fatalf("stale geo contaminated replacement: %+v", listed)
+		}
+
+		freshGeo := relay.GeoLocation{City: "New City", Country: "New Country", CountryCode: "NC"}
+		if err := store.UpdateGeo(second.ID, second.LeaseToken, freshGeo); err != nil {
+			t.Fatalf("current geo update: %v", err)
+		}
+		listed, err = store.List(now.Add(time.Minute), 20)
+		if err != nil {
+			t.Fatalf("list replacement after current geo: %v", err)
+		}
+		if len(listed) != 1 || listed[0].GeoLocation != freshGeo {
+			t.Fatalf("current geo was not stored: %+v", listed)
+		}
+	})
+}
+
 func TestStoreIdentityCannotSeizeLiveFoundationEndpoint(t *testing.T) {
 	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
 		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
@@ -138,7 +271,7 @@ func TestStoreIdentityCannotSeizeLiveFoundationEndpoint(t *testing.T) {
 		if !errors.Is(err, ErrNodeClassForbidden) {
 			t.Fatalf("expected ErrNodeClassForbidden, got %v", err)
 		}
-		if _, err := store.Heartbeat(foundation.ID, relay.NodeClassFoundation, now.Add(time.Minute), 3*time.Minute); err != nil {
+		if _, err := store.Heartbeat(foundation.ID, foundation.LeaseToken, relay.NodeClassFoundation, now.Add(time.Minute), 3*time.Minute); err != nil {
 			t.Fatalf("foundation relay lost its row to a refused registration: %v", err)
 		}
 	})
@@ -171,7 +304,7 @@ func TestStoreIdentitySeizureRollbackKeepsOldRow(t *testing.T) {
 		if !errors.Is(err, ErrNodeClassForbidden) {
 			t.Fatalf("expected ErrNodeClassForbidden, got %v", err)
 		}
-		if _, err := store.Heartbeat(first.ID, relay.NodeClassVolunteer, now.Add(time.Minute), 3*time.Minute); err != nil {
+		if _, err := store.Heartbeat(first.ID, first.LeaseToken, relay.NodeClassVolunteer, now.Add(time.Minute), 3*time.Minute); err != nil {
 			t.Fatalf("refused move evicted the identity's own row: %v", err)
 		}
 	})

--- a/internal/broker/identity_store_test.go
+++ b/internal/broker/identity_store_test.go
@@ -1,0 +1,206 @@
+package broker
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+// The stable-identity store tests run against both backends through this
+// harness: the in-memory store always, Postgres when OPENRUNG_TEST_POSTGRES_URL
+// is set (mirroring the existing postgres-gated conventions).
+func runIdentityStoreTest(t *testing.T, test func(t *testing.T, store RelayStore)) {
+	t.Helper()
+	t.Run("memory", func(t *testing.T) {
+		test(t, NewStore())
+	})
+	t.Run("postgres", func(t *testing.T) {
+		test(t, newTestPostgresStore(t, RankingModeGlobal))
+	})
+}
+
+func signedIdentityRequest(t *testing.T, seed string, mutate func(*relay.RegisterRequest), now time.Time) relay.RegisterRequest {
+	t.Helper()
+	priv, err := relay.ParseIdentitySeed(seed)
+	if err != nil {
+		t.Fatalf("parse seed: %v", err)
+	}
+	req := validRegisterRequest()
+	if mutate != nil {
+		mutate(&req)
+	}
+	req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt =
+		relay.SignIdentity(priv, req, now.Add(relay.IdentityProofTTLDirect))
+	return req
+}
+
+const (
+	identityStoreSeedA = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI="
+	identityStoreSeedB = "Q0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0M="
+)
+
+func TestStoreIdentityRegistrationKeepsRelayIDAcrossReRegistration(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+		first, err := store.Register(signedIdentityRequest(t, identityStoreSeedA, nil, now), now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register: %v", err)
+		}
+		if !strings.HasPrefix(first.ID, "relay_") || len(first.ID) != len("relay_")+32 {
+			t.Fatalf("derived ID has the wrong shape: %s", first.ID)
+		}
+
+		// Same identity, later re-registration (e.g. after the broker forgot
+		// the lease): same relay ID, fresh lease.
+		later := now.Add(10 * time.Minute)
+		second, err := store.Register(signedIdentityRequest(t, identityStoreSeedA, nil, later), later, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("re-register: %v", err)
+		}
+		if second.ID != first.ID {
+			t.Fatalf("relay ID churned across re-registration: %s -> %s", first.ID, second.ID)
+		}
+		if !second.ExpiresAt.After(second.RegisteredAt) {
+			t.Fatalf("stale lease on re-registration: %+v", second)
+		}
+
+		// A different identity at a different endpoint must derive a different ID.
+		other, err := store.Register(signedIdentityRequest(t, identityStoreSeedB, func(r *relay.RegisterRequest) {
+			r.PublicHost = "198.51.100.44"
+		}, later), later, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register other identity: %v", err)
+		}
+		if other.ID == first.ID {
+			t.Fatal("distinct identities derived the same relay ID")
+		}
+
+		// Heartbeat works against the derived ID like any other.
+		if _, err := store.Heartbeat(first.ID, relay.NodeClassVolunteer, later.Add(time.Minute), 3*time.Minute); err != nil {
+			t.Fatalf("heartbeat derived ID: %v", err)
+		}
+	})
+}
+
+func TestStoreIdentityEndpointMoveAbandonsOldRow(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+		first, err := store.Register(signedIdentityRequest(t, identityStoreSeedA, nil, now), now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register: %v", err)
+		}
+
+		// The same identity re-registers from a new endpoint (relay moved
+		// hosts). Same ID, exactly one row: without the same-ID eviction, the
+		// Postgres id PRIMARY KEY would reject this insert outright.
+		moved, err := store.Register(signedIdentityRequest(t, identityStoreSeedA, func(r *relay.RegisterRequest) {
+			r.PublicHost = "198.51.100.77"
+		}, now.Add(time.Minute)), now.Add(time.Minute), 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register moved endpoint: %v", err)
+		}
+		if moved.ID != first.ID {
+			t.Fatalf("relay ID churned on endpoint move: %s -> %s", first.ID, moved.ID)
+		}
+		listed, err := store.List(now.Add(time.Minute), 20)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(listed) != 1 {
+			t.Fatalf("expected exactly one row after the move, got %d: %+v", len(listed), listed)
+		}
+		if listed[0].PublicHost != "198.51.100.77" {
+			t.Fatalf("listing still shows the old endpoint: %+v", listed[0])
+		}
+	})
+}
+
+func TestStoreIdentityCannotSeizeLiveFoundationEndpoint(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+		foundationReq := validRegisterRequest()
+		foundationReq.NodeClass = relay.NodeClassFoundation
+		foundation, err := store.Register(foundationReq, now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register foundation relay: %v", err)
+		}
+
+		// A volunteer-class identity registration at the same endpoint must be
+		// refused exactly like a legacy one — a valid possession proof for a
+		// DIFFERENT key grants no authority over the endpoint.
+		_, err = store.Register(signedIdentityRequest(t, identityStoreSeedA, nil, now.Add(time.Minute)), now.Add(time.Minute), 3*time.Minute)
+		if !errors.Is(err, ErrNodeClassForbidden) {
+			t.Fatalf("expected ErrNodeClassForbidden, got %v", err)
+		}
+		if _, err := store.Heartbeat(foundation.ID, relay.NodeClassFoundation, now.Add(time.Minute), 3*time.Minute); err != nil {
+			t.Fatalf("foundation relay lost its row to a refused registration: %v", err)
+		}
+	})
+}
+
+func TestStoreIdentitySeizureRollbackKeepsOldRow(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+		// The identity registers legitimately at endpoint A...
+		first, err := store.Register(signedIdentityRequest(t, identityStoreSeedA, nil, now), now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("register: %v", err)
+		}
+		// ...a foundation relay holds endpoint B...
+		foundationReq := validRegisterRequest()
+		foundationReq.NodeClass = relay.NodeClassFoundation
+		foundationReq.PublicHost = "198.51.100.88"
+		if _, err := store.Register(foundationReq, now, 3*time.Minute); err != nil {
+			t.Fatalf("register foundation relay: %v", err)
+		}
+		// ...and the identity then tries to move onto endpoint B as a
+		// volunteer. The registration is refused, and the refusal must not
+		// have evicted the identity's own row at endpoint A (the Postgres
+		// implementation deletes it inside the same transaction — a rollback
+		// must restore it).
+		_, err = store.Register(signedIdentityRequest(t, identityStoreSeedA, func(r *relay.RegisterRequest) {
+			r.PublicHost = "198.51.100.88"
+		}, now.Add(time.Minute)), now.Add(time.Minute), 3*time.Minute)
+		if !errors.Is(err, ErrNodeClassForbidden) {
+			t.Fatalf("expected ErrNodeClassForbidden, got %v", err)
+		}
+		if _, err := store.Heartbeat(first.ID, relay.NodeClassVolunteer, now.Add(time.Minute), 3*time.Minute); err != nil {
+			t.Fatalf("refused move evicted the identity's own row: %v", err)
+		}
+	})
+}
+
+func TestStoreIdentityInvalidProofRejected(t *testing.T) {
+	runIdentityStoreTest(t, func(t *testing.T, store RelayStore) {
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+		// Tampered content after signing.
+		req := signedIdentityRequest(t, identityStoreSeedA, nil, now)
+		req.Label = "evil-otter"
+		if _, err := store.Register(req, now, 3*time.Minute); !errors.Is(err, relay.ErrIdentityProofInvalid) {
+			t.Fatalf("expected ErrIdentityProofInvalid, got %v", err)
+		}
+
+		// Expired proof.
+		expired := signedIdentityRequest(t, identityStoreSeedA, nil, now.Add(-2*relay.IdentityProofTTLDirect))
+		if _, err := store.Register(expired, now, 3*time.Minute); !errors.Is(err, relay.ErrIdentityProofExpired) {
+			t.Fatalf("expected ErrIdentityProofExpired, got %v", err)
+		}
+
+		// Legacy registration is untouched by all of this: random ID minted.
+		legacy, err := store.Register(validRegisterRequest(), now, 3*time.Minute)
+		if err != nil {
+			t.Fatalf("legacy register: %v", err)
+		}
+		if legacy.ID == "" || legacy.IdentityPublicKey != "" {
+			t.Fatalf("legacy registration gained identity state: %+v", legacy)
+		}
+	})
+}

--- a/internal/broker/nodeclass_test.go
+++ b/internal/broker/nodeclass_test.go
@@ -389,7 +389,7 @@ func TestStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 		t.Fatalf("register: %v", err)
 	}
 
-	if _, err := store.Heartbeat(desc.ID, relay.NodeClassVolunteer, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
+	if _, err := store.Heartbeat(desc.ID, desc.LeaseToken, relay.NodeClassVolunteer, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
 		t.Fatalf("volunteer-class credential heartbeat of foundation relay: err = %v, want ErrNodeClassForbidden", err)
 	}
 	// The refused heartbeat must not have extended the lease.
@@ -401,11 +401,11 @@ func TestStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-register: %v", err)
 	}
-	if _, err := store.Heartbeat(desc.ID, relay.NodeClassFoundation, now.Add(time.Second), time.Minute); err != nil {
+	if _, err := store.Heartbeat(desc.ID, desc.LeaseToken, relay.NodeClassFoundation, now.Add(time.Second), time.Minute); err != nil {
 		t.Fatalf("foundation-credential heartbeat: %v", err)
 	}
 
-	if _, err := store.Heartbeat("relay_missing", relay.NodeClassFoundation, now, time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat("relay_missing", "", relay.NodeClassFoundation, now, time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("missing relay: err = %v, want ErrRelayNotFound", err)
 	}
 }
@@ -469,7 +469,7 @@ func TestRegisterFoundationCanRefreshOwnEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first foundation register: %v", err)
 	}
-	if _, err := store.Heartbeat(preSquat.ID, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat(preSquat.ID, preSquat.LeaseToken, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("pre-squatting volunteer-class relay ID survived foundation registration: %v", err)
 	}
 
@@ -481,7 +481,7 @@ func TestRegisterFoundationCanRefreshOwnEndpoint(t *testing.T) {
 	if refreshed.ID == firstFoundation.ID {
 		t.Fatal("expected foundation refresh to receive a new relay ID")
 	}
-	if _, err := store.Heartbeat(firstFoundation.ID, relay.NodeClassFoundation, now.Add(3*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat(firstFoundation.ID, firstFoundation.LeaseToken, relay.NodeClassFoundation, now.Add(3*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("old foundation ID survived refresh: %v", err)
 	}
 	listed, err := store.List(now.Add(3*time.Second), 10)
@@ -518,7 +518,7 @@ func TestStoreExpiredFoundationEndpointIsReclaimable(t *testing.T) {
 	if reclaimed.NodeClass != relay.NodeClassVolunteer {
 		t.Fatalf("reclaimed node_class = %q, want %q", reclaimed.NodeClass, relay.NodeClassVolunteer)
 	}
-	if _, err := store.Heartbeat(expired.ID, relay.NodeClassFoundation, now.Add(2*time.Minute), time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat(expired.ID, expired.LeaseToken, relay.NodeClassFoundation, now.Add(2*time.Minute), time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("expired foundation ID survived endpoint reclaim: %v", err)
 	}
 	listed, err := store.List(now.Add(2*time.Minute), 10)

--- a/internal/broker/postgres_store.go
+++ b/internal/broker/postgres_store.go
@@ -42,7 +42,8 @@ const descriptorColumns = `
 	longitude,
 	exit_host,
 	node_class,
-	identity_public_key
+	identity_public_key,
+	lease_token
 `
 
 const postgresOperationTimeout = 5 * time.Second
@@ -78,6 +79,7 @@ CREATE TABLE IF NOT EXISTS relay_descriptors (
 	exit_host text NOT NULL DEFAULT '',
 	node_class text NOT NULL DEFAULT 'volunteer',
 	identity_public_key text NOT NULL DEFAULT '',
+	lease_token text NOT NULL DEFAULT '',
 	attributes jsonb NOT NULL DEFAULT '{}'::jsonb,
 	UNIQUE (public_host, public_port)
 );
@@ -120,6 +122,9 @@ ALTER TABLE relay_descriptors
 
 ALTER TABLE relay_descriptors
 	ADD COLUMN IF NOT EXISTS identity_public_key text NOT NULL DEFAULT '';
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS lease_token text NOT NULL DEFAULT '';
 
 CREATE INDEX IF NOT EXISTS relay_descriptors_active_idx
 	ON relay_descriptors (expires_at DESC, last_heartbeat_at DESC);
@@ -207,9 +212,17 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 	} else if id, err = newRelayID(); err != nil {
 		return relay.Descriptor{}, err
 	}
+	var leaseToken string
+	if identityKey != nil {
+		leaseToken, err = newRelayLeaseToken()
+		if err != nil {
+			return relay.Descriptor{}, err
+		}
+	}
 	desc := relay.Descriptor{
 		ID:                id,
 		IdentityPublicKey: req.IdentityPublicKey,
+		LeaseToken:        leaseToken,
 		Label:             req.Label,
 		NodeClass:         normalizeNodeClass(req.NodeClass),
 		PublicHost:        req.PublicHost,
@@ -305,9 +318,10 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			punch_endpoint,
 			exit_host,
 			node_class,
-			identity_public_key
+			identity_public_key,
+			lease_token
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
 		)
 		ON CONFLICT (public_host, public_port) DO UPDATE SET
 			id = EXCLUDED.id,
@@ -336,9 +350,10 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			longitude = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.longitude ELSE 0 END,
 			exit_host = EXCLUDED.exit_host,
 			node_class = EXCLUDED.node_class,
-			identity_public_key = EXCLUDED.identity_public_key
-		WHERE relay_descriptors.node_class <> $25
-			OR EXCLUDED.node_class = $25
+			identity_public_key = EXCLUDED.identity_public_key,
+			lease_token = EXCLUDED.lease_token
+		WHERE relay_descriptors.node_class <> $26
+			OR EXCLUDED.node_class = $26
 			OR relay_descriptors.expires_at <= EXCLUDED.registered_at
 		RETURNING `+descriptorColumns,
 		desc.ID,
@@ -365,6 +380,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		desc.ExitHost,
 		desc.NodeClass,
 		desc.IdentityPublicKey,
+		desc.LeaseToken,
 		relay.NodeClassFoundation,
 	))
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -391,7 +407,7 @@ type pgxQuerier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-func (s *PostgresStore) Heartbeat(id, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error) {
+func (s *PostgresStore) Heartbeat(id, leaseToken, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error) {
 	ctx, cancel := postgresOperationContext()
 	defer cancel()
 
@@ -399,10 +415,13 @@ func (s *PostgresStore) Heartbeat(id, maxClass string, now time.Time, ttl time.D
 	// heartbeat never extends the lease, not even transiently.
 	desc, err := scanDescriptor(s.pool.QueryRow(ctx, `
 		UPDATE relay_descriptors
-		SET last_heartbeat_at = $2, expires_at = $3
-		WHERE id = $1 AND (node_class <> $4 OR $5)
+		SET last_heartbeat_at = $3, expires_at = $4
+		WHERE id = $1
+			AND (identity_public_key = '' OR (lease_token <> '' AND lease_token = $2))
+			AND (node_class <> $5 OR $6)
 		RETURNING `+descriptorColumns,
 		id,
+		leaseToken,
 		now,
 		now.Add(ttl),
 		relay.NodeClassFoundation,
@@ -413,32 +432,37 @@ func (s *PostgresStore) Heartbeat(id, maxClass string, now time.Time, ttl time.D
 		// foundation row. Distinguish so the handler can answer 403 vs 404
 		// (the 404 drives client re-registration and must stay accurate).
 		return relay.Descriptor{}, heartbeatMissError(
-			s.pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM relay_descriptors WHERE id = $1)`, id),
+			s.pool.QueryRow(ctx, `
+				SELECT EXISTS (SELECT 1 FROM relay_descriptors WHERE id = $1),
+					EXISTS (SELECT 1 FROM relay_descriptors WHERE id = $1 AND node_class = $2)`,
+				id, relay.NodeClassFoundation),
+			maxClass,
 		)
 	}
 	return desc, err
 }
 
-func heartbeatMissError(row pgx.Row) error {
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
+func heartbeatMissError(row pgx.Row, maxClass string) error {
+	var exists, foundation bool
+	if err := row.Scan(&exists, &foundation); err != nil {
 		return err
 	}
-	if exists {
+	if exists && foundation && maxClass != relay.NodeClassFoundation {
 		return ErrNodeClassForbidden
 	}
 	return ErrRelayNotFound
 }
 
-func (s *PostgresStore) UpdateGeo(id string, geo relay.GeoLocation) error {
+func (s *PostgresStore) UpdateGeo(id, leaseToken string, geo relay.GeoLocation) error {
 	ctx, cancel := postgresOperationContext()
 	defer cancel()
 
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE relay_descriptors
-		SET city = $2, country = $3, country_code = $4, latitude = $5, longitude = $6
+		SET city = $3, country = $4, country_code = $5, latitude = $6, longitude = $7
 		WHERE id = $1
-	`, id, geo.City, geo.Country, geo.CountryCode, geo.Latitude, geo.Longitude)
+			AND (identity_public_key = '' OR (lease_token <> '' AND lease_token = $2))
+	`, id, leaseToken, geo.City, geo.Country, geo.CountryCode, geo.Latitude, geo.Longitude)
 	if err != nil {
 		return err
 	}
@@ -839,6 +863,7 @@ func scanDescriptor(row pgx.Row) (relay.Descriptor, error) {
 		&desc.ExitHost,
 		&desc.NodeClass,
 		&desc.IdentityPublicKey,
+		&desc.LeaseToken,
 	)
 	return desc, err
 }

--- a/internal/broker/postgres_store.go
+++ b/internal/broker/postgres_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -41,7 +42,8 @@ const descriptorColumns = `
 	latitude,
 	longitude,
 	exit_host,
-	node_class
+	node_class,
+	identity_public_key
 `
 
 const postgresOperationTimeout = 5 * time.Second
@@ -76,6 +78,7 @@ CREATE TABLE IF NOT EXISTS relay_descriptors (
 	longitude double precision NOT NULL DEFAULT 0,
 	exit_host text NOT NULL DEFAULT '',
 	node_class text NOT NULL DEFAULT 'volunteer',
+	identity_public_key text NOT NULL DEFAULT '',
 	attributes jsonb NOT NULL DEFAULT '{}'::jsonb,
 	UNIQUE (public_host, public_port)
 );
@@ -115,6 +118,9 @@ ALTER TABLE relay_descriptors
 
 ALTER TABLE relay_descriptors
 	ADD COLUMN IF NOT EXISTS node_class text NOT NULL DEFAULT 'volunteer';
+
+ALTER TABLE relay_descriptors
+	ADD COLUMN IF NOT EXISTS identity_public_key text NOT NULL DEFAULT '';
 
 CREATE INDEX IF NOT EXISTS relay_descriptors_active_idx
 	ON relay_descriptors (expires_at DESC, last_heartbeat_at DESC);
@@ -187,33 +193,45 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 	ctx, cancel := postgresOperationContext()
 	defer cancel()
 
-	id, err := newRelayID()
+	// Verification lives in the store, not the handler, so no future caller
+	// can register an identity-bearing request without the possession proof —
+	// the derived ID is only ever handed to a registrant holding the private
+	// key. Legacy requests (no identity fields) return a nil key and keep the
+	// random mint below.
+	identityKey, err := relay.VerifyIdentity(req, now)
 	if err != nil {
 		return relay.Descriptor{}, err
 	}
+	var id string
+	if identityKey != nil {
+		id = relay.DeriveRelayID(identityKey)
+	} else if id, err = newRelayID(); err != nil {
+		return relay.Descriptor{}, err
+	}
 	desc := relay.Descriptor{
-		ID:               id,
-		Label:            req.Label,
-		NodeClass:        normalizeNodeClass(req.NodeClass),
-		PublicHost:       req.PublicHost,
-		PublicPort:       req.PublicPort,
-		ExitHost:         req.ExitHost,
-		Protocol:         req.Protocol,
-		ClientID:         req.ClientID,
-		RealityPublicKey: req.RealityPublicKey,
-		ShortID:          req.ShortID,
-		ServerName:       req.ServerName,
-		Flow:             req.Flow,
-		ExitMode:         req.ExitMode,
-		MaxSessions:      req.MaxSessions,
-		MaxMbps:          req.MaxMbps,
-		RelayVersion:     req.RelayVersion,
-		Transport:        normalizeTransport(req.Transport),
-		PunchCapable:     req.PunchCapable,
-		PunchEndpoint:    req.PunchEndpoint,
-		RegisteredAt:     now,
-		LastHeartbeatAt:  now,
-		ExpiresAt:        now.Add(ttl),
+		ID:                id,
+		IdentityPublicKey: req.IdentityPublicKey,
+		Label:             req.Label,
+		NodeClass:         normalizeNodeClass(req.NodeClass),
+		PublicHost:        req.PublicHost,
+		PublicPort:        req.PublicPort,
+		ExitHost:          req.ExitHost,
+		Protocol:          req.Protocol,
+		ClientID:          req.ClientID,
+		RealityPublicKey:  req.RealityPublicKey,
+		ShortID:           req.ShortID,
+		ServerName:        req.ServerName,
+		Flow:              req.Flow,
+		ExitMode:          req.ExitMode,
+		MaxSessions:       req.MaxSessions,
+		MaxMbps:           req.MaxMbps,
+		RelayVersion:      req.RelayVersion,
+		Transport:         normalizeTransport(req.Transport),
+		PunchCapable:      req.PunchCapable,
+		PunchEndpoint:     req.PunchEndpoint,
+		RegisteredAt:      now,
+		LastHeartbeatAt:   now,
+		ExpiresAt:         now.Add(ttl),
 	}
 
 	// Geo columns are deliberately absent from the INSERT: a re-registration
@@ -235,7 +253,37 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 	// reclaimable, matching the in-memory Store's ExpiresAt.After(now) guard.
 	// A suppressed update returns no row (pgx.ErrNoRows), which we map to
 	// ErrNodeClassForbidden.
-	desc, err = scanDescriptor(s.pool.QueryRow(ctx, `
+	//
+	// Identity registrations run inside a transaction so a relay moving to a
+	// new endpoint atomically abandons its old row: the id is the PRIMARY KEY,
+	// so without the DELETE the insert at the new endpoint would collide with
+	// the relay's own previous row. The DELETE can only ever remove rows owned
+	// by this identity (the id is derived from the key the registrant just
+	// proved possession of), and a rollback — e.g. the foundation-endpoint
+	// guard suppressing the upsert — preserves the old row untouched.
+	querier := pgxQuerier(s.pool)
+	if identityKey != nil {
+		tx, err := s.pool.Begin(ctx)
+		if err != nil {
+			return relay.Descriptor{}, fmt.Errorf("begin relay registration: %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		moved, err := tx.Exec(ctx, `
+			DELETE FROM relay_descriptors
+			WHERE id = $1 AND (public_host <> $2 OR public_port <> $3)`,
+			id, desc.PublicHost, desc.PublicPort)
+		if err != nil {
+			return relay.Descriptor{}, fmt.Errorf("evict moved relay identity: %w", err)
+		}
+		if moved.RowsAffected() > 0 {
+			// Two deployments sharing one identity seed (a copy-paste error)
+			// would show up here as endpoint flip-flopping.
+			slog.Warn("relay identity moved endpoint", "relay_id", id,
+				"new", fmt.Sprintf("%s:%d", desc.PublicHost, desc.PublicPort))
+		}
+		querier = tx
+	}
+	desc, err = scanDescriptor(querier.QueryRow(ctx, `
 		INSERT INTO relay_descriptors (
 			id,
 			public_host,
@@ -259,9 +307,10 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			punch_capable,
 			punch_endpoint,
 			exit_host,
-			node_class
+			node_class,
+			identity_public_key
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
 		)
 		ON CONFLICT (public_host, public_port) DO UPDATE SET
 			id = EXCLUDED.id,
@@ -289,9 +338,10 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			latitude = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.latitude ELSE 0 END,
 			longitude = CASE WHEN relay_descriptors.exit_host = EXCLUDED.exit_host THEN relay_descriptors.longitude ELSE 0 END,
 			exit_host = EXCLUDED.exit_host,
-			node_class = EXCLUDED.node_class
-		WHERE relay_descriptors.node_class <> $24
-			OR EXCLUDED.node_class = $24
+			node_class = EXCLUDED.node_class,
+			identity_public_key = EXCLUDED.identity_public_key
+		WHERE relay_descriptors.node_class <> $25
+			OR EXCLUDED.node_class = $25
 			OR relay_descriptors.expires_at <= EXCLUDED.registered_at
 		RETURNING `+descriptorColumns,
 		desc.ID,
@@ -317,6 +367,7 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		desc.PunchEndpoint,
 		desc.ExitHost,
 		desc.NodeClass,
+		desc.IdentityPublicKey,
 		relay.NodeClassFoundation,
 	))
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -325,7 +376,22 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 		// (non-foundation) registration may not take it over.
 		return relay.Descriptor{}, ErrNodeClassForbidden
 	}
-	return desc, err
+	if err != nil {
+		return relay.Descriptor{}, err
+	}
+	if tx, ok := querier.(pgx.Tx); ok {
+		if err := tx.Commit(ctx); err != nil {
+			return relay.Descriptor{}, fmt.Errorf("commit relay registration: %w", err)
+		}
+	}
+	return desc, nil
+}
+
+// pgxQuerier is the intersection of pgxpool.Pool and pgx.Tx that Register
+// needs, so the identity path can run its statements inside a transaction
+// while the legacy path keeps hitting the pool directly.
+type pgxQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
 func (s *PostgresStore) Heartbeat(id, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error) {
@@ -775,6 +841,7 @@ func scanDescriptor(row pgx.Row) (relay.Descriptor, error) {
 		&desc.Longitude,
 		&desc.ExitHost,
 		&desc.NodeClass,
+		&desc.IdentityPublicKey,
 	)
 	return desc, err
 }

--- a/internal/broker/postgres_store.go
+++ b/internal/broker/postgres_store.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -268,18 +267,16 @@ func (s *PostgresStore) Register(req relay.RegisterRequest, now time.Time, ttl t
 			return relay.Descriptor{}, fmt.Errorf("begin relay registration: %w", err)
 		}
 		defer func() { _ = tx.Rollback(ctx) }()
-		moved, err := tx.Exec(ctx, `
+		// A stable identity re-registering from a new endpoint abandons its old
+		// row. Tunnel relays hit this on most reconnects (the hub round-robins
+		// their public port), and the upsert below can still be refused and
+		// rolled back by the foundation-endpoint guard, so this is deliberately
+		// silent — logging here would be both noisy and, on a rollback, false.
+		if _, err := tx.Exec(ctx, `
 			DELETE FROM relay_descriptors
 			WHERE id = $1 AND (public_host <> $2 OR public_port <> $3)`,
-			id, desc.PublicHost, desc.PublicPort)
-		if err != nil {
+			id, desc.PublicHost, desc.PublicPort); err != nil {
 			return relay.Descriptor{}, fmt.Errorf("evict moved relay identity: %w", err)
-		}
-		if moved.RowsAffected() > 0 {
-			// Two deployments sharing one identity seed (a copy-paste error)
-			// would show up here as endpoint flip-flopping.
-			slog.Warn("relay identity moved endpoint", "relay_id", id,
-				"new", fmt.Sprintf("%s:%d", desc.PublicHost, desc.PublicPort))
 		}
 		querier = tx
 	}

--- a/internal/broker/postgres_store_test.go
+++ b/internal/broker/postgres_store_test.go
@@ -19,22 +19,44 @@ func (row heartbeatMissRow) Scan(dest ...any) error {
 func TestHeartbeatMissError(t *testing.T) {
 	lookupErr := errors.New("lookup failed")
 	tests := []struct {
-		name string
-		row  heartbeatMissRow
-		want error
+		name     string
+		row      heartbeatMissRow
+		maxClass string
+		want     error
 	}{
 		{
 			name: "foundation row exists",
 			row: func(dest ...any) error {
 				*dest[0].(*bool) = true
+				*dest[1].(*bool) = true
 				return nil
 			},
 			want: ErrNodeClassForbidden,
 		},
 		{
+			name: "authorized foundation registration mismatch",
+			row: func(dest ...any) error {
+				*dest[0].(*bool) = true
+				*dest[1].(*bool) = true
+				return nil
+			},
+			maxClass: relay.NodeClassFoundation,
+			want:     ErrRelayNotFound,
+		},
+		{
+			name: "volunteer registration mismatch",
+			row: func(dest ...any) error {
+				*dest[0].(*bool) = true
+				*dest[1].(*bool) = false
+				return nil
+			},
+			want: ErrRelayNotFound,
+		},
+		{
 			name: "relay is missing",
 			row: func(dest ...any) error {
 				*dest[0].(*bool) = false
+				*dest[1].(*bool) = false
 				return nil
 			},
 			want: ErrRelayNotFound,
@@ -47,7 +69,7 @@ func TestHeartbeatMissError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := heartbeatMissError(test.row); !errors.Is(err, test.want) {
+			if err := heartbeatMissError(test.row, test.maxClass); !errors.Is(err, test.want) {
 				t.Fatalf("heartbeat miss error = %v, want %v", err, test.want)
 			}
 		})
@@ -71,7 +93,7 @@ func TestPostgresStoreSharesRelayStateAcrossInstances(t *testing.T) {
 		t.Fatalf("second store did not see registered relay: %+v", listed)
 	}
 
-	updated, err := storeB.Heartbeat(desc.ID, relay.NodeClassVolunteer, now.Add(30*time.Second), time.Minute)
+	updated, err := storeB.Heartbeat(desc.ID, desc.LeaseToken, relay.NodeClassVolunteer, now.Add(30*time.Second), time.Minute)
 	if err != nil {
 		t.Fatalf("heartbeat from second store: %v", err)
 	}
@@ -143,7 +165,7 @@ func TestPostgresStoreDuplicateEndpointReplacesOldDescriptor(t *testing.T) {
 	if first.ID == second.ID {
 		t.Fatal("expected replacement to receive a new relay ID")
 	}
-	if _, err := store.Heartbeat(first.ID, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat(first.ID, first.LeaseToken, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("expected old relay ID to be forgotten, got %v", err)
 	}
 	listed, err := store.List(now.Add(2*time.Second), 10)
@@ -193,7 +215,7 @@ func TestPostgresStoreGeoSurvivesReRegistration(t *testing.T) {
 		t.Fatalf("register relay: %v", err)
 	}
 	geo := relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP"}
-	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+	if err := store.UpdateGeo(desc.ID, desc.LeaseToken, geo); err != nil {
 		t.Fatalf("update geo: %v", err)
 	}
 	listed, err := store.List(now.Add(time.Second), 10)
@@ -213,7 +235,7 @@ func TestPostgresStoreGeoSurvivesReRegistration(t *testing.T) {
 		t.Fatalf("expected re-registered relay to keep geo, got %+v", replacement.GeoLocation)
 	}
 
-	if err := store.UpdateGeo("relay_missing", geo); !errors.Is(err, ErrRelayNotFound) {
+	if err := store.UpdateGeo("relay_missing", "", geo); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("expected ErrRelayNotFound for unknown relay, got %v", err)
 	}
 }
@@ -233,7 +255,7 @@ func TestPostgresStoreExitHostChangeClearsGeo(t *testing.T) {
 		t.Fatalf("expected stored exit host, got %q", desc.ExitHost)
 	}
 	geo := relay.GeoLocation{City: "Tehran", Country: "Iran", CountryCode: "IR"}
-	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+	if err := store.UpdateGeo(desc.ID, desc.LeaseToken, geo); err != nil {
 		t.Fatalf("update geo: %v", err)
 	}
 
@@ -367,7 +389,7 @@ func TestPostgresStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 		t.Fatalf("register foundation relay: %v", err)
 	}
 
-	if _, err := store.Heartbeat(desc.ID, relay.NodeClassVolunteer, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
+	if _, err := store.Heartbeat(desc.ID, desc.LeaseToken, relay.NodeClassVolunteer, now.Add(time.Second), time.Minute); !errors.Is(err, ErrNodeClassForbidden) {
 		t.Fatalf("volunteer-class credential heartbeat of foundation relay: err = %v, want ErrNodeClassForbidden", err)
 	}
 	// The refused heartbeat must not have extended the lease: past the
@@ -376,7 +398,7 @@ func TestPostgresStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 		t.Fatalf("foundation relay lease was extended by refused heartbeat: %+v %v", listed, err)
 	}
 
-	updated, err := store.Heartbeat(desc.ID, relay.NodeClassFoundation, now.Add(30*time.Second), time.Minute)
+	updated, err := store.Heartbeat(desc.ID, desc.LeaseToken, relay.NodeClassFoundation, now.Add(30*time.Second), time.Minute)
 	if err != nil {
 		t.Fatalf("foundation-credential heartbeat: %v", err)
 	}
@@ -384,7 +406,7 @@ func TestPostgresStoreHeartbeatGuardsFoundationLease(t *testing.T) {
 		t.Fatalf("heartbeat descriptor node_class = %q, want %q", updated.NodeClass, relay.NodeClassFoundation)
 	}
 
-	if _, err := store.Heartbeat("relay_missing", relay.NodeClassFoundation, now, time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat("relay_missing", "", relay.NodeClassFoundation, now, time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("missing relay: err = %v, want ErrRelayNotFound", err)
 	}
 }

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -138,6 +138,16 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 		}
 
 		desc, err := store.Register(req, time.Now().UTC(), cfg.RelayLeaseTTL)
+		// A malformed or stale identity proof fails the registration loudly
+		// instead of silently falling back to a random relay ID — a relay that
+		// believes it has a stable identity should crash-loop where its
+		// operator can see it, mirroring the foundation-token posture above.
+		// The exact expired message is a contract: the relay hub matches it to
+		// recycle a tunnel session whose stored proof has aged out.
+		if errors.Is(err, relay.ErrIdentityProofExpired) || errors.Is(err, relay.ErrIdentityProofInvalid) || errors.Is(err, relay.ErrIdentityIncomplete) {
+			writeError(w, http.StatusUnauthorized, err.Error())
+			return
+		}
 		if errors.Is(err, ErrNodeClassForbidden) {
 			// The endpoint is held by a live foundation relay; a
 			// non-foundation registration may not seize it.

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -98,6 +99,9 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 
 func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Stable registrations return a bearer-like lease token. Keep it out of
+		// browser, intermediary, and edge caches on success and every error path.
+		w.Header().Set("Cache-Control", "no-store")
 		maxClass, ok := credentialNodeClass(r, cfg)
 		if !ok {
 			writeError(w, http.StatusUnauthorized, "missing or invalid relay registration token")
@@ -162,7 +166,7 @@ func registerHandler(store RelayStore, cfg Config) http.HandlerFunc {
 		resolveRelayGeo(r.Context(), store, cfg.GeoIP, &desc)
 		slog.Info("relay registered", "relay_id", desc.ID, "node_class", desc.NodeClass, "public", desc.PublicHost, "port", desc.PublicPort, "city", desc.City, "country", desc.Country, "max_sessions", desc.MaxSessions, "version", desc.RelayVersion)
 
-		writeJSON(w, http.StatusCreated, desc)
+		writeJSON(w, http.StatusCreated, relay.RegisterResponse{Descriptor: desc})
 	}
 }
 
@@ -182,8 +186,14 @@ func heartbeatHandler(store RelayStore, cfg Config) http.HandlerFunc {
 			writeError(w, http.StatusNotFound, "unknown relay endpoint")
 			return
 		}
+		var heartbeat relay.HeartbeatRequest
+		r.Body = http.MaxBytesReader(w, r.Body, maxRegisterBodyBytes)
+		if err := json.NewDecoder(r.Body).Decode(&heartbeat); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON request")
+			return
+		}
 
-		desc, err := store.Heartbeat(id, maxClass, time.Now().UTC(), cfg.RelayLeaseTTL)
+		desc, err := store.Heartbeat(id, heartbeat.LeaseToken, maxClass, time.Now().UTC(), cfg.RelayLeaseTTL)
 		if errors.Is(err, ErrRelayNotFound) {
 			writeError(w, http.StatusNotFound, "relay not found")
 			return
@@ -221,7 +231,12 @@ func resolveRelayGeo(ctx context.Context, store RelayStore, resolver GeoIPResolv
 		slog.Warn("could not resolve relay location", "relay_id", desc.ID, "host", host, "error", err)
 		return
 	}
-	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+	if err := store.UpdateGeo(desc.ID, desc.LeaseToken, geo); err != nil {
+		if errors.Is(err, ErrRelayNotFound) {
+			// A newer stable-ID registration replaced this descriptor while the
+			// lookup was in flight. Its own handler will resolve the current exit.
+			return
+		}
 		slog.Warn("could not store relay location", "relay_id", desc.ID, "error", err)
 		return
 	}

--- a/internal/broker/server_test.go
+++ b/internal/broker/server_test.go
@@ -63,16 +63,89 @@ func TestCanonicalRelayRoutesRegisterAndHeartbeat(t *testing.T) {
 	if registerRecorder.Code != http.StatusCreated {
 		t.Fatalf("register: expected 201, got %d: %s", registerRecorder.Code, registerRecorder.Body.String())
 	}
+	if got := registerRecorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("register Cache-Control = %q, want no-store", got)
+	}
 
 	var desc relay.Descriptor
 	if err := json.Unmarshal(registerRecorder.Body.Bytes(), &desc); err != nil {
 		t.Fatalf("decode descriptor: %v", err)
+	}
+	var registerFields map[string]any
+	if err := json.Unmarshal(registerRecorder.Body.Bytes(), &registerFields); err != nil {
+		t.Fatalf("decode registration fields: %v", err)
+	}
+	if _, ok := registerFields["lease_token"]; ok {
+		t.Fatalf("legacy identityless registration unexpectedly returned lease_token: %s", registerRecorder.Body.String())
 	}
 	heartbeatRecorder := httptest.NewRecorder()
 	heartbeatPath := "/api/v1/relays/" + desc.ID + "/heartbeat"
 	server.ServeHTTP(heartbeatRecorder, httptest.NewRequest(http.MethodPost, heartbeatPath, nil))
 	if heartbeatRecorder.Code != http.StatusOK {
 		t.Fatalf("heartbeat: expected 200, got %d: %s", heartbeatRecorder.Code, heartbeatRecorder.Body.String())
+	}
+}
+
+func TestStableRegistrationLeaseTokenRequiredAndNotListed(t *testing.T) {
+	now := time.Now().UTC()
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed(), RelayLeaseTTL: time.Minute})
+	req := signedIdentityRequest(t, identityStoreSeedA, func(r *relay.RegisterRequest) {
+		r.Transport = relay.TransportTunnel
+	}, now)
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal register request: %v", err)
+	}
+
+	registerRecorder := httptest.NewRecorder()
+	server.ServeHTTP(registerRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/relays/register", bytes.NewReader(body)))
+	if registerRecorder.Code != http.StatusCreated {
+		t.Fatalf("register: expected 201, got %d: %s", registerRecorder.Code, registerRecorder.Body.String())
+	}
+	if got := registerRecorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("stable register Cache-Control = %q, want no-store", got)
+	}
+	var registration relay.RegisterResponse
+	if err := json.Unmarshal(registerRecorder.Body.Bytes(), &registration); err != nil {
+		t.Fatalf("decode registration: %v", err)
+	}
+	desc := registration.Descriptor
+	if desc.LeaseToken == "" {
+		t.Fatal("stable registration response omitted lease_token")
+	}
+
+	heartbeatPath := "/api/v1/relays/" + desc.ID + "/heartbeat"
+	missingRecorder := httptest.NewRecorder()
+	server.ServeHTTP(missingRecorder, httptest.NewRequest(http.MethodPost, heartbeatPath, nil))
+	if missingRecorder.Code != http.StatusNotFound {
+		t.Fatalf("missing-token heartbeat: expected 404, got %d: %s", missingRecorder.Code, missingRecorder.Body.String())
+	}
+	heartbeatBody, err := json.Marshal(relay.HeartbeatRequest{OK: true, LeaseToken: desc.LeaseToken})
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	validRecorder := httptest.NewRecorder()
+	server.ServeHTTP(validRecorder, httptest.NewRequest(http.MethodPost, heartbeatPath, bytes.NewReader(heartbeatBody)))
+	if validRecorder.Code != http.StatusOK {
+		t.Fatalf("valid heartbeat: expected 200, got %d: %s", validRecorder.Code, validRecorder.Body.String())
+	}
+
+	listRecorder := httptest.NewRecorder()
+	server.ServeHTTP(listRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("list relays: expected 200, got %d: %s", listRecorder.Code, listRecorder.Body.String())
+	}
+	var listed struct {
+		Relays []map[string]any `json:"relays"`
+	}
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode relay list: %v", err)
+	}
+	if len(listed.Relays) != 1 {
+		t.Fatalf("listed relays = %d, want 1", len(listed.Relays))
+	}
+	if _, ok := listed.Relays[0]["lease_token"]; ok {
+		t.Fatalf("public relay list leaked lease_token: %s", listRecorder.Body.String())
 	}
 }
 

--- a/internal/broker/store.go
+++ b/internal/broker/store.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -80,34 +82,46 @@ func NewStoreWithRanking(rankingMode RankingMode) *Store {
 }
 
 func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Duration) (relay.Descriptor, error) {
-	id, err := newRelayID()
+	// Verification lives in the store, not the handler, so no future caller
+	// can register an identity-bearing request without the possession proof —
+	// the derived ID is only ever handed to a registrant holding the private
+	// key. Legacy requests (no identity fields) return a nil key and keep the
+	// random mint below.
+	identityKey, err := relay.VerifyIdentity(req, now)
 	if err != nil {
+		return relay.Descriptor{}, err
+	}
+	var id string
+	if identityKey != nil {
+		id = relay.DeriveRelayID(identityKey)
+	} else if id, err = newRelayID(); err != nil {
 		return relay.Descriptor{}, err
 	}
 
 	desc := relay.Descriptor{
-		ID:               id,
-		Label:            req.Label,
-		NodeClass:        normalizeNodeClass(req.NodeClass),
-		PublicHost:       req.PublicHost,
-		PublicPort:       req.PublicPort,
-		ExitHost:         req.ExitHost,
-		Protocol:         req.Protocol,
-		ClientID:         req.ClientID,
-		RealityPublicKey: req.RealityPublicKey,
-		ShortID:          req.ShortID,
-		ServerName:       req.ServerName,
-		Flow:             req.Flow,
-		ExitMode:         req.ExitMode,
-		MaxSessions:      req.MaxSessions,
-		MaxMbps:          req.MaxMbps,
-		RelayVersion:     req.RelayVersion,
-		Transport:        normalizeTransport(req.Transport),
-		PunchCapable:     req.PunchCapable,
-		PunchEndpoint:    req.PunchEndpoint,
-		RegisteredAt:     now,
-		LastHeartbeatAt:  now,
-		ExpiresAt:        now.Add(ttl),
+		ID:                id,
+		IdentityPublicKey: req.IdentityPublicKey,
+		Label:             req.Label,
+		NodeClass:         normalizeNodeClass(req.NodeClass),
+		PublicHost:        req.PublicHost,
+		PublicPort:        req.PublicPort,
+		ExitHost:          req.ExitHost,
+		Protocol:          req.Protocol,
+		ClientID:          req.ClientID,
+		RealityPublicKey:  req.RealityPublicKey,
+		ShortID:           req.ShortID,
+		ServerName:        req.ServerName,
+		Flow:              req.Flow,
+		ExitMode:          req.ExitMode,
+		MaxSessions:       req.MaxSessions,
+		MaxMbps:           req.MaxMbps,
+		RelayVersion:      req.RelayVersion,
+		Transport:         normalizeTransport(req.Transport),
+		PunchCapable:      req.PunchCapable,
+		PunchEndpoint:     req.PunchEndpoint,
+		RegisteredAt:      now,
+		LastHeartbeatAt:   now,
+		ExpiresAt:         now.Add(ttl),
 	}
 
 	s.mu.Lock()
@@ -146,6 +160,17 @@ func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Dura
 	}
 	for _, replacedID := range replacedIDs {
 		delete(s.relays, replacedID)
+	}
+	// A stable identity re-registering from a new endpoint abandons its old
+	// row — the map insert below replaces it by key, but log the move: two
+	// deployments sharing one identity seed (a copy-paste error) would show up
+	// here as endpoint flip-flopping.
+	if existing, ok := s.relays[id]; ok &&
+		(existing.PublicHost != desc.PublicHost || existing.PublicPort != desc.PublicPort) {
+		slog.Warn("relay identity moved endpoint",
+			"relay_id", id,
+			"old", fmt.Sprintf("%s:%d", existing.PublicHost, existing.PublicPort),
+			"new", fmt.Sprintf("%s:%d", desc.PublicHost, desc.PublicPort))
 	}
 	s.relays[id] = desc
 

--- a/internal/broker/store.go
+++ b/internal/broker/store.go
@@ -5,8 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
-	"fmt"
-	"log/slog"
 	"sync"
 	"time"
 
@@ -162,16 +160,9 @@ func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Dura
 		delete(s.relays, replacedID)
 	}
 	// A stable identity re-registering from a new endpoint abandons its old
-	// row — the map insert below replaces it by key, but log the move: two
-	// deployments sharing one identity seed (a copy-paste error) would show up
-	// here as endpoint flip-flopping.
-	if existing, ok := s.relays[id]; ok &&
-		(existing.PublicHost != desc.PublicHost || existing.PublicPort != desc.PublicPort) {
-		slog.Warn("relay identity moved endpoint",
-			"relay_id", id,
-			"old", fmt.Sprintf("%s:%d", existing.PublicHost, existing.PublicPort),
-			"new", fmt.Sprintf("%s:%d", desc.PublicHost, desc.PublicPort))
-	}
+	// row; the map insert replaces it by key. (Tunnel relays legitimately hit
+	// this on most reconnects, because the hub round-robins their public port,
+	// so it is normal traffic and not logged.)
 	s.relays[id] = desc
 
 	return desc, nil

--- a/internal/broker/store.go
+++ b/internal/broker/store.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"sync"
@@ -38,8 +39,8 @@ type RelayStore interface {
 	// e.g. an endpoint takeover through a rolled-back broker binary whose
 	// upsert predates node_class — expires within one TTL instead of being
 	// kept alive indefinitely by whoever now heartbeats the ID.
-	Heartbeat(id, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error)
-	UpdateGeo(string, relay.GeoLocation) error
+	Heartbeat(id, leaseToken, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error)
+	UpdateGeo(id, leaseToken string, geo relay.GeoLocation) error
 	List(time.Time, int) ([]relay.Descriptor, error)
 	// RelayNodeClasses resolves active relay IDs to the broker-attested class
 	// stored on their descriptors. Telemetry ingestion uses this bounded lookup
@@ -95,10 +96,18 @@ func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Dura
 	} else if id, err = newRelayID(); err != nil {
 		return relay.Descriptor{}, err
 	}
+	var leaseToken string
+	if identityKey != nil {
+		leaseToken, err = newRelayLeaseToken()
+		if err != nil {
+			return relay.Descriptor{}, err
+		}
+	}
 
 	desc := relay.Descriptor{
 		ID:                id,
 		IdentityPublicKey: req.IdentityPublicKey,
+		LeaseToken:        leaseToken,
 		Label:             req.Label,
 		NodeClass:         normalizeNodeClass(req.NodeClass),
 		PublicHost:        req.PublicHost,
@@ -168,7 +177,7 @@ func (s *Store) Register(req relay.RegisterRequest, now time.Time, ttl time.Dura
 	return desc, nil
 }
 
-func (s *Store) Heartbeat(id, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error) {
+func (s *Store) Heartbeat(id, leaseToken, maxClass string, now time.Time, ttl time.Duration) (relay.Descriptor, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -179,6 +188,14 @@ func (s *Store) Heartbeat(id, maxClass string, now time.Time, ttl time.Duration)
 	if desc.NodeClass == relay.NodeClassFoundation && maxClass != relay.NodeClassFoundation {
 		return relay.Descriptor{}, ErrNodeClassForbidden
 	}
+	// A stable relay ID names an identity, not one registration. Require the
+	// unlisted token minted for this exact incarnation so a stale session (or a
+	// one-time replay that moved the endpoint) cannot renew whichever endpoint
+	// currently occupies the ID. Empty stored tokens are migrated/pre-token
+	// stable rows and deliberately fail closed, forcing a fresh registration.
+	if desc.IdentityPublicKey != "" && (desc.LeaseToken == "" || subtle.ConstantTimeCompare([]byte(desc.LeaseToken), []byte(leaseToken)) != 1) {
+		return relay.Descriptor{}, ErrRelayNotFound
+	}
 
 	desc.LastHeartbeatAt = now
 	desc.ExpiresAt = now.Add(ttl)
@@ -187,12 +204,19 @@ func (s *Store) Heartbeat(id, maxClass string, now time.Time, ttl time.Duration)
 	return desc, nil
 }
 
-func (s *Store) UpdateGeo(id string, geo relay.GeoLocation) error {
+func (s *Store) UpdateGeo(id, leaseToken string, geo relay.GeoLocation) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	desc, ok := s.relays[id]
 	if !ok {
+		return ErrRelayNotFound
+	}
+	// GeoIP resolution happens after registration/heartbeat and may finish
+	// after another registration has reused this stable ID. Scope the delayed
+	// write to the registration that requested it so stale endpoint geography
+	// cannot contaminate the replacement descriptor.
+	if desc.IdentityPublicKey != "" && (desc.LeaseToken == "" || subtle.ConstantTimeCompare([]byte(desc.LeaseToken), []byte(leaseToken)) != 1) {
 		return ErrRelayNotFound
 	}
 	desc.GeoLocation = geo
@@ -436,4 +460,12 @@ func newRelayID() (string, error) {
 		return "", err
 	}
 	return "relay_" + hex.EncodeToString(b[:]), nil
+}
+
+func newRelayLeaseToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "lease_" + hex.EncodeToString(b[:]), nil
 }

--- a/internal/broker/store_test.go
+++ b/internal/broker/store_test.go
@@ -81,7 +81,7 @@ func TestHeartbeatExtendsRelayLease(t *testing.T) {
 	}
 
 	heartbeatAt := now.Add(30 * time.Second)
-	updated, err := store.Heartbeat(desc.ID, relay.NodeClassVolunteer, heartbeatAt, time.Minute)
+	updated, err := store.Heartbeat(desc.ID, desc.LeaseToken, relay.NodeClassVolunteer, heartbeatAt, time.Minute)
 	if err != nil {
 		t.Fatalf("heartbeat relay: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestStoreDuplicateEndpointReplacesOldDescriptor(t *testing.T) {
 	if first.ID == second.ID {
 		t.Fatal("expected replacement to receive a new relay ID")
 	}
-	if _, err := store.Heartbeat(first.ID, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
+	if _, err := store.Heartbeat(first.ID, first.LeaseToken, relay.NodeClassVolunteer, now.Add(2*time.Second), time.Minute); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("expected old relay ID to be forgotten, got %v", err)
 	}
 	listed, err := store.List(now.Add(2*time.Second), 10)
@@ -133,7 +133,7 @@ func TestStoreUpdateGeo(t *testing.T) {
 	}
 
 	geo := relay.GeoLocation{City: "Tokyo", Country: "Japan", CountryCode: "JP"}
-	if err := store.UpdateGeo(desc.ID, geo); err != nil {
+	if err := store.UpdateGeo(desc.ID, desc.LeaseToken, geo); err != nil {
 		t.Fatalf("update geo: %v", err)
 	}
 	listed, err := store.List(now.Add(time.Second), 10)
@@ -144,7 +144,7 @@ func TestStoreUpdateGeo(t *testing.T) {
 		t.Fatalf("expected listed relay to carry geo, got %+v", listed)
 	}
 
-	if err := store.UpdateGeo("relay_missing", geo); !errors.Is(err, ErrRelayNotFound) {
+	if err := store.UpdateGeo("relay_missing", "", geo); !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("expected ErrRelayNotFound for unknown relay, got %v", err)
 	}
 }

--- a/internal/relay/identity.go
+++ b/internal/relay/identity.go
@@ -1,0 +1,205 @@
+package relay
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Relay identity (spec "openrung-relay-identity-v1").
+//
+// A relay may hold a long-lived Ed25519 identity keypair and prove possession
+// of it at registration. The broker then derives the relay ID from the public
+// key instead of minting a random one, so the same relay keeps the same ID
+// across process restarts, broker restarts, and lease expiries — the churn
+// that previously orphaned dashboard history and ranking state on every
+// re-registration. Identity is optional: a registration without the identity
+// fields keeps today's random-ID behavior, so old relays and hubs continue to
+// work against a new broker (and new relays degrade gracefully against an old
+// broker, which ignores the unknown fields).
+//
+// The proof is a signature over a canonical statement that binds the
+// identity-relevant registration fields plus a relay-chosen expiry, so a
+// captured proof cannot be replayed with altered content, after expiry, or
+// across transports. The endpoint is bound only for direct transport: a
+// tunnel relay cannot know the hub-assigned endpoint when it signs (the hub
+// registers on its behalf and replays the stored request verbatim on broker
+// loss, which is also why the proof carries an expiry instead of a nonce).
+const (
+	// IdentitySpecV1 is the domain-separation tag for both the signed
+	// statement and the relay-ID derivation.
+	IdentitySpecV1 = "openrung-relay-identity-v1"
+
+	// MaxIdentityProofWindow bounds how far in the future a proof's expiry may
+	// lie. It caps replay of a captured proof; the check is expiry-only so a
+	// relay with a slow clock still produces a valid (merely shorter-lived)
+	// proof.
+	MaxIdentityProofWindow = 48 * time.Hour
+
+	// IdentityProofTTLDirect is generous only for clock skew: direct-mode
+	// registrations sign a fresh proof per call. IdentityProofTTLTunnel is
+	// long-lived by design — the hub replays the HELLO's proof verbatim on
+	// broker loss, and a fresh proof arrives with each tunnel reconnect.
+	IdentityProofTTLDirect = time.Hour
+	IdentityProofTTLTunnel = 24 * time.Hour
+)
+
+var (
+	ErrIdentityIncomplete   = errors.New("identity_public_key, identity_proof, and identity_expires_at must be supplied together")
+	ErrIdentityProofExpired = errors.New("relay identity proof expired")
+	ErrIdentityProofInvalid = errors.New("invalid relay identity proof")
+)
+
+// IdentityStatement returns the exact bytes the relay signs. Fields are
+// newline-joined in fixed order; every bound value is rejected elsewhere if it
+// contains a newline (see ValidateIdentityFields), so the encoding is
+// unambiguous. expiresAt is the verbatim identity_expires_at string from the
+// request — the broker echoes the string into the statement and parses it
+// separately for the freshness check, so no reformatting can desynchronize
+// signer and verifier. The endpoint slots are bound only for direct transport;
+// tunnel relays sign an empty host and port 0 because the hub assigns their
+// endpoint after the fact. Transport is always bound, so a tunnel proof can
+// never be replayed as a direct registration at an attacker-chosen endpoint.
+// RelayVersion is deliberately unbound: it changes on every upgrade and is
+// display-only.
+func IdentityStatement(req RegisterRequest, expiresAt string) []byte {
+	transport := req.Transport
+	if strings.TrimSpace(transport) == "" {
+		transport = TransportDirect
+	}
+	host := req.PublicHost
+	port := req.PublicPort
+	if transport == TransportTunnel {
+		host = ""
+		port = 0
+	}
+	nodeClass := req.NodeClass
+	if strings.TrimSpace(nodeClass) == "" {
+		nodeClass = NodeClassVolunteer
+	}
+	fields := []string{
+		IdentitySpecV1,
+		expiresAt,
+		transport,
+		host,
+		strconv.Itoa(port),
+		req.ClientID,
+		req.RealityPublicKey,
+		req.ShortID,
+		req.ServerName,
+		req.Flow,
+		req.ExitMode,
+		strconv.Itoa(req.MaxSessions),
+		strconv.Itoa(req.MaxMbps),
+		req.Label,
+		nodeClass,
+	}
+	return []byte(strings.Join(fields, "\n"))
+}
+
+// ValidateIdentityFields rejects bound fields containing newline or carriage
+// return, which would make the newline-joined statement ambiguous. Only
+// identity-bearing registrations pay this check.
+func ValidateIdentityFields(req RegisterRequest) error {
+	for name, value := range map[string]string{
+		"public_host":        req.PublicHost,
+		"client_id":          req.ClientID,
+		"reality_public_key": req.RealityPublicKey,
+		"short_id":           req.ShortID,
+		"server_name":        req.ServerName,
+		"flow":               req.Flow,
+		"exit_mode":          req.ExitMode,
+		"label":              req.Label,
+		"node_class":         req.NodeClass,
+		"transport":          req.Transport,
+	} {
+		if strings.ContainsAny(value, "\n\r") {
+			return fmt.Errorf("%s may not contain newline characters", name)
+		}
+	}
+	return nil
+}
+
+// SignIdentity produces the identity fields for a registration request: the
+// base64 raw public key, the base64 signature over the canonical statement,
+// and the RFC 3339 expiry string that was bound into it.
+func SignIdentity(priv ed25519.PrivateKey, req RegisterRequest, expiresAt time.Time) (publicKey, proof, expires string) {
+	expires = expiresAt.UTC().Format(time.RFC3339)
+	signature := ed25519.Sign(priv, IdentityStatement(req, expires))
+	publicKey = base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey))
+	proof = base64.StdEncoding.EncodeToString(signature)
+	return publicKey, proof, expires
+}
+
+// VerifyIdentity checks a registration's identity proof and returns the raw
+// public key on success. It enforces: all three fields present together, a
+// well-formed 32-byte key and 64-byte signature, an expiry that is in the
+// future but no further out than MaxIdentityProofWindow, newline-safe bound
+// fields, and a valid signature over the canonical statement.
+func VerifyIdentity(req RegisterRequest, now time.Time) (ed25519.PublicKey, error) {
+	if req.IdentityPublicKey == "" && req.IdentityProof == "" && req.IdentityExpiresAt == "" {
+		return nil, nil
+	}
+	if req.IdentityPublicKey == "" || req.IdentityProof == "" || req.IdentityExpiresAt == "" {
+		return nil, ErrIdentityIncomplete
+	}
+	if err := ValidateIdentityFields(req); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrIdentityProofInvalid, err)
+	}
+	publicKey, err := base64.StdEncoding.DecodeString(req.IdentityPublicKey)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: identity_public_key must be a base64 32-byte Ed25519 key", ErrIdentityProofInvalid)
+	}
+	signature, err := base64.StdEncoding.DecodeString(req.IdentityProof)
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("%w: identity_proof must be a base64 64-byte signature", ErrIdentityProofInvalid)
+	}
+	expires, err := time.Parse(time.RFC3339, req.IdentityExpiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("%w: identity_expires_at must be RFC 3339", ErrIdentityProofInvalid)
+	}
+	if !expires.After(now) {
+		return nil, ErrIdentityProofExpired
+	}
+	if expires.After(now.Add(MaxIdentityProofWindow)) {
+		return nil, fmt.Errorf("%w: identity_expires_at is more than %s in the future", ErrIdentityProofInvalid, MaxIdentityProofWindow)
+	}
+	if !ed25519.Verify(publicKey, IdentityStatement(req, req.IdentityExpiresAt), signature) {
+		return nil, ErrIdentityProofInvalid
+	}
+	return ed25519.PublicKey(publicKey), nil
+}
+
+// DeriveRelayID maps an identity public key to its stable relay ID:
+// "relay_" + lowercase hex of the first 16 bytes of SHA-256 over the
+// domain-separation tag and the raw key. Same shape as the legacy random IDs
+// (relay_ + 32 hex chars), so nothing downstream needs to distinguish them.
+func DeriveRelayID(publicKey ed25519.PublicKey) string {
+	sum := sha256.Sum256(append([]byte(IdentitySpecV1+":id:"), publicKey...))
+	return "relay_" + hex.EncodeToString(sum[:16])
+}
+
+// ParseIdentitySeed decodes a base64 32-byte Ed25519 seed (the same encoding
+// the broker uses for its relay-list signing key) into a private key.
+func ParseIdentitySeed(encoded string) (ed25519.PrivateKey, error) {
+	seed, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		return nil, errors.New("identity seed must be base64")
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("identity seed must decode to %d bytes, got %d", ed25519.SeedSize, len(seed))
+	}
+	return ed25519.NewKeyFromSeed(seed), nil
+}
+
+// EncodeIdentitySeed is the inverse of ParseIdentitySeed, used when persisting
+// a generated identity.
+func EncodeIdentitySeed(priv ed25519.PrivateKey) string {
+	return base64.StdEncoding.EncodeToString(priv.Seed())
+}

--- a/internal/relay/identity.go
+++ b/internal/relay/identity.go
@@ -37,16 +37,21 @@ const (
 	IdentitySpecV1 = "openrung-relay-identity-v1"
 
 	// MaxIdentityProofWindow bounds how far in the future a proof's expiry may
-	// lie. It caps replay of a captured proof; the check is expiry-only so a
-	// relay with a slow clock still produces a valid (merely shorter-lived)
-	// proof.
+	// lie, capping replay of a captured proof. It must exceed both TTLs below
+	// (a fast relay clock can date a proof up to its TTL ahead) with headroom.
 	MaxIdentityProofWindow = 48 * time.Hour
 
-	// IdentityProofTTLDirect is generous only for clock skew: direct-mode
-	// registrations sign a fresh proof per call. IdentityProofTTLTunnel is
-	// long-lived by design — the hub replays the HELLO's proof verbatim on
-	// broker loss, and a fresh proof arrives with each tunnel reconnect.
-	IdentityProofTTLDirect = time.Hour
+	// The proof TTLs are the replay window for a captured registration, but a
+	// replayed proof is low-value: it can only re-register the same identity —
+	// a direct proof binds the endpoint (so it merely re-asserts the relay's
+	// own registration), and a replayed tunnel proof cannot serve traffic
+	// because the bound Reality public key's private half stays on the real
+	// relay. So the TTLs are sized for clock tolerance, not minimized: a relay
+	// whose clock is off by less than the TTL still registers. Direct signs a
+	// fresh proof per call and tunnel re-signs on every reconnect (with
+	// session recycling when the broker reports one expired), so a short-lived
+	// proof is never a liability in practice.
+	IdentityProofTTLDirect = 24 * time.Hour
 	IdentityProofTTLTunnel = 24 * time.Hour
 )
 

--- a/internal/relay/identity_test.go
+++ b/internal/relay/identity_test.go
@@ -1,0 +1,242 @@
+package relay
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func identityTestKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	priv, err := ParseIdentitySeed("QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=")
+	if err != nil {
+		t.Fatalf("parse test seed: %v", err)
+	}
+	return priv
+}
+
+func identityTestRequest() RegisterRequest {
+	return RegisterRequest{
+		PublicHost:       "203.0.113.7",
+		PublicPort:       443,
+		Protocol:         ProtocolVLESSRealityVision,
+		ClientID:         "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+		RealityPublicKey: "hSN7wJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo",
+		ShortID:          "0123abcd",
+		ServerName:       "www.cloudflare.com",
+		Flow:             FlowVision,
+		ExitMode:         ExitModeDirect,
+		MaxSessions:      8,
+		MaxMbps:          20,
+		Label:            "witty-otter",
+	}
+}
+
+// TestIdentityGoldenVectors pins the wire format: statement bytes, derived
+// relay ID, and the (deterministic) Ed25519 proof. Breaking these breaks every
+// deployed relay and hub, so change them only with a new spec version.
+func TestIdentityGoldenVectors(t *testing.T) {
+	raw, err := os.ReadFile("testdata/identity_vectors.json")
+	if err != nil {
+		t.Fatalf("read vectors: %v", err)
+	}
+	var vectors struct {
+		IdentitySeedBase64      string `json:"identity_seed_base64"`
+		IdentityPublicKeyBase64 string `json:"identity_public_key_base64"`
+		DerivedRelayID          string `json:"derived_relay_id"`
+		DirectRegistration      struct {
+			IdentityExpiresAt   string `json:"identity_expires_at"`
+			Statement           string `json:"statement"`
+			IdentityProofBase64 string `json:"identity_proof_base64"`
+		} `json:"direct_registration"`
+	}
+	if err := json.Unmarshal(raw, &vectors); err != nil {
+		t.Fatalf("decode vectors: %v", err)
+	}
+
+	priv, err := ParseIdentitySeed(vectors.IdentitySeedBase64)
+	if err != nil {
+		t.Fatalf("parse vector seed: %v", err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	if got := base64.StdEncoding.EncodeToString(pub); got != vectors.IdentityPublicKeyBase64 {
+		t.Fatalf("public key mismatch: got %s want %s", got, vectors.IdentityPublicKeyBase64)
+	}
+	if got := DeriveRelayID(pub); got != vectors.DerivedRelayID {
+		t.Fatalf("derived relay ID mismatch: got %s want %s", got, vectors.DerivedRelayID)
+	}
+
+	req := identityTestRequest()
+	if got := string(IdentityStatement(req, vectors.DirectRegistration.IdentityExpiresAt)); got != vectors.DirectRegistration.Statement {
+		t.Fatalf("statement mismatch:\n got %q\nwant %q", got, vectors.DirectRegistration.Statement)
+	}
+	expires, err := time.Parse(time.RFC3339, vectors.DirectRegistration.IdentityExpiresAt)
+	if err != nil {
+		t.Fatalf("parse vector expiry: %v", err)
+	}
+	_, proof, expiresOut := SignIdentity(priv, req, expires)
+	if expiresOut != vectors.DirectRegistration.IdentityExpiresAt {
+		t.Fatalf("expiry serialization mismatch: got %s", expiresOut)
+	}
+	if proof != vectors.DirectRegistration.IdentityProofBase64 {
+		t.Fatalf("proof mismatch:\n got %s\nwant %s", proof, vectors.DirectRegistration.IdentityProofBase64)
+	}
+}
+
+func TestVerifyIdentityRoundTrip(t *testing.T) {
+	priv := identityTestKey(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	req := identityTestRequest()
+	req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt = SignIdentity(priv, req, now.Add(time.Hour))
+
+	key, err := VerifyIdentity(req, now)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if DeriveRelayID(key) != DeriveRelayID(priv.Public().(ed25519.PublicKey)) {
+		t.Fatal("verified key does not match the signer")
+	}
+
+	// A request with no identity fields is a legacy registration: nil key, no error.
+	legacy := identityTestRequest()
+	key, err = VerifyIdentity(legacy, now)
+	if err != nil || key != nil {
+		t.Fatalf("legacy request must verify to nil key: key=%v err=%v", key, err)
+	}
+}
+
+// TestVerifyIdentityBindsEveryStatementField flips each bound field after
+// signing and requires verification to fail: a captured proof must not be
+// replayable with altered registration content.
+func TestVerifyIdentityBindsEveryStatementField(t *testing.T) {
+	priv := identityTestKey(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	mutations := map[string]func(*RegisterRequest){
+		"public_host":        func(r *RegisterRequest) { r.PublicHost = "198.51.100.99" },
+		"public_port":        func(r *RegisterRequest) { r.PublicPort = 8443 },
+		"transport":          func(r *RegisterRequest) { r.Transport = TransportTunnel },
+		"client_id":          func(r *RegisterRequest) { r.ClientID = "d2719f3a-0000-4562-b3fc-2c963f66afa6" },
+		"reality_public_key": func(r *RegisterRequest) { r.RealityPublicKey = "AAAAwJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo" },
+		"short_id":           func(r *RegisterRequest) { r.ShortID = "ffffffff" },
+		"server_name":        func(r *RegisterRequest) { r.ServerName = "www.example.com" },
+		"flow":               func(r *RegisterRequest) { r.Flow = "none" },
+		"exit_mode":          func(r *RegisterRequest) { r.ExitMode = ExitModeDedicated },
+		"max_sessions":       func(r *RegisterRequest) { r.MaxSessions = 999 },
+		"max_mbps":           func(r *RegisterRequest) { r.MaxMbps = 999 },
+		"label":              func(r *RegisterRequest) { r.Label = "evil-otter" },
+		"node_class":         func(r *RegisterRequest) { r.NodeClass = NodeClassFoundation },
+		"expires_at":         func(r *RegisterRequest) { r.IdentityExpiresAt = now.Add(30 * time.Hour).UTC().Format(time.RFC3339) },
+	}
+	for field, mutate := range mutations {
+		req := identityTestRequest()
+		req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt = SignIdentity(priv, req, now.Add(time.Hour))
+		mutate(&req)
+		if _, err := VerifyIdentity(req, now); err == nil {
+			t.Errorf("mutating %s after signing must fail verification", field)
+		}
+	}
+
+	// Unbound fields may change without breaking the proof: the hub sets them
+	// after the relay signed (tunnel endpoint, punch settings, exit host), and
+	// relay_version changes on every upgrade.
+	req := identityTestRequest()
+	req.Transport = TransportTunnel
+	req.PublicHost = ""
+	req.PublicPort = 0
+	req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt = SignIdentity(priv, req, now.Add(time.Hour))
+	req.PublicHost = "hub.example.org"
+	req.PublicPort = 40001
+	req.ExitHost = "192.0.2.55"
+	req.PunchCapable = true
+	req.PunchEndpoint = "https://hub.example.org:9444"
+	req.RelayVersion = "relay/9.9.9"
+	if _, err := VerifyIdentity(req, now); err != nil {
+		t.Fatalf("hub-controlled fields must stay outside the tunnel statement: %v", err)
+	}
+}
+
+func TestVerifyIdentityExpiryWindow(t *testing.T) {
+	priv := identityTestKey(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	expired := identityTestRequest()
+	expired.IdentityPublicKey, expired.IdentityProof, expired.IdentityExpiresAt = SignIdentity(priv, expired, now.Add(-time.Second))
+	if _, err := VerifyIdentity(expired, now); !errors.Is(err, ErrIdentityProofExpired) {
+		t.Fatalf("expected ErrIdentityProofExpired, got %v", err)
+	}
+
+	tooFar := identityTestRequest()
+	tooFar.IdentityPublicKey, tooFar.IdentityProof, tooFar.IdentityExpiresAt = SignIdentity(priv, tooFar, now.Add(MaxIdentityProofWindow+time.Hour))
+	if _, err := VerifyIdentity(tooFar, now); !errors.Is(err, ErrIdentityProofInvalid) {
+		t.Fatalf("expected ErrIdentityProofInvalid for an over-window expiry, got %v", err)
+	}
+}
+
+func TestVerifyIdentityRejectsPartialFieldsAndNewlines(t *testing.T) {
+	priv := identityTestKey(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	partial := identityTestRequest()
+	partial.IdentityPublicKey, partial.IdentityProof, partial.IdentityExpiresAt = SignIdentity(priv, partial, now.Add(time.Hour))
+	partial.IdentityProof = ""
+	if _, err := VerifyIdentity(partial, now); !errors.Is(err, ErrIdentityIncomplete) {
+		t.Fatalf("expected ErrIdentityIncomplete, got %v", err)
+	}
+
+	// A newline inside a bound field would let two different field sets
+	// produce one statement; identity registrations refuse it outright.
+	sneaky := identityTestRequest()
+	sneaky.Label = "witty-otter\nvolunteer"
+	sneaky.IdentityPublicKey, sneaky.IdentityProof, sneaky.IdentityExpiresAt = SignIdentity(priv, sneaky, now.Add(time.Hour))
+	if _, err := VerifyIdentity(sneaky, now); !errors.Is(err, ErrIdentityProofInvalid) {
+		t.Fatalf("expected newline rejection, got %v", err)
+	}
+}
+
+func TestVerifyIdentityRejectsWrongKeyOrGarbage(t *testing.T) {
+	priv := identityTestKey(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	// Signature by one key presented with a different public key: the classic
+	// hijack — knowing a relay's public identity (it is public) must not allow
+	// registering as it.
+	otherSeed := strings.Repeat("A", 43) + "="
+	otherPriv, err := ParseIdentitySeed(otherSeed)
+	if err != nil {
+		t.Fatalf("parse other seed: %v", err)
+	}
+	req := identityTestRequest()
+	req.IdentityPublicKey, req.IdentityProof, req.IdentityExpiresAt = SignIdentity(otherPriv, req, now.Add(time.Hour))
+	req.IdentityPublicKey = base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey))
+	if _, err := VerifyIdentity(req, now); !errors.Is(err, ErrIdentityProofInvalid) {
+		t.Fatalf("expected forged-key rejection, got %v", err)
+	}
+
+	malformed := identityTestRequest()
+	malformed.IdentityPublicKey = "not-base64!"
+	malformed.IdentityProof = "AAAA"
+	malformed.IdentityExpiresAt = now.Add(time.Hour).Format(time.RFC3339)
+	if _, err := VerifyIdentity(malformed, now); !errors.Is(err, ErrIdentityProofInvalid) {
+		t.Fatalf("expected malformed-key rejection, got %v", err)
+	}
+}
+
+func TestParseIdentitySeed(t *testing.T) {
+	if _, err := ParseIdentitySeed("!!!"); err == nil {
+		t.Fatal("expected error for non-base64 seed")
+	}
+	if _, err := ParseIdentitySeed(base64.StdEncoding.EncodeToString([]byte("short"))); err == nil {
+		t.Fatal("expected error for wrong-length seed")
+	}
+	priv := identityTestKey(t)
+	round, err := ParseIdentitySeed(EncodeIdentitySeed(priv))
+	if err != nil || !round.Equal(priv) {
+		t.Fatalf("seed round-trip failed: %v", err)
+	}
+}

--- a/internal/relay/testdata/identity_vectors.json
+++ b/internal/relay/testdata/identity_vectors.json
@@ -1,0 +1,26 @@
+{
+  "spec": "openrung-relay-identity-v1",
+  "comment": "Golden wire vectors for the relay stable-identity proof. The seed is 32 bytes of 0x42 (the same test-seed convention as openrung-relay-list-signing-v1 §2.3). Ed25519 signatures are deterministic, so the proof is a stable golden value. Any implementation change that breaks these vectors is a wire-format break for deployed relays and hubs.",
+  "identity_seed_base64": "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=",
+  "identity_public_key_base64": "IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "derived_relay_id": "relay_0883de4588ee3af0f925ec7e3ce18aa7",
+  "direct_registration": {
+    "request": {
+      "public_host": "203.0.113.7",
+      "public_port": 443,
+      "protocol": "vless-reality-vision",
+      "client_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "reality_public_key": "hSN7wJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo",
+      "short_id": "0123abcd",
+      "server_name": "www.cloudflare.com",
+      "flow": "xtls-rprx-vision",
+      "exit_mode": "direct",
+      "max_sessions": 8,
+      "max_mbps": 20,
+      "label": "witty-otter"
+    },
+    "identity_expires_at": "2026-07-21T12:00:00Z",
+    "statement": "openrung-relay-identity-v1\n2026-07-21T12:00:00Z\ndirect\n203.0.113.7\n443\n3fa85f64-5717-4562-b3fc-2c963f66afa6\nhSN7wJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo\n0123abcd\nwww.cloudflare.com\nxtls-rprx-vision\ndirect\n8\n20\nwitty-otter\nvolunteer",
+    "identity_proof_base64": "9RVjlzxdNwlSn/ajekgF8Eikrycx7E2ydq8pRFgKyO/W03w+as55SOnGwWfsvH0xpdKqw9rbTmzf8cS4D8dIAg=="
+  }
+}

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -160,6 +160,12 @@ type Descriptor struct {
 	// Stored for operations and future per-relay auth; not serialized — the
 	// relay ID it derives is the public handle, and the list stays lean.
 	IdentityPublicKey string `json:"-"`
+	// LeaseToken identifies one concrete registration of this relay ID. Stable
+	// identities deliberately reuse their public ID across reconnects, so the
+	// ID alone cannot authorize a heartbeat: an older session would otherwise
+	// keep a newer session's endpoint alive. The token is returned only by the
+	// registration endpoint and is never included in public relay lists.
+	LeaseToken string `json:"-"`
 	// NodeClass is the broker-attested operator class (NodeClassFoundation or
 	// NodeClassVolunteer). Always serialized, and covered by the relay-list
 	// signature like every other descriptor field; clients that predate it
@@ -181,6 +187,51 @@ type Descriptor struct {
 	RegisteredAt     time.Time `json:"registered_at"`
 	LastHeartbeatAt  time.Time `json:"last_heartbeat_at"`
 	ExpiresAt        time.Time `json:"expires_at"`
+}
+
+// RegisterResponse is the private response to a successful registration. It
+// has the same wire shape as Descriptor plus lease_token; keeping the token out
+// of Descriptor's JSON representation prevents it from leaking through signed
+// public relay-list responses.
+type RegisterResponse struct {
+	Descriptor Descriptor
+}
+
+func (r RegisterResponse) MarshalJSON() ([]byte, error) {
+	type descriptorAlias Descriptor
+	return json.Marshal(struct {
+		descriptorAlias
+		VolunteerVersion string `json:"volunteer_version"`
+		LeaseToken       string `json:"lease_token,omitempty"`
+	}{
+		descriptorAlias:  descriptorAlias(r.Descriptor),
+		VolunteerVersion: r.Descriptor.RelayVersion,
+		LeaseToken:       r.Descriptor.LeaseToken,
+	})
+}
+
+func (r *RegisterResponse) UnmarshalJSON(data []byte) error {
+	var desc Descriptor
+	if err := json.Unmarshal(data, &desc); err != nil {
+		return err
+	}
+	var private struct {
+		LeaseToken string `json:"lease_token"`
+	}
+	if err := json.Unmarshal(data, &private); err != nil {
+		return err
+	}
+	desc.LeaseToken = private.LeaseToken
+	r.Descriptor = desc
+	return nil
+}
+
+// HeartbeatRequest renews exactly the registration that received LeaseToken.
+// Old identityless relays may omit it during a rolling upgrade; stable-
+// identity registrations require it because their relay ID is reusable.
+type HeartbeatRequest struct {
+	OK         bool   `json:"ok,omitempty"`
+	LeaseToken string `json:"lease_token,omitempty"`
 }
 
 // MarshalJSON keeps volunteer_version as a deprecated v1 response alias while

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -79,6 +79,14 @@ type RegisterRequest struct {
 	// never serves it to clients. Rejected for direct transport, where
 	// PublicHost already is the exit.
 	ExitHost string `json:"exit_host,omitempty"`
+	// IdentityPublicKey/IdentityProof/IdentityExpiresAt carry the optional
+	// stable-identity proof (spec openrung-relay-identity-v1, see identity.go).
+	// All three travel together; a registration without them keeps the legacy
+	// random relay ID. Old brokers ignore these unknown fields, so a new relay
+	// registers fine (with a random ID) during a rolling deploy.
+	IdentityPublicKey string `json:"identity_public_key,omitempty"`
+	IdentityProof     string `json:"identity_proof,omitempty"`
+	IdentityExpiresAt string `json:"identity_expires_at,omitempty"`
 }
 
 // MarshalJSON emits the canonical key plus the deprecated v1 alias so upgraded
@@ -147,6 +155,11 @@ type Descriptor struct {
 	// a CGNAT relay's observed exit IP through the public API would defeat the
 	// privacy the hub provides.
 	ExitHost string `json:"-"`
+	// IdentityPublicKey is the base64 Ed25519 key a stable-identity relay
+	// proved possession of at registration (empty for legacy registrations).
+	// Stored for operations and future per-relay auth; not serialized — the
+	// relay ID it derives is the public handle, and the list stays lean.
+	IdentityPublicKey string `json:"-"`
 	// NodeClass is the broker-attested operator class (NodeClassFoundation or
 	// NodeClassVolunteer). Always serialized, and covered by the relay-list
 	// signature like every other descriptor field; clients that predate it

--- a/internal/relay/types_test.go
+++ b/internal/relay/types_test.go
@@ -78,3 +78,57 @@ func TestDescriptorRelayVersionJSONMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistrationLeaseTokenIsPrivateToRegisterResponse(t *testing.T) {
+	desc := Descriptor{
+		ID:           "relay_stable",
+		RelayVersion: "1.2.3",
+		LeaseToken:   "lease_secret",
+	}
+
+	descriptorJSON, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("marshal descriptor: %v", err)
+	}
+	var publicFields map[string]any
+	if err := json.Unmarshal(descriptorJSON, &publicFields); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+	if _, ok := publicFields["lease_token"]; ok {
+		t.Fatalf("public descriptor leaked lease_token: %s", descriptorJSON)
+	}
+
+	registrationJSON, err := json.Marshal(RegisterResponse{Descriptor: desc})
+	if err != nil {
+		t.Fatalf("marshal registration response: %v", err)
+	}
+	var privateFields map[string]any
+	if err := json.Unmarshal(registrationJSON, &privateFields); err != nil {
+		t.Fatalf("decode registration response fields: %v", err)
+	}
+	if privateFields["lease_token"] != desc.LeaseToken {
+		t.Fatalf("registration lease_token = %#v, want %q", privateFields["lease_token"], desc.LeaseToken)
+	}
+
+	var decoded RegisterResponse
+	if err := json.Unmarshal(registrationJSON, &decoded); err != nil {
+		t.Fatalf("unmarshal registration response: %v", err)
+	}
+	if decoded.Descriptor.LeaseToken != desc.LeaseToken || decoded.Descriptor.RelayVersion != desc.RelayVersion {
+		t.Fatalf("registration round trip = %+v, want lease and version preserved", decoded.Descriptor)
+	}
+}
+
+func TestLegacyRegisterResponseOmitsEmptyLeaseToken(t *testing.T) {
+	payload, err := json.Marshal(RegisterResponse{Descriptor: Descriptor{ID: "relay_legacy"}})
+	if err != nil {
+		t.Fatalf("marshal legacy registration response: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatalf("decode legacy registration response: %v", err)
+	}
+	if _, ok := fields["lease_token"]; ok {
+		t.Fatalf("legacy response changed wire shape with empty lease_token: %s", payload)
+	}
+}

--- a/internal/relayruntime/broker.go
+++ b/internal/relayruntime/broker.go
@@ -37,18 +37,18 @@ type BrokerClient struct {
 
 // Register announces the relay and returns the broker-minted descriptor.
 func (b *BrokerClient) Register(ctx context.Context, req relay.RegisterRequest) (relay.Descriptor, error) {
-	var desc relay.Descriptor
-	if err := b.postJSON(ctx, relayRegisterPath, req, &desc); err != nil {
+	var registration relay.RegisterResponse
+	if err := b.postJSON(ctx, relayRegisterPath, req, &registration); err != nil {
 		return relay.Descriptor{}, err
 	}
-	return desc, nil
+	return registration.Descriptor, nil
 }
 
 // Heartbeat renews the relay's lease. A pruned relay yields an APIError with
 // status 404 that IsRelayNotFound recognizes.
-func (b *BrokerClient) Heartbeat(ctx context.Context, id string) error {
+func (b *BrokerClient) Heartbeat(ctx context.Context, id, leaseToken string) error {
 	var resp relay.HeartbeatResponse
-	return b.postJSON(ctx, relayHeartbeatPathBase+id+"/heartbeat", map[string]bool{"ok": true}, &resp)
+	return b.postJSON(ctx, relayHeartbeatPathBase+id+"/heartbeat", relay.HeartbeatRequest{OK: true, LeaseToken: leaseToken}, &resp)
 }
 
 func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out any) error {

--- a/internal/relayruntime/broker_test.go
+++ b/internal/relayruntime/broker_test.go
@@ -45,19 +45,20 @@ func TestBrokerClientUsesCanonicalRoutes(t *testing.T) {
 			if !reflect.DeepEqual(req, testBrokerRegisterRequest()) {
 				t.Errorf("register request = %+v, want %+v", req, testBrokerRegisterRequest())
 			}
-			writeBrokerJSON(w, http.StatusCreated, relay.Descriptor{
+			writeBrokerJSON(w, http.StatusCreated, relay.RegisterResponse{Descriptor: relay.Descriptor{
 				ID:         "relay_canonical",
 				PublicHost: "203.0.113.10",
 				PublicPort: 443,
 				ExpiresAt:  expiresAt,
-			})
+				LeaseToken: "lease_canonical",
+			}})
 		case relayHeartbeatPathBase + "relay_canonical/heartbeat":
-			var body map[string]bool
+			var body relay.HeartbeatRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Errorf("decode heartbeat request: %v", err)
 			}
-			if !body["ok"] {
-				t.Errorf("heartbeat body = %v, want ok=true", body)
+			if !body.OK || body.LeaseToken != "lease_canonical" {
+				t.Errorf("heartbeat body = %+v, want ok=true and propagated lease", body)
 			}
 			writeBrokerJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true, ExpiresAt: expiresAt})
 		default:
@@ -76,11 +77,12 @@ func TestBrokerClientUsesCanonicalRoutes(t *testing.T) {
 		PublicHost: "203.0.113.10",
 		PublicPort: 443,
 		ExpiresAt:  expiresAt,
+		LeaseToken: "lease_canonical",
 	}
 	if !reflect.DeepEqual(desc, want) {
 		t.Fatalf("Register() = %+v, want %+v", desc, want)
 	}
-	if err := client.Heartbeat(context.Background(), desc.ID); err != nil {
+	if err := client.Heartbeat(context.Background(), desc.ID, desc.LeaseToken); err != nil {
 		t.Fatalf("Heartbeat() error = %v", err)
 	}
 
@@ -120,7 +122,7 @@ func TestBrokerClientRelayNotFoundUsesCanonicalRoute(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	client := &BrokerClient{BaseURL: server.URL, HTTPClient: server.Client()}
-	err := client.Heartbeat(context.Background(), "relay_missing")
+	err := client.Heartbeat(context.Background(), "relay_missing", "")
 	if !IsRelayNotFound(err) {
 		t.Fatalf("Heartbeat() error = %v, want relay-not-found API error", err)
 	}
@@ -380,7 +382,7 @@ func TestBrokerClientSecureTransportAllowsLoopbackHTTP(t *testing.T) {
 	if desc.ID != "relay_foundation" {
 		t.Fatalf("Register() ID = %q, want relay_foundation", desc.ID)
 	}
-	if err := client.Heartbeat(context.Background(), desc.ID); err != nil {
+	if err := client.Heartbeat(context.Background(), desc.ID, desc.LeaseToken); err != nil {
 		t.Fatalf("Heartbeat() over loopback HTTP: %v", err)
 	}
 }
@@ -400,7 +402,7 @@ func TestBrokerClientSecureTransportRejectsRedirectsBeforeCredentialLeak(t *test
 		{
 			name: "heartbeat",
 			do: func(client *BrokerClient) error {
-				return client.Heartbeat(context.Background(), "relay_foundation")
+				return client.Heartbeat(context.Background(), "relay_foundation", "")
 			},
 		},
 	}
@@ -449,7 +451,7 @@ func TestBrokerClientSecureTransportRejectsRemotePlaintextBeforeSending(t *testi
 		RequireSecureTransport: true,
 	}
 
-	if err := client.Heartbeat(context.Background(), "relay_foundation"); err == nil {
+	if err := client.Heartbeat(context.Background(), "relay_foundation", ""); err == nil {
 		t.Fatal("Heartbeat() error = nil, want plaintext rejection")
 	}
 	if requests.Load() != 0 {

--- a/internal/relayruntime/config.go
+++ b/internal/relayruntime/config.go
@@ -2,15 +2,22 @@ package relayruntime
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 )
+
+// IdentitySeedEnvironmentVariable carries the relay's long-lived Ed25519
+// identity seed. Xray never needs it, so every Xray subprocess is launched
+// with this variable removed from its environment.
+const IdentitySeedEnvironmentVariable = "OPENRUNG_IDENTITY_SEED"
 
 type XrayConfigInput struct {
 	ListenHost        string
@@ -124,13 +131,33 @@ func GenerateRealityKeyPair(xrayPath string) (RealityKeyPair, error) {
 	if xrayPath == "" {
 		xrayPath = "xray"
 	}
-	cmd := exec.Command(xrayPath, "x25519")
+	cmd := NewXrayCommand(context.Background(), xrayPath, "x25519")
 	ConfigureBackgroundCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return RealityKeyPair{}, fmt.Errorf("run %s x25519: %w: %s", xrayPath, err, strings.TrimSpace(string(out)))
 	}
 	return ParseRealityKeyPair(out)
+}
+
+// NewXrayCommand constructs an Xray subprocess without passing the relay's
+// stable-identity seed to it. This shared boundary covers both one-shot key
+// generation and the long-running relay process.
+func NewXrayCommand(ctx context.Context, path string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Env = environmentWithoutIdentitySeed(os.Environ())
+	return cmd
+}
+
+func environmentWithoutIdentitySeed(environ []string) []string {
+	filtered := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		name, _, _ := strings.Cut(entry, "=")
+		if !strings.EqualFold(name, IdentitySeedEnvironmentVariable) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }
 
 func ParseRealityKeyPair(out []byte) (RealityKeyPair, error) {

--- a/internal/relayruntime/config_test.go
+++ b/internal/relayruntime/config_test.go
@@ -1,9 +1,64 @@
 package relayruntime
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
 	"testing"
 )
+
+func TestNewXrayCommandExcludesIdentitySeedFromEnvironment(t *testing.T) {
+	t.Setenv(IdentitySeedEnvironmentVariable, "long-lived-secret")
+	t.Setenv("OPENRUNG_TEST_CHILD_ENV", "preserved")
+
+	cmd := NewXrayCommand(context.Background(), "xray", "run")
+	if slices.Contains(cmd.Env, IdentitySeedEnvironmentVariable+"=long-lived-secret") {
+		t.Fatal("Xray command inherited OPENRUNG_IDENTITY_SEED")
+	}
+	if !slices.Contains(cmd.Env, "OPENRUNG_TEST_CHILD_ENV=preserved") {
+		t.Fatal("Xray command dropped unrelated environment variables")
+	}
+
+	// Windows treats environment names case-insensitively. Exercise the filter
+	// directly so a differently-cased spelling cannot survive into a child.
+	filtered := environmentWithoutIdentitySeed([]string{
+		"OpenRung_Identity_Seed=also-secret",
+		"OPENRUNG_TEST_CHILD_ENV=preserved",
+	})
+	if len(filtered) != 1 || filtered[0] != "OPENRUNG_TEST_CHILD_ENV=preserved" {
+		t.Fatalf("case-insensitive identity seed filtering = %q", filtered)
+	}
+}
+
+func TestGenerateRealityKeyPairExcludesIdentitySeedFromEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Xray executable requires a POSIX shell")
+	}
+
+	fakeXray := filepath.Join(t.TempDir(), "xray")
+	script := `#!/bin/sh
+if [ -n "${OPENRUNG_IDENTITY_SEED:-}" ]; then
+  echo "identity seed leaked to xray" >&2
+  exit 97
+fi
+printf 'Private key: private_key\nPublic key: public-key\n'
+`
+	if err := os.WriteFile(fakeXray, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake Xray: %v", err)
+	}
+	t.Setenv(IdentitySeedEnvironmentVariable, "long-lived-secret")
+
+	keys, err := GenerateRealityKeyPair(fakeXray)
+	if err != nil {
+		t.Fatalf("generate Reality key pair: %v", err)
+	}
+	if keys.PrivateKey != "private_key" || keys.PublicKey != "public-key" {
+		t.Fatalf("unexpected keys: %+v", keys)
+	}
+}
 
 func TestBuildXrayConfig(t *testing.T) {
 	cfg, err := BuildXrayConfig(XrayConfigInput{

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -589,17 +589,21 @@ func (e *Engine) prepareIdentity(cfg Config) (Identity, error) {
 		id.RealityPublicKey = keyPair.PublicKey
 		generated = true
 	}
-	if id.IdentitySeed == "" {
-		_, priv, err := ed25519.GenerateKey(cryptorand.Reader)
-		if err != nil {
-			return Identity{}, fmt.Errorf("generate identity key: %w", err)
+	if _, err := id.identityKey(); err != nil {
+		// Missing OR corrupt: regenerate rather than fail. A GUI volunteer has
+		// no way to hand-reset a mangled identity.json, and losing ID
+		// continuity (a fresh relay ID) is a far better outcome than an app
+		// that refuses to start. The regenerated seed is reported through
+		// OnIdentity below and persisted, healing the file.
+		if id.IdentitySeed != "" {
+			e.logf("persisted identity seed was unreadable; generating a new relay identity")
+		}
+		_, priv, genErr := ed25519.GenerateKey(cryptorand.Reader)
+		if genErr != nil {
+			return Identity{}, fmt.Errorf("generate identity key: %w", genErr)
 		}
 		id.IdentitySeed = relay.EncodeIdentitySeed(priv)
 		generated = true
-	} else if _, err := id.identityKey(); err != nil {
-		// A corrupt persisted seed would otherwise fail every registration;
-		// refuse loudly so the operator (or the desktop app) can reset it.
-		return Identity{}, fmt.Errorf("invalid persisted identity seed: %w", err)
 	}
 
 	if generated {

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -7,6 +7,8 @@ package engine
 
 import (
 	"context"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
@@ -59,6 +61,17 @@ type Identity struct {
 	RealityPrivateKey string `json:"realityPrivateKey"`
 	RealityPublicKey  string `json:"realityPublicKey"`
 	ShortID           string `json:"shortId"`
+	// IdentitySeed is the base64 Ed25519 seed behind the relay's stable
+	// identity (spec openrung-relay-identity-v1): the broker derives the relay
+	// ID from the proven public key, so persisting the seed keeps the same
+	// relay ID across restarts. Identity files written before this field exist
+	// gain a generated seed on next start.
+	IdentitySeed string `json:"identitySeed,omitempty"`
+}
+
+// identityKey parses the Ed25519 signing key out of the persisted seed.
+func (id Identity) identityKey() (ed25519.PrivateKey, error) {
+	return relay.ParseIdentitySeed(id.IdentitySeed)
 }
 
 // Config describes one relay. Zero values take the same defaults as
@@ -576,6 +589,18 @@ func (e *Engine) prepareIdentity(cfg Config) (Identity, error) {
 		id.RealityPublicKey = keyPair.PublicKey
 		generated = true
 	}
+	if id.IdentitySeed == "" {
+		_, priv, err := ed25519.GenerateKey(cryptorand.Reader)
+		if err != nil {
+			return Identity{}, fmt.Errorf("generate identity key: %w", err)
+		}
+		id.IdentitySeed = relay.EncodeIdentitySeed(priv)
+		generated = true
+	} else if _, err := id.identityKey(); err != nil {
+		// A corrupt persisted seed would otherwise fail every registration;
+		// refuse loudly so the operator (or the desktop app) can reset it.
+		return Identity{}, fmt.Errorf("invalid persisted identity seed: %w", err)
+	}
 
 	if generated {
 		e.mu.Lock()
@@ -694,6 +719,10 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 
 	e.setStatus(func() { e.phase = PhaseRegistering })
 
+	identityKey, err := identity.identityKey()
+	if err != nil {
+		return err
+	}
 	req := relay.RegisterRequest{
 		PublicHost:       publicHost,
 		PublicPort:       cfg.ListenPort,
@@ -709,7 +738,16 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 		RelayVersion:     cfg.Version,
 		Label:            label,
 	}
-	desc, err := registerWithRetry(ctx, broker, req)
+	// Every register call — initial and after an expired lease — signs a fresh
+	// proof over the final request fields, so the proof never ages out within
+	// a session.
+	signedReq := func() relay.RegisterRequest {
+		signed := req
+		signed.IdentityPublicKey, signed.IdentityProof, signed.IdentityExpiresAt =
+			relay.SignIdentity(identityKey, signed, time.Now().Add(relay.IdentityProofTTLDirect))
+		return signed
+	}
+	desc, err := registerWithRetry(ctx, broker, signedReq())
 	if err != nil {
 		return err
 	}
@@ -768,7 +806,7 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 					e.logf("heartbeat failed: %v", err)
 					continue
 				}
-				updated, regErr := broker.Register(ctx, req)
+				updated, regErr := broker.Register(ctx, signedReq())
 				if regErr != nil {
 					e.logf("re-register after expired lease failed: %v", regErr)
 					continue
@@ -830,23 +868,35 @@ func (e *Engine) runTunnelSession(ctx context.Context, cfg Config, label string,
 
 	e.setStatus(func() { e.phase = PhaseRegistering })
 
+	identityKey, err := identity.identityKey()
+	if err != nil {
+		return err
+	}
+	hello := tunnel.HelloFrame{
+		Token:            cfg.Token,
+		RealityPublicKey: identity.RealityPublicKey,
+		ShortID:          identity.ShortID,
+		ServerName:       cfg.ServerName,
+		ClientID:         identity.ClientID,
+		Flow:             relay.FlowVision,
+		ExitMode:         relay.ExitModeDirect,
+		MaxSessions:      cfg.MaxSessions,
+		MaxMbps:          cfg.MaxMbps,
+		Label:            label,
+		RelayVersion:     cfg.Version,
+		StreamTyping:     true,
+		PunchCapable:     cfg.PunchCapable,
+	}
 	client := &tunnel.Client{
 		HubAddr:   cfg.HubAddr,
 		TLSConfig: hubTLSConfig(cfg),
-		Hello: tunnel.HelloFrame{
-			Token:            cfg.Token,
-			RealityPublicKey: identity.RealityPublicKey,
-			ShortID:          identity.ShortID,
-			ServerName:       cfg.ServerName,
-			ClientID:         identity.ClientID,
-			Flow:             relay.FlowVision,
-			ExitMode:         relay.ExitModeDirect,
-			MaxSessions:      cfg.MaxSessions,
-			MaxMbps:          cfg.MaxMbps,
-			Label:            label,
-			RelayVersion:     cfg.Version,
-			StreamTyping:     true,
-			PunchCapable:     cfg.PunchCapable,
+		Hello:     hello,
+		// Each reconnect signs a fresh identity proof, so the hub always holds
+		// one with the full tunnel TTL ahead of it.
+		RefreshHello: func() tunnel.HelloFrame {
+			signed := hello
+			tunnel.SignHello(identityKey, &signed, time.Now().Add(relay.IdentityProofTTLTunnel))
+			return signed
 		},
 		TargetHost: loopHost,
 		TargetPort: loopPort,

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -658,7 +658,7 @@ func (e *Engine) startXray(ctx context.Context, cfg Config, identity Identity, l
 		return nil, make(chan error), nil
 	}
 
-	cmd := exec.CommandContext(ctx, cfg.XrayPath, "run", "-config", configPath)
+	cmd := relayruntime.NewXrayCommand(ctx, cfg.XrayPath, "run", "-config", configPath)
 	relayruntime.ConfigureBackgroundCommand(cmd)
 	logw := e.events.Log
 	cmd.Stdout = logw
@@ -805,7 +805,7 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 				return errPublicIPChanged
 			}
 		case <-heartbeat.C:
-			if err := broker.Heartbeat(ctx, desc.ID); err != nil {
+			if err := broker.Heartbeat(ctx, desc.ID, desc.LeaseToken); err != nil {
 				if !relayruntime.IsRelayNotFound(err) {
 					e.logf("heartbeat failed: %v", err)
 					continue

--- a/internal/relayruntime/engine/engine_test.go
+++ b/internal/relayruntime/engine/engine_test.go
@@ -259,7 +259,7 @@ func (h *hubRegistrar) Register(_ context.Context, req relay.RegisterRequest) (t
 	}, nil
 }
 
-func (h *hubRegistrar) Heartbeat(context.Context, string) error { return nil }
+func (h *hubRegistrar) Heartbeat(context.Context, string, string) error { return nil }
 
 func startTestHub(t *testing.T) (*tunnel.Hub, string) {
 	t.Helper()

--- a/internal/relayruntime/engine/engine_test.go
+++ b/internal/relayruntime/engine/engine_test.go
@@ -24,6 +24,9 @@ var testIdentity = Identity{
 	RealityPrivateKey: "yBaw3qcPC-EBiVzTF-3EbLpDF-eZ0lZ2pkc6y7NkoE4",
 	RealityPublicKey:  "1S86-yqTP6d76nEWXXWlNAci9c9uFhYaSOFAIUYIljI",
 	ShortID:           "0123456789abcdef",
+	// Tests that call run*Session directly bypass prepareIdentity, which is
+	// what fills this in for real callers.
+	IdentitySeed: "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=",
 }
 
 func freePort(t *testing.T) int {
@@ -283,4 +286,53 @@ func startTestHub(t *testing.T) (*tunnel.Hub, string) {
 	go func() { _ = hub.Serve(ctx) }()
 	t.Cleanup(cancel)
 	return hub, controlLn.Addr().String()
+}
+
+// TestPrepareIdentityBackfillsSeed pins the migration path for identity.json
+// files written before IdentitySeed existed: the engine generates a seed,
+// reports it through OnIdentity for persistence, and keeps every existing
+// field untouched.
+func TestPrepareIdentityBackfillsSeed(t *testing.T) {
+	legacy := testIdentity
+	legacy.IdentitySeed = ""
+	var persisted []Identity
+	eng := New(Config{
+		BrokerURL: "http://127.0.0.1:1",
+		Mode:      ModeDirect,
+		Identity:  legacy,
+	}, Events{OnIdentity: func(id Identity) { persisted = append(persisted, id) }})
+
+	got, err := eng.prepareIdentity(eng.cfg)
+	if err != nil {
+		t.Fatalf("prepareIdentity: %v", err)
+	}
+	if got.IdentitySeed == "" {
+		t.Fatal("expected a generated identity seed")
+	}
+	if _, err := got.identityKey(); err != nil {
+		t.Fatalf("generated seed does not parse: %v", err)
+	}
+	if got.ClientID != legacy.ClientID || got.RealityPublicKey != legacy.RealityPublicKey || got.ShortID != legacy.ShortID {
+		t.Fatalf("existing identity fields changed: %+v", got)
+	}
+	if len(persisted) != 1 || persisted[0].IdentitySeed != got.IdentitySeed {
+		t.Fatalf("expected the backfilled identity to be reported for persistence, got %+v", persisted)
+	}
+
+	// A fully populated identity is reported nowhere and stays byte-identical.
+	persisted = nil
+	again, err := eng.prepareIdentity(eng.cfg)
+	if err != nil {
+		t.Fatalf("prepareIdentity (second): %v", err)
+	}
+	if again != got || len(persisted) != 0 {
+		t.Fatalf("stable identity must be a no-op: %+v (persisted %d)", again, len(persisted))
+	}
+
+	// A corrupt persisted seed refuses loudly instead of churning identity.
+	corrupt := eng.cfg
+	corrupt.Identity.IdentitySeed = "!!!not-base64!!!"
+	if _, err := eng.prepareIdentity(corrupt); err == nil {
+		t.Fatal("expected an error for a corrupt persisted seed")
+	}
 }

--- a/internal/relayruntime/engine/engine_test.go
+++ b/internal/relayruntime/engine/engine_test.go
@@ -329,10 +329,23 @@ func TestPrepareIdentityBackfillsSeed(t *testing.T) {
 		t.Fatalf("stable identity must be a no-op: %+v (persisted %d)", again, len(persisted))
 	}
 
-	// A corrupt persisted seed refuses loudly instead of churning identity.
+	// A corrupt persisted seed regenerates (a GUI volunteer cannot hand-reset
+	// identity.json) and reports the fresh identity for persistence, rather
+	// than bricking the app.
+	persisted = nil
 	corrupt := eng.cfg
 	corrupt.Identity.IdentitySeed = "!!!not-base64!!!"
-	if _, err := eng.prepareIdentity(corrupt); err == nil {
-		t.Fatal("expected an error for a corrupt persisted seed")
+	healed, err := eng.prepareIdentity(corrupt)
+	if err != nil {
+		t.Fatalf("corrupt seed must regenerate, not fail: %v", err)
+	}
+	if healed.IdentitySeed == "" || healed.IdentitySeed == "!!!not-base64!!!" {
+		t.Fatalf("corrupt seed was not replaced: %q", healed.IdentitySeed)
+	}
+	if _, err := healed.identityKey(); err != nil {
+		t.Fatalf("regenerated seed does not parse: %v", err)
+	}
+	if len(persisted) != 1 || persisted[0].IdentitySeed != healed.IdentitySeed {
+		t.Fatalf("healed identity must be reported for persistence, got %+v", persisted)
 	}
 }

--- a/internal/tunnel/client.go
+++ b/internal/tunnel/client.go
@@ -30,6 +30,12 @@ type Client struct {
 	TLSConfig *tls.Config
 	// Hello is the handshake the relay announces (token + relay metadata).
 	Hello HelloFrame
+	// RefreshHello, when set, replaces Hello for each connection attempt. A
+	// stable-identity relay uses it to sign a fresh identity proof per
+	// reconnect, so a long-lived proof aging out never wedges the tunnel: the
+	// hub recycles the session when the broker rejects an expired proof, and
+	// the next attempt arrives freshly signed.
+	RefreshHello func() HelloFrame
 	// TargetHost and TargetPort point at the local Xray listener that streams
 	// are piped to.
 	TargetHost string
@@ -138,6 +144,9 @@ func (c *Client) runOnce(ctx context.Context) (time.Duration, error) {
 	defer conn.Close()
 
 	hello := c.Hello
+	if c.RefreshHello != nil {
+		hello = c.RefreshHello()
+	}
 	hello.ProtocolVersion = ProtocolVersion
 
 	_ = conn.SetDeadline(time.Now().Add(c.handshakeTimeout()))

--- a/internal/tunnel/identity_test.go
+++ b/internal/tunnel/identity_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/yamux"
 
 	"openrung/internal/relay"
 )
@@ -127,5 +130,47 @@ func TestClaimTunnelRejectsStaleSessionOnSharedID(t *testing.T) {
 	// B may still refresh its own claim (the normal reregister path).
 	if !hub.claimTunnel(id, b) {
 		t.Fatal("the owning session must be able to reclaim its own ID")
+	}
+}
+
+func TestLostRegistrationRetiresStaleHubSessionWithoutReregistering(t *testing.T) {
+	registrar := &fakeRegistrar{relayID: "relay_stable"}
+	hub := &Hub{Registrar: registrar}
+	serverConn, clientConn := net.Pipe()
+	serverSession, err := yamux.Server(serverConn, yamuxConfig())
+	if err != nil {
+		t.Fatalf("create stale yamux session: %v", err)
+	}
+	clientSession, err := yamux.Client(clientConn, yamuxConfig())
+	if err != nil {
+		t.Fatalf("create peer yamux session: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	const id = "relay_stable"
+	stale := &tunnel{
+		hub:        hub,
+		session:    serverSession,
+		relayID:    id,
+		leaseToken: "lease_old",
+		logger:     discardLogger(),
+	}
+	newer := &tunnel{}
+	hub.addTunnel(id, newer)
+
+	// The broker's 404/token-mismatch path reaches this method. Because B
+	// already owns the stable ID in the local registry, A must close before it
+	// can replay its stored proof and move the broker endpoint back to A.
+	stale.handleRegistrationLost(context.Background(), id)
+	if registers, _, _ := registrar.stats(); registers != 0 {
+		t.Fatalf("stale session performed %d registrations, want 0", registers)
+	}
+	select {
+	case <-serverSession.CloseChan():
+	case <-time.After(time.Second):
+		t.Fatal("stale session was not closed")
+	}
+	if hub.lookupTunnel(id) != newer {
+		t.Fatal("retiring stale session displaced the newer registry owner")
 	}
 }

--- a/internal/tunnel/identity_test.go
+++ b/internal/tunnel/identity_test.go
@@ -86,3 +86,46 @@ func TestRegistrarMapsIdentityProofExpired(t *testing.T) {
 		t.Fatalf("expected ErrIdentityProofExpired, got %v", err)
 	}
 }
+
+// TestClaimTunnelRejectsStaleSessionOnSharedID pins the fix for shared stable
+// IDs: when a fast reconnect (session B) already holds the relay ID, the stale
+// session A re-registering the SAME ID must not clobber B in the punch
+// registry — claimTunnel refuses, and A is expected to retire.
+func TestClaimTunnelRejectsStaleSessionOnSharedID(t *testing.T) {
+	hub := &Hub{}
+	a := &tunnel{}
+	b := &tunnel{}
+	const id = "relay_stable"
+
+	// A connects first and installs itself.
+	hub.addTunnel(id, a)
+	if hub.lookupTunnel(id) != a {
+		t.Fatal("A should own the slot after connect")
+	}
+
+	// B reconnects with the same derived ID and takes the slot (newest wins).
+	hub.addTunnel(id, b)
+	if hub.lookupTunnel(id) != b {
+		t.Fatal("B should own the slot after its connect")
+	}
+
+	// A, now stale, re-registers the same ID after the broker forgot the lease.
+	// It must lose the claim rather than overwrite B.
+	if hub.claimTunnel(id, a) {
+		t.Fatal("stale session A must not reclaim an ID owned by live session B")
+	}
+	if hub.lookupTunnel(id) != b {
+		t.Fatal("claimTunnel by A corrupted B's registry entry")
+	}
+
+	// A's eventual teardown is a no-op (compare-and-delete by pointer).
+	hub.removeTunnel(id, a)
+	if hub.lookupTunnel(id) != b {
+		t.Fatal("A's teardown evicted B")
+	}
+
+	// B may still refresh its own claim (the normal reregister path).
+	if !hub.claimTunnel(id, b) {
+		t.Fatal("the owning session must be able to reclaim its own ID")
+	}
+}

--- a/internal/tunnel/identity_test.go
+++ b/internal/tunnel/identity_test.go
@@ -1,0 +1,88 @@
+package tunnel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+// TestSignHelloSurvivesHubRegisterRequest pins the tunnel identity chain: the
+// relay signs at HELLO time without knowing the hub-assigned endpoint, the hub
+// builds its RegisterRequest (endpoint, exit host, punch settings, tunnel
+// transport), and the broker-side verifier must accept the result. If the
+// hub's registerRequest ever starts overwriting a statement-bound field, this
+// fails.
+func TestSignHelloSurvivesHubRegisterRequest(t *testing.T) {
+	priv, err := relay.ParseIdentitySeed("QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=")
+	if err != nil {
+		t.Fatalf("parse seed: %v", err)
+	}
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	hello := HelloFrame{
+		RealityPublicKey: "hSN7wJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo",
+		ShortID:          "0123abcd",
+		ServerName:       "www.cloudflare.com",
+		ClientID:         "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+		Flow:             relay.FlowVision,
+		ExitMode:         relay.ExitModeDirect,
+		MaxSessions:      8,
+		MaxMbps:          20,
+		Label:            "witty-otter",
+		RelayVersion:     "relay/1.0.0",
+		StreamTyping:     true,
+		PunchCapable:     true,
+	}
+	SignHello(priv, &hello, now.Add(relay.IdentityProofTTLTunnel))
+
+	hub := &Hub{PublicHost: "203.0.113.99", PunchEndpoint: "https://203.0.113.99:9444"}
+	req := hub.registerRequest(hello, 40007, "192.0.2.55")
+
+	key, err := relay.VerifyIdentity(req, now)
+	if err != nil {
+		t.Fatalf("hub-shaped request failed verification: %v", err)
+	}
+	if key == nil {
+		t.Fatal("identity fields were dropped between HELLO and RegisterRequest")
+	}
+
+	// The proof must stay valid on the hub's verbatim re-register later in the
+	// session, and reject once the relay-chosen expiry passes.
+	if _, err := relay.VerifyIdentity(req, now.Add(23*time.Hour)); err != nil {
+		t.Fatalf("verbatim re-register within the proof TTL failed: %v", err)
+	}
+	if _, err := relay.VerifyIdentity(req, now.Add(25*time.Hour)); !errors.Is(err, relay.ErrIdentityProofExpired) {
+		t.Fatalf("expected expiry after the proof TTL, got %v", err)
+	}
+
+	// A tunnel proof must not be replayable as a direct registration at an
+	// attacker-chosen endpoint: transport is bound.
+	hijack := req
+	hijack.Transport = relay.TransportDirect
+	if _, err := relay.VerifyIdentity(hijack, now); err == nil {
+		t.Fatal("tunnel proof was accepted for a direct registration")
+	}
+}
+
+// TestRegistrarMapsIdentityProofExpired pins the error contract the hub's
+// session-recycling depends on.
+func TestRegistrarMapsIdentityProofExpired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(relay.ErrorResponse{Error: "relay identity proof expired"})
+	}))
+	defer server.Close()
+
+	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
+	_, err := registrar.Register(context.Background(), relay.RegisterRequest{})
+	if !errors.Is(err, ErrIdentityProofExpired) {
+		t.Fatalf("expected ErrIdentityProofExpired, got %v", err)
+	}
+}

--- a/internal/tunnel/protocol.go
+++ b/internal/tunnel/protocol.go
@@ -1,11 +1,15 @@
 package tunnel
 
 import (
+	"crypto/ed25519"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"time"
+
+	"openrung/internal/relay"
 )
 
 // ProtocolVersion is the tunnel control-protocol version. The relay sends it
@@ -59,6 +63,37 @@ type HelloFrame struct {
 	// PunchCapable requests that the hub advertise this relay as punch-capable to
 	// clients. Only meaningful when StreamTyping is also set.
 	PunchCapable bool `json:"punch_capable,omitempty"`
+	// IdentityPublicKey/IdentityProof/IdentityExpiresAt carry the relay's
+	// optional stable-identity proof (spec openrung-relay-identity-v1). The hub
+	// forwards them verbatim to the broker, which derives the relay ID from the
+	// proven key. The tunnel statement binds no endpoint — the relay cannot
+	// know the hub-assigned one — so the proof stays valid for the hub's
+	// verbatim re-registrations until IdentityExpiresAt; a fresh HELLO on each
+	// reconnect renews it. Additive: absent fields keep the legacy random ID.
+	IdentityPublicKey string `json:"identity_public_key,omitempty"`
+	IdentityProof     string `json:"identity_proof,omitempty"`
+	IdentityExpiresAt string `json:"identity_expires_at,omitempty"`
+}
+
+// SignHello fills hello's identity fields with a proof over the tunnel-shaped
+// registration statement: the exact field set the hub will submit on this
+// relay's behalf, with the endpoint slots empty (the hub assigns them) and
+// volunteer node class (the hub never claims a class). Must be called after
+// every other HelloFrame field is final.
+func SignHello(priv ed25519.PrivateKey, hello *HelloFrame, expiresAt time.Time) {
+	req := relay.RegisterRequest{
+		Transport:        relay.TransportTunnel,
+		ClientID:         hello.ClientID,
+		RealityPublicKey: hello.RealityPublicKey,
+		ShortID:          hello.ShortID,
+		ServerName:       hello.ServerName,
+		Flow:             hello.Flow,
+		ExitMode:         hello.ExitMode,
+		MaxSessions:      hello.MaxSessions,
+		MaxMbps:          hello.MaxMbps,
+		Label:            hello.Label,
+	}
+	hello.IdentityPublicKey, hello.IdentityProof, hello.IdentityExpiresAt = relay.SignIdentity(priv, req, expiresAt)
 }
 
 // HelloAckFrame is the hub's reply to a HelloFrame. On success it carries the

--- a/internal/tunnel/punch.go
+++ b/internal/tunnel/punch.go
@@ -44,6 +44,25 @@ func (h *Hub) addTunnel(relayID string, t *tunnel) {
 	h.registry[relayID] = t
 }
 
+// claimTunnel installs t under relayID only if the slot is free or already t,
+// returning false when another live tunnel owns it. A stable relay identity
+// makes a reconnect reuse the same relay ID, so a stale session re-registering
+// after the broker forgot the lease must not overwrite the newer session that
+// already took the slot. Distinct from addTunnel, which is the unconditional
+// first install at connect time (the connecting session always owns its ID).
+func (h *Hub) claimTunnel(relayID string, t *tunnel) bool {
+	h.registryMu.Lock()
+	defer h.registryMu.Unlock()
+	if current, ok := h.registry[relayID]; ok && current != t {
+		return false
+	}
+	if h.registry == nil {
+		h.registry = make(map[string]*tunnel)
+	}
+	h.registry[relayID] = t
+	return true
+}
+
 // removeTunnel deletes the entry only if it is still this tunnel, so a fast
 // reconnect that already installed a new tunnel under a new relay ID is never
 // evicted by the old tunnel's teardown.

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -19,6 +19,16 @@ import (
 // restart. The caller should re-register rather than keep heartbeating.
 var ErrRelayNotFound = errors.New("relay not found")
 
+// ErrIdentityProofExpired is returned (wrapped) by Register when the broker
+// rejects a stored identity proof whose relay-chosen expiry has passed. Only
+// the relay can sign a fresh one, so the hub recycles the tunnel session
+// instead of retrying the doomed request.
+var ErrIdentityProofExpired = errors.New(relayIdentityProofExpiredMessage)
+
+// relayIdentityProofExpiredMessage mirrors relay.ErrIdentityProofExpired's
+// exact text, which the broker serves verbatim in its error body.
+const relayIdentityProofExpiredMessage = "relay identity proof expired"
+
 const maxBrokerErrorBodyBytes = 64 << 10
 
 // RelayRegistration is the result of registering a tunneled relay with the broker.
@@ -120,6 +130,9 @@ func (b *brokerRegistrar) postJSON(ctx context.Context, path string, body, out a
 		}
 		if resp.StatusCode == http.StatusNotFound && apiErr.Error == "relay not found" {
 			return fmt.Errorf("broker %s: %w", path, ErrRelayNotFound)
+		}
+		if resp.StatusCode == http.StatusUnauthorized && strings.HasPrefix(apiErr.Error, relayIdentityProofExpiredMessage) {
+			return fmt.Errorf("broker %s: %w", path, ErrIdentityProofExpired)
 		}
 		return &brokerHTTPError{
 			path:    path,

--- a/internal/tunnel/registrar.go
+++ b/internal/tunnel/registrar.go
@@ -34,6 +34,7 @@ const maxBrokerErrorBodyBytes = 64 << 10
 // RelayRegistration is the result of registering a tunneled relay with the broker.
 type RelayRegistration struct {
 	RelayID    string
+	LeaseToken string
 	PublicHost string
 	PublicPort int
 	ExpiresAt  time.Time
@@ -43,7 +44,7 @@ type RelayRegistration struct {
 // is an interface so the hub can be tested without a live broker.
 type Registrar interface {
 	Register(ctx context.Context, req relay.RegisterRequest) (RelayRegistration, error)
-	Heartbeat(ctx context.Context, relayID string) error
+	Heartbeat(ctx context.Context, relayID, leaseToken string) error
 }
 
 // brokerRegistrar registers relays over the broker's canonical HTTP API using
@@ -73,21 +74,23 @@ func NewBrokerRegistrar(brokerURL, token string, client *http.Client) Registrar 
 }
 
 func (b *brokerRegistrar) Register(ctx context.Context, req relay.RegisterRequest) (RelayRegistration, error) {
-	var desc relay.Descriptor
-	if err := b.postJSON(ctx, "/api/v1/relays/register", req, &desc); err != nil {
+	var response relay.RegisterResponse
+	if err := b.postJSON(ctx, "/api/v1/relays/register", req, &response); err != nil {
 		return RelayRegistration{}, err
 	}
+	desc := response.Descriptor
 	return RelayRegistration{
 		RelayID:    desc.ID,
+		LeaseToken: desc.LeaseToken,
 		PublicHost: desc.PublicHost,
 		PublicPort: desc.PublicPort,
 		ExpiresAt:  desc.ExpiresAt,
 	}, nil
 }
 
-func (b *brokerRegistrar) Heartbeat(ctx context.Context, relayID string) error {
+func (b *brokerRegistrar) Heartbeat(ctx context.Context, relayID, leaseToken string) error {
 	var resp relay.HeartbeatResponse
-	return b.postJSON(ctx, "/api/v1/relays/"+relayID+"/heartbeat", map[string]bool{"ok": true}, &resp)
+	return b.postJSON(ctx, "/api/v1/relays/"+relayID+"/heartbeat", relay.HeartbeatRequest{OK: true, LeaseToken: leaseToken}, &resp)
 }
 
 // brokerHTTPError is a non-2xx broker response.

--- a/internal/tunnel/registrar_test.go
+++ b/internal/tunnel/registrar_test.go
@@ -48,19 +48,20 @@ func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 			if !reflect.DeepEqual(req, testRegisterRequest()) {
 				t.Errorf("register request = %+v, want %+v", req, testRegisterRequest())
 			}
-			writeRegistrarJSON(w, http.StatusOK, relay.Descriptor{
+			writeRegistrarJSON(w, http.StatusOK, relay.RegisterResponse{Descriptor: relay.Descriptor{
 				ID:         "relay_canonical",
 				PublicHost: "203.0.113.10",
 				PublicPort: 443,
 				ExpiresAt:  expiresAt,
-			})
+				LeaseToken: "lease_canonical",
+			}})
 		case "/api/v1/relays/relay_canonical/heartbeat":
-			var body map[string]bool
+			var body relay.HeartbeatRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Errorf("decode heartbeat request: %v", err)
 			}
-			if !body["ok"] {
-				t.Errorf("heartbeat body = %v, want ok=true", body)
+			if !body.OK || body.LeaseToken != "lease_canonical" {
+				t.Errorf("heartbeat body = %+v, want ok=true and propagated lease", body)
 			}
 			writeRegistrarJSON(w, http.StatusOK, relay.HeartbeatResponse{OK: true, ExpiresAt: expiresAt})
 		default:
@@ -76,6 +77,7 @@ func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 	}
 	want := RelayRegistration{
 		RelayID:    "relay_canonical",
+		LeaseToken: "lease_canonical",
 		PublicHost: "203.0.113.10",
 		PublicPort: 443,
 		ExpiresAt:  expiresAt,
@@ -83,7 +85,7 @@ func TestBrokerRegistrarUsesCanonicalRoutes(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Register() = %+v, want %+v", got, want)
 	}
-	if err := registrar.Heartbeat(context.Background(), got.RelayID); err != nil {
+	if err := registrar.Heartbeat(context.Background(), got.RelayID, got.LeaseToken); err != nil {
 		t.Fatalf("Heartbeat() error = %v", err)
 	}
 
@@ -123,7 +125,7 @@ func TestBrokerRegistrarMapsRelayNotFound(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	registrar := NewBrokerRegistrar(server.URL, "", server.Client())
-	err := registrar.Heartbeat(context.Background(), "relay_missing")
+	err := registrar.Heartbeat(context.Background(), "relay_missing", "")
 	if !errors.Is(err, ErrRelayNotFound) {
 		t.Fatalf("Heartbeat() error = %v, want ErrRelayNotFound", err)
 	}

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -204,6 +204,12 @@ func (h *Hub) registerRequest(hello HelloFrame, port int, exitHost string) relay
 		Transport:        relay.TransportTunnel,
 		PunchCapable:     punchOn,
 		PunchEndpoint:    punchEndpoint,
+		// Forwarded verbatim: the identity statement binds only relay-known
+		// fields (the hub-assigned endpoint and punch settings are outside it),
+		// so the broker can verify the relay's proof without hub involvement.
+		IdentityPublicKey: hello.IdentityPublicKey,
+		IdentityProof:     hello.IdentityProof,
+		IdentityExpiresAt: hello.IdentityExpiresAt,
 	}
 }
 
@@ -447,6 +453,14 @@ func (t *tunnel) reregister(ctx context.Context) {
 	registration, err := t.hub.Registrar.Register(regCtx, t.registerReq)
 	cancel()
 	if err != nil {
+		// A stored identity proof past its expiry can never re-register — only
+		// the relay holds the signing key. Recycle the session: the relay
+		// reconnects with a freshly signed HELLO and registration recovers.
+		if errors.Is(err, ErrIdentityProofExpired) {
+			t.logger.Warn("relay identity proof expired; recycling tunnel session for a fresh handshake")
+			_ = t.session.Close()
+			return
+		}
 		t.logger.Warn("relay re-registration failed", "error", err)
 		return
 	}

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -167,6 +167,7 @@ func (h *Hub) handleControl(ctx context.Context, conn net.Conn) {
 		publicListener: publicListener,
 		port:           port,
 		relayID:        registration.RelayID,
+		leaseToken:     registration.LeaseToken,
 		registerReq:    regReq,
 		streamTyping:   streamTyping,
 		logger:         logger.With("relay_id", registration.RelayID, "public_port", port, "remote", remote),
@@ -280,10 +281,11 @@ type tunnel struct {
 	// heartbeat loop can re-register verbatim if the broker forgets the relay.
 	registerReq relay.RegisterRequest
 
-	// relayID is the broker-assigned ID; it changes on re-registration, so it
-	// is guarded for the teardown path that reads it after the heartbeat loop.
-	relayIDMu sync.Mutex
-	relayID   string
+	// relayID and leaseToken identify one broker registration. They rotate
+	// together on re-registration and are guarded for heartbeat/teardown reads.
+	relayIDMu  sync.Mutex
+	relayID    string
+	leaseToken string
 }
 
 func (t *tunnel) currentRelayID() string {
@@ -292,10 +294,17 @@ func (t *tunnel) currentRelayID() string {
 	return t.relayID
 }
 
-func (t *tunnel) setRelayID(id string) {
+func (t *tunnel) currentRegistration() (string, string) {
+	t.relayIDMu.Lock()
+	defer t.relayIDMu.Unlock()
+	return t.relayID, t.leaseToken
+}
+
+func (t *tunnel) setRegistration(id, leaseToken string) {
 	t.relayIDMu.Lock()
 	defer t.relayIDMu.Unlock()
 	t.relayID = id
+	t.leaseToken = leaseToken
 }
 
 func (t *tunnel) run(parent context.Context) {
@@ -427,8 +436,9 @@ func (t *tunnel) heartbeatLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			relayID, leaseToken := t.currentRegistration()
 			hbCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			err := t.hub.Registrar.Heartbeat(hbCtx, t.currentRelayID())
+			err := t.hub.Registrar.Heartbeat(hbCtx, relayID, leaseToken)
 			cancel()
 			if err == nil {
 				continue
@@ -437,9 +447,22 @@ func (t *tunnel) heartbeatLoop(ctx context.Context) {
 				t.logger.Warn("relay heartbeat failed", "error", err)
 				continue
 			}
-			t.reregister(ctx)
+			// A newer tunnel session with the same stable relay ID has replaced
+			// this registration. Retire locally before re-registering: replaying
+			// this stale session's stored proof would move the broker endpoint
+			// back to its dead public listener for another heartbeat interval.
+			t.handleRegistrationLost(ctx, relayID)
 		}
 	}
+}
+
+func (t *tunnel) handleRegistrationLost(ctx context.Context, relayID string) {
+	if !t.hub.claimTunnel(relayID, t) {
+		t.logger.Info("relay registration belongs to a newer tunnel; retiring stale tunnel", "relay_id", relayID)
+		_ = t.session.Close()
+		return
+	}
+	t.reregister(ctx)
 }
 
 // reregister refreshes the broker registration after the broker forgot the
@@ -465,7 +488,7 @@ func (t *tunnel) reregister(ctx context.Context) {
 		return
 	}
 	oldID := t.currentRelayID()
-	t.setRelayID(registration.RelayID)
+	t.setRegistration(registration.RelayID, registration.LeaseToken)
 	if oldID != registration.RelayID {
 		// Legacy random-ID path: release the old key outright.
 		t.hub.removeTunnel(oldID, t)

--- a/internal/tunnel/server.go
+++ b/internal/tunnel/server.go
@@ -466,8 +466,22 @@ func (t *tunnel) reregister(ctx context.Context) {
 	}
 	oldID := t.currentRelayID()
 	t.setRelayID(registration.RelayID)
-	t.hub.removeTunnel(oldID, t)
-	t.hub.addTunnel(registration.RelayID, t)
+	if oldID != registration.RelayID {
+		// Legacy random-ID path: release the old key outright.
+		t.hub.removeTunnel(oldID, t)
+	}
+	// With a stable identity, a fast reconnect (session B) registers the SAME
+	// relay ID and is already installed in the registry. This stale session A
+	// re-registering must not clobber B: claim the slot only if it is free or
+	// still ours. Losing means B took over — retire A so its dead port stops
+	// being advertised and the punch registry keeps pointing at the live
+	// session.
+	if !t.hub.claimTunnel(registration.RelayID, t) {
+		t.logger.Info("relay identity already served by a newer session; retiring stale tunnel",
+			"relay_id", registration.RelayID)
+		_ = t.session.Close()
+		return
+	}
 	t.logger.Info("relay re-registered after broker forgot it",
 		"old_relay_id", oldID, "new_relay_id", registration.RelayID)
 }

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -19,11 +19,13 @@ func discardLogger() *slog.Logger {
 }
 
 type fakeRegistrar struct {
-	mu            sync.Mutex
-	registerCount int
-	heartbeats    int
-	lastReq       relay.RegisterRequest
-	relayID       string
+	mu                      sync.Mutex
+	registerCount           int
+	heartbeats              int
+	lastHeartbeatRelayID    string
+	lastHeartbeatLeaseToken string
+	lastReq                 relay.RegisterRequest
+	relayID                 string
 	// relayIDs, when non-empty, are consumed one per Register call before
 	// falling back to relayID.
 	relayIDs []string
@@ -49,12 +51,14 @@ func (f *fakeRegistrar) Register(_ context.Context, req relay.RegisterRequest) (
 	if id == "" {
 		id = "relay_test"
 	}
-	return RelayRegistration{RelayID: id, PublicHost: req.PublicHost, PublicPort: req.PublicPort, ExpiresAt: time.Now().Add(time.Minute)}, nil
+	return RelayRegistration{RelayID: id, LeaseToken: fmt.Sprintf("lease_%d", f.registerCount), PublicHost: req.PublicHost, PublicPort: req.PublicPort, ExpiresAt: time.Now().Add(time.Minute)}, nil
 }
 
-func (f *fakeRegistrar) Heartbeat(ctx context.Context, _ string) error {
+func (f *fakeRegistrar) Heartbeat(ctx context.Context, relayID, leaseToken string) error {
 	f.mu.Lock()
 	f.heartbeats++
+	f.lastHeartbeatRelayID = relayID
+	f.lastHeartbeatLeaseToken = leaseToken
 	err := f.failHeartbeatOnce
 	if err == nil {
 		f.mu.Unlock()
@@ -80,6 +84,12 @@ func (f *fakeRegistrar) stats() (registers, heartbeats int, lastReq relay.Regist
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.registerCount, f.heartbeats, f.lastReq
+}
+
+func (f *fakeRegistrar) lastHeartbeat() (relayID, leaseToken string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastHeartbeatRelayID, f.lastHeartbeatLeaseToken
 }
 
 func startEchoServer(t *testing.T) (string, int) {
@@ -251,6 +261,9 @@ func TestHubClientEndToEnd(t *testing.T) {
 	}) {
 		t.Fatal("expected at least one heartbeat while connected")
 	}
+	if relayID, leaseToken := registrar.lastHeartbeat(); relayID != "relay_abc" || leaseToken != "lease_1" {
+		t.Fatalf("heartbeat registration = (%q, %q), want (relay_abc, lease_1)", relayID, leaseToken)
+	}
 
 	// Teardown: cancel the client; the hub should free the allocated port.
 	clientCancel()
@@ -347,6 +360,9 @@ func TestHubReregistersWhenBrokerForgetsRelay(t *testing.T) {
 		return hb > hbBefore
 	}) {
 		t.Fatal("heartbeats stopped after re-registration")
+	}
+	if relayID, leaseToken := registrar.lastHeartbeat(); relayID != "relay_new" || leaseToken != "lease_2" {
+		t.Fatalf("heartbeat after re-registration = (%q, %q), want (relay_new, lease_2)", relayID, leaseToken)
 	}
 	registers, _, _ := registrar.stats()
 	if registers != 2 {


### PR DESCRIPTION
## Why

The broker mints a fresh random `relay_id` on **every** registration, so a relay's ID churns whenever it restarts or the broker forgets its lease (any >3-min outage, an in-memory store loss, a fleet roll). In 7 days of prod telemetry, **50 of 64 relay IDs were orphans** — which is why the dashboard shows retired relays as raw hex (`relay_217d20a8…FND`) and fragments each relay's ranking and history across throwaway IDs. Today's broker deploy churned the Portland box (`zesty-quokka`) exactly this way.

This makes `relay_id` **stable and self-authenticating**: the relay proves possession of a long-lived Ed25519 key, and the broker derives the ID from that key instead of minting randomly. Same key → same ID, forever, with no broker-side state.

## Design — spec `openrung-relay-identity-v1`

- The relay holds an Ed25519 identity key and signs a canonical statement binding the identity-relevant registration fields + a relay-chosen expiry (`internal/relay/identity.go`). The broker verifies possession and derives `relay_` + hex(SHA-256(tag‖pubkey)[:16]) — same shape as today's IDs, so nothing downstream changes.
- **Proven, not asserted.** All identity fields are public in the signed relay list, so an unproven "same key ⇒ same ID" rule would let anyone hijack a relay's history from public data. The signature closes that. The identity grants *nothing* beyond ID continuity: node class is still token-attested per registration, and the foundation endpoint guard is unchanged (a valid proof for a different key confers no authority over an endpoint).
- **Backward compatible.** A registration without the identity fields keeps the legacy random-ID path, so old relays/hubs work against a new broker, and new relays degrade to random IDs against an old broker (which ignores the unknown fields). New Postgres column added via the existing idempotent `ADD COLUMN IF NOT EXISTS` migration — no manual DB step.
- **All transports.** Direct relays sign per registration (endpoint bound). Tunnel relays sign at HELLO time (the hub can't be trusted with the key and assigns the endpoint after signing), the hub forwards the proof verbatim, and the session recycles for a fresh HELLO if the broker reports an expired proof.
- **Fleet.** `cmd/relay` pins the key with `-identity-seed` / `OPENRUNG_IDENTITY_SEED`; the deploy scripts mint one per instance; the desktop app persists it in `identity.json`; an unpinned relay generates one per process (still stable across broker outages within its lifetime).

## Review

Built and adversarially reviewed with a multi-agent workflow (4 lenses → 2 skeptics per finding). The confirmed findings are fixed in the second commit:

- **Security:** the deploy script traced the identity seed (an Ed25519 *private key*) into the persisted `/var/log/openrung-init.log` under `set -x` — fixed by disabling xtrace before minting it.
- **Hub registry:** a stale tunnel session re-registering a now-shared stable ID could clobber the newer live session in the punch registry — fixed with a compare-and-set claim (`claimTunnel`).
- **Ops noise / false log:** dropped the "relay identity moved endpoint" warning (fired on every routine tunnel reconnect, and logged falsely on rolled-back foundation refusals); the eviction it accompanied is kept.
- **Clock skew:** mandatory signing hard-failed relays with >1h clock skew — widened the proof TTL (a replayed proof is low value: endpoint-bound for direct, non-servable for tunnel since the Reality private key never leaves the real relay).
- **Desktop resilience:** a corrupt `identity.json` seed now regenerates instead of bricking the app; the relay binary reads `OPENRUNG_IDENTITY_SEED` directly.
- **Docs:** `docs/api.md` now states precisely what the tunnel proof binds and its residual (a captured tunnel proof can, within its lifetime, point the ID at a *dead* endpoint — a transient denial, not interception — only on observable/plaintext registration paths).

Tests: full suite green including Postgres-gated store tests (parity across both backends, re-registration keeps ID, endpoint-move eviction, foundation-seizure refusal + transaction rollback, invalid/expired proof rejection, hub registry CAS, golden wire vectors, desktop seed migration).

## Deploy notes (not blocking merge)

1. **Roll the relayhub image too.** An old hub silently strips the HELLO identity fields, so tunnel relays (incl. all desktop-volunteer installs on the shared hub) keep churning until it's updated. Roll broker + relay + hub together.
2. **Existing fleet.** The per-instance seed is minted at instance-creation, so already-running containers don't get one until recreated (`docker run` with `OPENRUNG_IDENTITY_SEED=…`) or reprovisioned. They keep working (random IDs) until then.
3. Known minor edge, self-healing: two genuinely-concurrent registrations of the *same* identity at *different* endpoints can hit a transient Postgres error and get retried by the relay (503 → retry). Duplicate-seed deployments are operator error (last writer wins the row), same failure class as duplicate Reality keys today.

No merge — my review + Codex review first, then you merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)