### PR TITLE
Broker: honor aggregated application connection counts

### DIFF
--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -199,9 +199,12 @@ In postgres mode the admin dashboard aggregates in SQL, bounded by the
 selected time window, so dashboard cost and broker memory stay flat as event
 history grows. High-volume `application_connection` events are not stored as
 rows in either store: ingestion folds them into an hourly per-application
-count (`telemetry_app_counts` in postgres mode) that feeds the dashboard's
-top-applications panel, and discards the per-event destination and client
-metadata.
+count (`telemetry_app_counts` in postgres mode), summing the bounded optional
+`measurements.connection_count` used by aggregating clients and defaulting to
+one for legacy or out-of-range integer values. One application can contribute
+at most 100,000 represented flows per batch. The aggregate feeds the
+dashboard's top-applications panel; per-event destination and client metadata
+is discarded.
 
 ## Telemetry dashboard
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,9 +58,9 @@ Content-Type: application/json
       "session_id": "d9943d4f-fd59-4fb8-a170-ed8af949ccee",
       "application_package": "com.android.chrome",
       "application_uid": 10241,
-      "destination_ip": "142.250.191.142",
-      "destination_port": 443,
-      "protocol": "tcp"
+      "measurements": {
+        "connection_count": 237
+      }
     }
   ]
 }
