### PR TITLE
fix: let direct Xray bind relay port 443

### DIFF
--- a/cmd/relay/main_test.go
+++ b/cmd/relay/main_test.go
@@ -145,6 +145,9 @@ func TestRelayDeploymentCoLocatesHardenedWSSSidecar(t *testing.T) {
 		"COPY --from=build /out/wss-sidecar /usr/local/bin/wss-sidecar",
 		"chown openrung:openrung /var/lib/openrung",
 		"chmod 0700 /var/lib/openrung",
+		"setcap 'cap_net_bind_service=+ep' /usr/local/bin/relay",
+		"setcap 'cap_net_bind_service=+ep' /usr/local/bin/xray",
+		"getcap /usr/local/bin/xray | grep -q 'cap_net_bind_service=ep'",
 	} {
 		if !strings.Contains(dockerfile, required) {
 			t.Errorf("relay Dockerfile does not bundle sidecar: missing %q", required)

--- a/deploy/relay/Dockerfile
+++ b/deploy/relay/Dockerfile
@@ -93,13 +93,18 @@ COPY --from=build /out/wss-sidecar /usr/local/bin/wss-sidecar
 COPY deploy/relay/entrypoint.sh /usr/local/bin/entrypoint.sh
 # Third-party attribution + GPL/MPL source offers travel with the distributed image.
 COPY THIRD_PARTY_NOTICES.md /usr/local/share/openrung/THIRD_PARTY_NOTICES.md
-# Let the non-root relay process bind the privileged public port (443). Pairs with
+# Let the non-root relay process, or its Xray child when the connection observer
+# is disabled, bind the privileged public port (443). Both executables need the
+# file capability because Linux clears relay's effective capability when it
+# execs the otherwise-unprivileged Xray binary. This pairs with
 # `cap_add: NET_BIND_SERVICE` at runtime. NOTE: file capabilities are ignored
 # under no-new-privileges, so do not enable that flag for this image (or switch
 # to a public port >= 1024 and run with zero capabilities instead).
 RUN apk add --no-cache --virtual .setcap libcap \
     && setcap 'cap_net_bind_service=+ep' /usr/local/bin/relay \
+    && setcap 'cap_net_bind_service=+ep' /usr/local/bin/xray \
     && getcap /usr/local/bin/relay | grep -q 'cap_net_bind_service=ep' \
+    && getcap /usr/local/bin/xray | grep -q 'cap_net_bind_service=ep' \
     && apk del .setcap \
     && chmod +x /usr/local/bin/entrypoint.sh
 USER openrung


### PR DESCRIPTION
## Summary

- grant Xray the same NET_BIND_SERVICE file capability as the relay wrapper
- preserve the non-root, read-only, capability-bounded runtime posture
- add a deployment regression assertion for the Xray capability

## Production finding

During the witty-salmon WSS canary, disabling the connection observer correctly moved public port 443 to Xray, but Xray exited with permission denied because only the wrapper binary carried the file capability. The candidate failed closed and the previous relay container was restored before this PR.

## Verification

- GOCACHE=/tmp/openrung-go-cache go test -race ./cmd/relay ./internal/relayruntime
- GOCACHE=/tmp/openrung-go-cache go test ./...
- built the relay image locally
- ran Xray as image user openrung with cap-drop ALL plus NET_BIND_SERVICE and verified a listening socket on port 443