### PR TITLE
Broker: prioritize relay reliability in ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flowchart LR
 Relay transport uses [Xray-core](https://github.com/XTLS/Xray-core)'s
 VLESS + REALITY + Vision, designed to be hard to distinguish from ordinary TLS
 traffic. The broker ranks relay candidates using recent shared metrics —
-active sessions, connection success, observed latency, and speed tests — so
+connection success, active sessions, observed latency, and speed tests — so
 clients are steered toward relays that actually work.
 
 ## Highlights

--- a/desktop/vpnservice/ranker.go
+++ b/desktop/vpnservice/ranker.go
@@ -15,18 +15,18 @@ import (
 // Client-side latency ranking for the relay connect ladder. Port of the mobile
 // RelayRanker (Android net/RelayRanker.kt, iOS Shared/RelayRanker.swift).
 //
-// The broker already orders relays by a composite score (load headroom, success
-// rate, latency, speed) from its own vantage; the one signal it cannot know is
+// The broker already orders relays by a composite score (success rate, load
+// headroom, latency, speed) from its own vantage; the one signal it cannot know is
 // THIS client's network path. The ranker probes TCP connect latency to the head
 // of the candidate list in parallel and reorders by latency BUCKET, so broker
 // order — and with it the broker's load balancing — still decides among relays
 // whose measured latency falls in the same bucket.
 //
-// Bucketing is what makes the reorder safe to ship: the broker's largest scoring
-// term is load headroom, and it has no admission control, so position in the
-// list is the only thing keeping clients off a saturated relay. Sorting on raw
-// latency would hand the ladder to the nearest relay for a 2ms win and herd
-// every client in a region onto it. Note the buckets are absolute (probeMs /
+// Bucketing is what makes the reorder safe to ship: the broker weights recent
+// reliability most heavily but still uses load headroom, and it has no admission
+// control, so position in the list helps keep clients off a saturated relay.
+// Sorting on raw latency would hand the ladder to the nearest relay for a 2ms win
+// and herd every client in a region onto it. Note the buckets are absolute (probeMs /
 // RelayRankBucketMS, truncating), not relative clusters: 29ms and 31ms fall in
 // different buckets while 31ms and 59ms share one. The compromise is coarse, not
 // exact — it bounds how often the client overrides the broker, rather than

--- a/docs/api.md
+++ b/docs/api.md
@@ -495,7 +495,7 @@ GET /api/v1/relays?limit=5
 ```
 
 The order of `relays` is the broker's candidate ranking. In global ranking mode,
-the broker uses recent active sessions, connection successes/failures, observed
+the broker uses recent connection successes/failures, active sessions, observed
 client latency, and speed-test telemetry. The latency it scores is aggregated
 across all clients, so it cannot describe any one client's path. IPv6 is only a
 final tie-breaker after score and heartbeat recency. `limit` truncates *after*

--- a/internal/broker/ranking.go
+++ b/internal/broker/ranking.go
@@ -21,6 +21,12 @@ const (
 	rankingHeadroomWeight    = 0.20
 	rankingLatencyWeight     = 0.20
 	rankingSpeedWeight       = 0.10
+
+	// A full relay has already forfeited the entire 0.20 headroom contribution.
+	// Continue applying back-pressure above capacity, but cap it below the 0.05
+	// margin by which a 75%-reliable full relay beats a 25%-reliable idle one
+	// when their latency and speed signals are equal.
+	rankingMaxOverCapacityPenalty = 0.04
 )
 
 type metricValue struct {
@@ -131,14 +137,22 @@ func relayScore(desc relay.Descriptor, snapshot RelayMetricsSnapshot) float64 {
 	latencyScore := observedLatencyScore(snapshot)
 	speedScore := observedSpeedScore(desc, snapshot)
 
-	// Headroom already declines continuously to zero at capacity. Do not apply a
-	// second threshold penalty here: that cliff used to let idle, failing relays
-	// outrank full relays with substantially better observed reliability.
+	// Headroom declines continuously to zero at capacity. Beyond capacity, keep
+	// a small gradient rather than the old threshold multiplier: the bounded
+	// penalty supplies back-pressure without letting load dominate reliability.
 	score := rankingReliabilityWeight*successRate +
 		rankingHeadroomWeight*headroom +
 		rankingLatencyWeight*latencyScore +
 		rankingSpeedWeight*speedScore
-	return score
+	return clamp01(score - overCapacityPenalty(desc, snapshot))
+}
+
+func overCapacityPenalty(desc relay.Descriptor, snapshot RelayMetricsSnapshot) float64 {
+	if desc.MaxSessions <= 0 || snapshot.ActiveSessions <= desc.MaxSessions {
+		return 0
+	}
+	overCapacityRatio := float64(snapshot.ActiveSessions-desc.MaxSessions) / float64(desc.MaxSessions)
+	return rankingMaxOverCapacityPenalty * clamp01(overCapacityRatio)
 }
 
 func observedLatencyScore(snapshot RelayMetricsSnapshot) float64 {

--- a/internal/broker/ranking.go
+++ b/internal/broker/ranking.go
@@ -10,7 +10,18 @@ import (
 	"openrung/internal/relay"
 )
 
-const rankingWindow = 30 * time.Minute
+const (
+	rankingWindow = 30 * time.Minute
+
+	// Reliability is the strongest ranking signal: spare capacity is useful only
+	// when clients can actually reach the relay. Keeping headroom below the
+	// reliability weight also prevents an idle, repeatedly failing relay from
+	// displacing a busy relay with a strong recent success record.
+	rankingReliabilityWeight = 0.50
+	rankingHeadroomWeight    = 0.20
+	rankingLatencyWeight     = 0.20
+	rankingSpeedWeight       = 0.10
+)
 
 type metricValue struct {
 	total float64
@@ -120,10 +131,13 @@ func relayScore(desc relay.Descriptor, snapshot RelayMetricsSnapshot) float64 {
 	latencyScore := observedLatencyScore(snapshot)
 	speedScore := observedSpeedScore(desc, snapshot)
 
-	score := 0.45*headroom + 0.25*successRate + 0.20*latencyScore + 0.10*speedScore
-	if desc.MaxSessions > 0 && snapshot.ActiveSessions >= desc.MaxSessions {
-		score *= 0.2
-	}
+	// Headroom already declines continuously to zero at capacity. Do not apply a
+	// second threshold penalty here: that cliff used to let idle, failing relays
+	// outrank full relays with substantially better observed reliability.
+	score := rankingReliabilityWeight*successRate +
+		rankingHeadroomWeight*headroom +
+		rankingLatencyWeight*latencyScore +
+		rankingSpeedWeight*speedScore
 	return score
 }
 

--- a/internal/broker/ranking_test.go
+++ b/internal/broker/ranking_test.go
@@ -1,0 +1,51 @@
+package broker
+
+import (
+	"testing"
+
+	"openrung/internal/relay"
+)
+
+func TestRelayScoreReliabilityDominatesHeadroom(t *testing.T) {
+	desc := relay.Descriptor{MaxSessions: 8, MaxMbps: 20}
+
+	// Force reliability and capacity into direct conflict: the reliable relay is
+	// full while the failing relay is idle. Reliability must win or a small
+	// default page excludes the relay that clients can actually use.
+	reliable := RelayMetricsSnapshot{
+		ActiveSessions: 8,
+		Successes:      8,
+		Failures:       2,
+	}
+	failing := RelayMetricsSnapshot{Successes: 2, Failures: 8}
+
+	reliableScore := relayScore(desc, reliable)
+	failingScore := relayScore(desc, failing)
+	if reliableScore <= failingScore {
+		t.Fatalf("reliable full relay score %f must exceed idle failing relay score %f", reliableScore, failingScore)
+	}
+}
+
+func TestRelayScoreHasNoOverCapacityCliff(t *testing.T) {
+	desc := relay.Descriptor{MaxSessions: 8, MaxMbps: 20}
+	metrics := RelayMetricsSnapshot{Successes: 8, Failures: 2}
+	justBelow := metrics
+	justBelow.ActiveSessions = 7
+	atCapacity := metrics
+	atCapacity.ActiveSessions = 8
+	slightlyOver := metrics
+	slightlyOver.ActiveSessions = 9
+
+	justBelowScore := relayScore(desc, justBelow)
+	atCapacityScore := relayScore(desc, atCapacity)
+	slightlyOverScore := relayScore(desc, slightlyOver)
+	if atCapacityScore >= justBelowScore {
+		t.Fatalf("capacity headroom did not lower score: below %f, at capacity %f", justBelowScore, atCapacityScore)
+	}
+	if atCapacityScore <= justBelowScore*0.90 {
+		t.Fatalf("reaching capacity caused a score cliff: score fell from %f to %f", justBelowScore, atCapacityScore)
+	}
+	if slightlyOverScore != atCapacityScore {
+		t.Fatalf("one extra session added a second capacity penalty: score changed from %f to %f", atCapacityScore, slightlyOverScore)
+	}
+}

--- a/internal/broker/ranking_test.go
+++ b/internal/broker/ranking_test.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"math"
 	"testing"
 
 	"openrung/internal/relay"
@@ -10,10 +11,11 @@ func TestRelayScoreReliabilityDominatesHeadroom(t *testing.T) {
 	desc := relay.Descriptor{MaxSessions: 8, MaxMbps: 20}
 
 	// Force reliability and capacity into direct conflict: the reliable relay is
-	// full while the failing relay is idle. Reliability must win or a small
-	// default page excludes the relay that clients can actually use.
+	// at twice its advertised capacity (the maximum overload penalty) while the
+	// failing relay is idle. Reliability must still win or a small default page
+	// excludes the relay that clients can actually use.
 	reliable := RelayMetricsSnapshot{
-		ActiveSessions: 8,
+		ActiveSessions: 16,
 		Successes:      8,
 		Failures:       2,
 	}
@@ -22,30 +24,50 @@ func TestRelayScoreReliabilityDominatesHeadroom(t *testing.T) {
 	reliableScore := relayScore(desc, reliable)
 	failingScore := relayScore(desc, failing)
 	if reliableScore <= failingScore {
-		t.Fatalf("reliable full relay score %f must exceed idle failing relay score %f", reliableScore, failingScore)
+		t.Fatalf("reliable overloaded relay score %f must exceed idle failing relay score %f", reliableScore, failingScore)
 	}
 }
 
-func TestRelayScoreHasNoOverCapacityCliff(t *testing.T) {
+func TestRelayScoreOverCapacityPenaltyIsContinuousAndBounded(t *testing.T) {
 	desc := relay.Descriptor{MaxSessions: 8, MaxMbps: 20}
-	metrics := RelayMetricsSnapshot{Successes: 8, Failures: 2}
-	justBelow := metrics
-	justBelow.ActiveSessions = 7
-	atCapacity := metrics
-	atCapacity.ActiveSessions = 8
-	slightlyOver := metrics
-	slightlyOver.ActiveSessions = 9
+	for _, tc := range []struct {
+		active int
+		want   float64
+	}{
+		{active: 7, want: 0.550},
+		{active: 8, want: 0.525},
+		{active: 9, want: 0.520},
+		{active: 12, want: 0.505},
+		{active: 16, want: 0.485},
+		{active: 24, want: 0.485},
+	} {
+		snapshot := RelayMetricsSnapshot{ActiveSessions: tc.active, Successes: 8, Failures: 2}
+		if got := relayScore(desc, snapshot); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("active sessions %d: score = %.9f, want %.9f", tc.active, got, tc.want)
+		}
+	}
+}
 
-	justBelowScore := relayScore(desc, justBelow)
-	atCapacityScore := relayScore(desc, atCapacity)
-	slightlyOverScore := relayScore(desc, slightlyOver)
-	if atCapacityScore >= justBelowScore {
-		t.Fatalf("capacity headroom did not lower score: below %f, at capacity %f", justBelowScore, atCapacityScore)
+func TestRelayScoreOverCapacityPenaltyNeverMakesScoreNegative(t *testing.T) {
+	desc := relay.Descriptor{MaxSessions: 8, MaxMbps: 20}
+	snapshot := RelayMetricsSnapshot{
+		ActiveSessions:    16,
+		Failures:          1000,
+		TCPMS:             metricValue{total: 2000, count: 1},
+		SpeedTests:        1,
+		DownloadMbpsTotal: 0,
 	}
-	if atCapacityScore <= justBelowScore*0.90 {
-		t.Fatalf("reaching capacity caused a score cliff: score fell from %f to %f", justBelowScore, atCapacityScore)
+	if got := relayScore(desc, snapshot); got != 0 {
+		t.Fatalf("score = %f, want zero floor", got)
 	}
-	if slightlyOverScore != atCapacityScore {
-		t.Fatalf("one extra session added a second capacity penalty: score changed from %f to %f", atCapacityScore, slightlyOverScore)
+}
+
+func TestRelayScoreUnlimitedCapacityHasNoOverloadPenalty(t *testing.T) {
+	desc := relay.Descriptor{MaxMbps: 20}
+	metrics := RelayMetricsSnapshot{Successes: 8, Failures: 2}
+	idleScore := relayScore(desc, metrics)
+	metrics.ActiveSessions = 1000
+	if busyScore := relayScore(desc, metrics); busyScore != idleScore {
+		t.Fatalf("unlimited relay score changed with active sessions: idle %f, busy %f", idleScore, busyScore)
 	}
 }


### PR DESCRIPTION
## Summary

- raise recent relay reliability from 25% to 50% of the broker score
- reduce load headroom from 45% to 20%, keeping latency at 20% and speed at 10%
- replace the `score *= 0.2` capacity cliff with bounded, continuous back-pressure
- subtract up to 0.04 points linearly between 1× and 2× advertised capacity, capped beyond 2×
- add regression coverage for reliable-overloaded vs idle-failing relays, the full score curve, the zero floor, and unlimited capacity
- align ranking documentation with the new signal priority

## Why

The previous calibration could rank an idle relay with sustained failures above a full relay with strong observed reliability. Removing the cliff outright fixed that failure mode but left no load gradient above capacity. The bounded additive penalty preserves reliability dominance while continuing to spread load before quality telemetry degrades.

With neutral latency and speed, the regression fixture scores a 75%-reliable relay at 2× capacity at 0.485 versus 0.475 for a 25%-reliable idle relay.

## Testing

- `go test ./...`
- `go test -race ./internal/broker`