@@ -71,19 +71,31 @@ more than one hour into the future are rejected (retention and dashboards key
 off the server's receipt time, so client clocks cannot extend either), and
 free-form fields are length-capped: attribute/measurement keys at 64
 characters, attribute values and `application_package` at 256. Package
-attribution is collected on Android 10 and newer. This first implementation
-records connection starts and destinations, not per-flow byte counters or flow
-completion times.
+attribution is collected on Android 10 and newer. Aggregating Android clients
+skip DNS, collapse repeated flows per application, and omit destination details.
+Legacy schema-version-1 clients may still send one event per flow and include
+destination fields; the broker accepts those fields but never retains them.
+
+For an `application_connection`, the optional integer
+`measurements.connection_count` says how many flows the event represents.
+Missing values count as `1` for legacy compatibility. Present integer values
+outside `1..100,000` also fall back to `1`, avoiding both a permanently retrying
+bad outbox item and maximum weighting for malformed input; non-integer values
+are rejected with the rest of an invalid JSON batch. Across one HTTP batch, all
+events for the same application can contribute at most `100,000`. The whole
+accepted count is assigned to the server receipt hour; it is a dashboard-grade
+approximation, not an exact per-flow timeline, and at-least-once client retries
+can duplicate counts.
 
 `application_connection` events are never stored as individual records — in
-either telemetry store. At ingestion the broker folds each one into an hourly
-per-application connection count (Postgres: the `telemetry_app_counts` table;
-JSONL mode: an in-memory rollup that restarts empty) and discards the rest of
-the event, so the destination IP and the per-event client metadata never reach
-disk. Only the aggregate feeds the dashboard's top-applications panel, whose
-window edge is consequently hour-granular. They are by far the highest-volume
-event (one per tunnelled flow, with a per-package fan-out on Android), so this
-also keeps dashboard queries bounded by session-grade volume.
+either telemetry store. At ingestion the broker adds the bounded represented
+flow count to an hourly per-application total (Postgres: the
+`telemetry_app_counts` table; JSONL mode: an in-memory rollup that restarts
+empty) and discards the rest of the event, so destination and per-event client
+metadata never reach disk. Only the aggregate feeds the dashboard's
+top-applications panel, whose window edge is consequently hour-granular. These
+were historically by far the highest-volume events, so client aggregation and
+the broker rollup keep dashboard queries bounded by session-grade volume.
 
 Before starting the tunnel, Android also resolves its public IP metadata and
 adds `client_ip`, `country`, `country_code`, `city`, `asn`, `isp`, and

--- a/internal/broker/dashboard_test.go
+++ b/internal/broker/dashboard_test.go
@@ -22,9 +22,14 @@ type dashboardTelemetryStore struct {
 // into the hourly rollup instead of being stored, so parity tests that feed
 // both backends the same batch exercise identical top-apps semantics.
 func (s *dashboardTelemetryStore) WriteTelemetry(_ context.Context, records []TelemetryRecord) error {
+	appCounts := make(telemetryAppConnectionBatchCounter)
 	for _, record := range records {
 		if record.Event.Event == telemetryAppConnectionEvent {
-			s.appRollup.add(telemetryAppRollupHour(record, time.Now().UTC()), record.Event.Application, 1)
+			s.appRollup.add(
+				telemetryAppRollupHour(record, time.Now().UTC()),
+				record.Event.Application,
+				appCounts.take(record.Event),
+			)
 			continue
 		}
 		s.records = append(s.records, record)

--- a/internal/broker/postgres_telemetry.go
+++ b/internal/broker/postgres_telemetry.go
@@ -83,7 +83,8 @@ CREATE INDEX IF NOT EXISTS telemetry_events_session_occurred_idx
 -- application_connection events are never stored as telemetry_events rows —
 -- only this hourly per-application rollup survives ingestion (see
 -- telemetryAppConnectionEvent). It is what the dashboard's top-apps panel
--- reads, and it is tiny: one row per (hour, application) seen.
+-- reads, and it is tiny: one row per (hour, application) seen. connections is
+-- the sum of each event's bounded connection_count (one for legacy events).
 CREATE TABLE IF NOT EXISTS telemetry_app_counts (
 	hour timestamptz NOT NULL,
 	application text NOT NULL,
@@ -215,10 +216,15 @@ func (s *PostgresTelemetrySink) WriteTelemetry(ctx context.Context, records []Te
 		return errors.New("telemetry storage is closed")
 	}
 	evictedBefore := s.pendingAppCounts.evictedEntries
+	appCounts := make(telemetryAppConnectionBatchCounter)
 	for _, record := range records {
 		if record.Event.Event == telemetryAppConnectionEvent {
 			// Rolled up, never inserted as a row — see telemetryAppConnectionEvent.
-			if !s.pendingAppCounts.add(telemetryAppRollupHour(record, now), record.Event.Application, 1) {
+			if !s.pendingAppCounts.add(
+				telemetryAppRollupHour(record, now),
+				record.Event.Application,
+				appCounts.take(record.Event),
+			) {
 				dropped++
 			}
 			continue

--- a/internal/broker/postgres_telemetry_query_test.go
+++ b/internal/broker/postgres_telemetry_query_test.go
@@ -151,8 +151,10 @@ func parityTelemetryRecords(now time.Time) []TelemetryRecord {
 
 		// application_connection events: stored by neither backend — both fold
 		// them into the hourly top-apps rollup keyed by receipt hour and drop
-		// the record. session-apponly/client-apponly exist only here, so they
-		// must appear in no total or panel besides top_applications. With
+		// the record. The first is a legacy one-flow event; the second represents
+		// 41 client-aggregated flows. session-apponly/client-apponly exist only
+		// here, so they must appear in no total or panel besides
+		// top_applications. With
 		// now=12:30, the two events received 3–4 minutes ago bucket to 12:00
 		// and the one received 70 minutes ago buckets to 11:00 — inside the 1h
 		// window's truncated start hour even though it was received before the
@@ -160,7 +162,7 @@ func parityTelemetryRecords(now time.Time) []TelemetryRecord {
 		record(3, 3, "application_connection", "client-apponly", "session-apponly", "relay-1", "203.0.113.10",
 			map[string]string{"_app": "com.instagram.android", "country": "IR", "client_ip": "203.0.113.77"}, nil),
 		record(4, 4, "application_connection", "client-apponly", "session-apponly", "relay-1", "203.0.113.10",
-			map[string]string{"_app": "com.instagram.android"}, nil),
+			map[string]string{"_app": "com.instagram.android"}, map[string]int64{telemetryAppConnectionCountMeasurement: 41}),
 		record(70, 70, "application_connection", "client-apponly", "session-apponly", "", "192.0.2.50",
 			map[string]string{"_app": "org.telegram.messenger"}, nil),
 	}

--- a/internal/broker/postgres_telemetry_test.go
+++ b/internal/broker/postgres_telemetry_test.go
@@ -475,6 +475,25 @@ func telemetryPartitionExists(t *testing.T, sink *PostgresTelemetrySink, day str
 	return exists != nil
 }
 
+func TestPostgresTelemetrySinkBuffersAggregatedApplicationCounts(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
+	sink := &PostgresTelemetrySink{now: func() time.Time { return now }}
+	if err := sink.WriteTelemetry(context.Background(), []TelemetryRecord{
+		appConnectionRecordAt(now.Add(-time.Minute), "legacy-app", "com.example.app"),
+		appConnectionRecordWithCountAt(now.Add(-2*time.Minute), "aggregated-app", "com.example.app", 41),
+	}); err != nil {
+		t.Fatalf("buffer application counts: %v", err)
+	}
+
+	hour := now.Truncate(time.Hour)
+	if got := sink.pendingAppCounts.hours[hour]["com.example.app"]; got != 42 {
+		t.Fatalf("buffered legacy + aggregated count = %d, want 42", got)
+	}
+	if len(sink.pending) != 0 {
+		t.Fatalf("application events entered the row buffer: %+v", sink.pending)
+	}
+}
+
 func TestPostgresTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 	now := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
 	sink := newTestPostgresTelemetrySink(t, now)
@@ -483,7 +502,7 @@ func TestPostgresTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 	records := []TelemetryRecord{
 		telemetryRecordAt(now.Add(-time.Minute), "kept-1"),
 		appConnectionRecordAt(now.Add(-2*time.Minute), "app-1", "com.instagram.android"),
-		appConnectionRecordAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android"),
+		appConnectionRecordWithCountAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android", 41),
 		appConnectionRecordAt(now.Add(-70*time.Minute), "app-3", "org.telegram.messenger"),
 	}
 	if err := sink.WriteTelemetry(ctx, records); err != nil {
@@ -500,11 +519,21 @@ func TestPostgresTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 	if eventRows != 1 {
 		t.Fatalf("application_connection events must not be inserted as rows, got %d rows", eventRows)
 	}
+	var firstCount int64
+	if err := sink.pool.QueryRow(
+		ctx,
+		`SELECT connections FROM telemetry_app_counts WHERE application = 'com.instagram.android'`,
+	).Scan(&firstCount); err != nil {
+		t.Fatalf("read first application count: %v", err)
+	}
+	if firstCount != 42 {
+		t.Fatalf("legacy + aggregated application count = %d, want 42", firstCount)
+	}
 
 	// A second batch in the same hour must increment via the upsert's conflict
 	// arm, not insert a second (hour, application) row.
 	if err := sink.WriteTelemetry(ctx, []TelemetryRecord{
-		appConnectionRecordAt(now.Add(-time.Minute), "app-4", "com.instagram.android"),
+		appConnectionRecordWithCountAt(now.Add(-time.Minute), "app-4", "com.instagram.android", 8),
 	}); err != nil {
 		t.Fatalf("write second batch: %v", err)
 	}
@@ -519,7 +548,7 @@ func TestPostgresTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 	// The telegram event was received 70 minutes ago — before the window
 	// opened, but inside the truncated start hour, so the hour-granular window
 	// edge keeps it (matching telemetryAppRollup.countsIn).
-	if len(overview.TopApps) != 2 || overview.TopApps[0].Name != "com.instagram.android" || overview.TopApps[0].Count != 3 || overview.TopApps[1].Count != 1 {
+	if len(overview.TopApps) != 2 || overview.TopApps[0].Name != "com.instagram.android" || overview.TopApps[0].Count != 50 || overview.TopApps[1].Count != 1 {
 		t.Fatalf("unexpected top apps: %+v", overview.TopApps)
 	}
 	// The app-only events created no session rows.

--- a/internal/broker/telemetry.go
+++ b/internal/broker/telemetry.go
@@ -149,14 +149,22 @@ type storedTelemetryRecord struct {
 	bytes  int64
 }
 
-// application_connection events are one row per tunnelled flow (with a
-// per-package fan-out on Android) — at production volume they were ~95% of all
-// telemetry rows while feeding exactly one dashboard panel, and their payload
-// pairs the client's IP with every destination it visited. No sink stores them
-// as records: every sink folds them into an hourly per-application count and
-// discards the rest of the event, so the destination/client-IP browsing log
-// never reaches disk. The dashboard's top-apps panel reads these rollups.
-const telemetryAppConnectionEvent = "application_connection"
+// Older clients send one application_connection event per tunnelled flow (with
+// a per-package fan-out on Android). Aggregating clients instead attach the
+// number of represented flows as connection_count. No sink stores these events
+// as records: every sink folds their bounded count into an hourly
+// per-application total and discards the payload, so destination/client-IP
+// browsing metadata never reaches disk. The dashboard's top-apps panel reads
+// these rollups.
+const (
+	telemetryAppConnectionEvent            = "application_connection"
+	telemetryAppConnectionCountMeasurement = "connection_count"
+	// A 15-minute client window would need to average more than 110 new flows
+	// per second to reach this ceiling. The same limit is shared by all events
+	// for one application in a write batch, preventing the 200-event HTTP batch
+	// from multiplying one anonymous application's contribution.
+	maxTelemetryAppConnectionCount int64 = 100_000
+)
 
 // maxTelemetryAppRollupEntries bounds the distinct (hour, application) pairs a
 // rollup holds in memory so a flood of fabricated package names cannot grow
@@ -173,6 +181,36 @@ func telemetryAppRollupHour(record TelemetryRecord, now time.Time) time.Time {
 		return at.UTC().Truncate(time.Hour)
 	}
 	return now.UTC().Truncate(time.Hour)
+}
+
+// telemetryAppConnectionCount returns how many flows an application event
+// represents. Missing values are legacy per-flow events. Invalid present
+// values also fall back to one so a bad telemetry item cannot permanently
+// block a client's retrying outbox or receive the maximum allowed weight.
+func telemetryAppConnectionCount(event TelemetryEvent) int64 {
+	count, ok := event.Measurements[telemetryAppConnectionCountMeasurement]
+	if !ok || count <= 0 || count > maxTelemetryAppConnectionCount {
+		return 1
+	}
+	return count
+}
+
+// telemetryAppConnectionBatchCounter enforces a per-application budget across
+// one sink write, which corresponds to one HTTP batch in production. It keeps
+// repeated events for the same package from multiplying the per-event bound;
+// different applications remain independent so one chatty app cannot consume
+// another application's legitimate count.
+type telemetryAppConnectionBatchCounter map[string]int64
+
+func (c telemetryAppConnectionBatchCounter) take(event TelemetryEvent) int64 {
+	used := c[event.Application]
+	remaining := maxTelemetryAppConnectionCount - used
+	if remaining <= 0 {
+		return 0
+	}
+	count := min(telemetryAppConnectionCount(event), remaining)
+	c[event.Application] = used + count
+	return count
 }
 
 // telemetryAppRollup accumulates hourly application-connection counts. None of
@@ -493,12 +531,17 @@ func (s *JSONLTelemetrySink) WriteTelemetry(_ context.Context, records []Telemet
 	s.appRollup.prune(cutoff)
 	droppedAppCounts := 0
 	evictedAppCountsBefore := s.appRollup.evictedEntries
+	appCounts := make(telemetryAppConnectionBatchCounter)
 	for _, record := range records {
 		if record.Event.Event == telemetryAppConnectionEvent {
 			// Rolled up, never persisted — see telemetryAppConnectionEvent. The
 			// in-memory rollup is this sink's only copy, so top-apps counts
 			// restart empty; the Postgres store persists its rollup instead.
-			if !s.appRollup.add(telemetryAppRollupHour(record, now), record.Event.Application, 1) {
+			if !s.appRollup.add(
+				telemetryAppRollupHour(record, now),
+				record.Event.Application,
+				appCounts.take(record.Event),
+			) {
 				droppedAppCounts++
 			}
 			continue

--- a/internal/broker/telemetry_test.go
+++ b/internal/broker/telemetry_test.go
@@ -130,6 +130,36 @@ func TestTelemetryHandlerRejectsMissingIdentity(t *testing.T) {
 	}
 }
 
+func TestTelemetryHandlerRejectsMalformedConnectionCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "string", value: `"42"`},
+		{name: "fractional", value: `1.5`},
+		{name: "integer overflow", value: `9223372036854775808`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sink := &memoryTelemetrySink{}
+			payload := []byte(fmt.Sprintf(
+				`{"events":[{"schema_version":1,"event_id":"event-1","event":"application_connection","occurred_at":"2026-06-20T12:00:00Z","client_id":"client-1","session_id":"session-1","application_package":"com.example.app","measurements":{"connection_count":%s}}]}`,
+				test.value,
+			))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/telemetry/events", bytes.NewReader(payload))
+			recorder := httptest.NewRecorder()
+			telemetryHandler(sink, nil, newClientIPResolver(nil)).ServeHTTP(recorder, req)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", recorder.Code, recorder.Body.String())
+			}
+			if len(sink.records) != 0 {
+				t.Fatalf("malformed count reached the sink: %+v", sink.records)
+			}
+		})
+	}
+}
+
 func TestSpeedTestHandlerStreamsRequestedBytes(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/speed-test?bytes=10000", nil)
 	recorder := httptest.NewRecorder()
@@ -691,6 +721,60 @@ func appConnectionRecordAt(receivedAt time.Time, eventID, application string) Te
 	return record
 }
 
+func appConnectionRecordWithCountAt(receivedAt time.Time, eventID, application string, count int64) TelemetryRecord {
+	record := appConnectionRecordAt(receivedAt, eventID, application)
+	record.Event.Measurements = map[string]int64{telemetryAppConnectionCountMeasurement: count}
+	return record
+}
+
+func TestTelemetryAppConnectionCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		measurements map[string]int64
+		want         int64
+	}{
+		{name: "legacy event", want: 1},
+		{name: "unrelated measurement", measurements: map[string]int64{"relay_tcp_ms": 42}, want: 1},
+		{name: "aggregated event", measurements: map[string]int64{telemetryAppConnectionCountMeasurement: 42}, want: 42},
+		{name: "zero falls back", measurements: map[string]int64{telemetryAppConnectionCountMeasurement: 0}, want: 1},
+		{name: "negative falls back", measurements: map[string]int64{telemetryAppConnectionCountMeasurement: -7}, want: 1},
+		{name: "maximum accepted", measurements: map[string]int64{telemetryAppConnectionCountMeasurement: maxTelemetryAppConnectionCount}, want: maxTelemetryAppConnectionCount},
+		{name: "oversized falls back", measurements: map[string]int64{telemetryAppConnectionCountMeasurement: maxTelemetryAppConnectionCount + 1}, want: 1},
+		{name: "int64 maximum falls back", measurements: map[string]int64{telemetryAppConnectionCountMeasurement: 1<<63 - 1}, want: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := TelemetryEvent{Measurements: test.measurements}
+			if got := telemetryAppConnectionCount(event); got != test.want {
+				t.Fatalf("telemetryAppConnectionCount() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTelemetryAppConnectionBatchCounterCapsEachApplication(t *testing.T) {
+	counts := make(telemetryAppConnectionBatchCounter)
+	event := func(application string, count int64) TelemetryEvent {
+		return TelemetryEvent{
+			Application:  application,
+			Measurements: map[string]int64{telemetryAppConnectionCountMeasurement: count},
+		}
+	}
+
+	if got := counts.take(event("app-a", 60_000)); got != 60_000 {
+		t.Fatalf("first app-a count = %d, want 60000", got)
+	}
+	if got := counts.take(event("app-a", 60_000)); got != 40_000 {
+		t.Fatalf("second app-a count = %d, want remaining 40000", got)
+	}
+	if got := counts.take(event("app-a", 1)); got != 0 {
+		t.Fatalf("app-a exceeded its batch budget by %d", got)
+	}
+	if got := counts.take(event("app-b", 60_000)); got != 60_000 {
+		t.Fatalf("app-b did not receive an independent budget: %d", got)
+	}
+}
+
 func TestTelemetryAppRollupBucketsPrunesAndCaps(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
 	var rollup telemetryAppRollup
@@ -797,7 +881,7 @@ func TestJSONLTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 	records := []TelemetryRecord{
 		telemetryRecordAt(now.Add(-time.Minute), "kept-1"),
 		appConnectionRecordAt(now.Add(-2*time.Minute), "app-1", "com.instagram.android"),
-		appConnectionRecordAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android"),
+		appConnectionRecordWithCountAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android", 41),
 		appConnectionRecordAt(now.Add(-70*time.Minute), "app-3", "org.telegram.messenger"),
 	}
 	if err := sink.WriteTelemetry(context.Background(), records); err != nil {
@@ -808,7 +892,7 @@ func TestJSONLTelemetrySinkRollsUpApplicationConnections(t *testing.T) {
 		t.Fatalf("application_connection records must not be retained: %+v", got)
 	}
 	counts := sink.AppConnectionCounts(now, time.Hour)
-	if counts["com.instagram.android"] != 2 || counts["org.telegram.messenger"] != 1 {
+	if counts["com.instagram.android"] != 42 || counts["org.telegram.messenger"] != 1 {
 		t.Fatalf("unexpected rollup counts: %+v", counts)
 	}
 	if err := sink.Close(); err != nil {
@@ -876,7 +960,7 @@ func TestTelemetryReaderQuerierServesTopAppsFromRollup(t *testing.T) {
 	err := store.WriteTelemetry(context.Background(), []TelemetryRecord{
 		telemetryRecordAt(now.Add(-time.Minute), "session-event"),
 		appConnectionRecordAt(now.Add(-2*time.Minute), "app-1", "com.instagram.android"),
-		appConnectionRecordAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android"),
+		appConnectionRecordWithCountAt(now.Add(-3*time.Minute), "app-2", "com.instagram.android", 41),
 		appConnectionRecordAt(now.Add(-4*time.Minute), "app-3", "org.telegram.messenger"),
 	})
 	if err != nil {
@@ -886,7 +970,7 @@ func TestTelemetryReaderQuerierServesTopAppsFromRollup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(overview.TopApps) != 2 || overview.TopApps[0].Name != "com.instagram.android" || overview.TopApps[0].Count != 2 {
+	if len(overview.TopApps) != 2 || overview.TopApps[0].Name != "com.instagram.android" || overview.TopApps[0].Count != 42 {
 		t.Fatalf("unexpected top apps: %+v", overview.TopApps)
 	}
 	// The app-connection events created no sessions or clients: only the


### PR DESCRIPTION
## Why

Mobile PR openrung/openrung-mobile-app#54 collapses application_connection events into windows and reports the represented flow total as measurements.connection_count. The current broker assigns every rollup event a value of 1, so deploying that client first would turn Top applications into active-window samples.

## What changed

- Sum bounded connection_count values in both JSONL and PostgreSQL hourly application rollups.
- Preserve legacy clients by defaulting missing counts to 1.
- Fall back to 1 for out-of-range typed counts, and cap one application at 100,000 represented flows per batch.
- Continue discarding raw application-connection payloads and destination metadata.
- Document receipt-hour bucketing, approximate semantics, and possible duplicates from at-least-once retries.

## Rollout

Merge and deploy this PR before openrung/openrung-mobile-app#54. The client-side final partial-window flush and session-handoff findings from that mobile review remain separate follow-ups before enabling aggregation in a release.

## Testing

- go vet ./...
- go test -race ./...
- PostgreSQL 16 integration and in-memory/PostgreSQL parity tests for legacy plus aggregated counts