### PR TITLE
fix(ci): use shasum on macOS in volunteer desktop release

### DIFF
--- a/.github/workflows/volunteer-desktop-release.yml
+++ b/.github/workflows/volunteer-desktop-release.yml
@@ -97,7 +97,12 @@ jobs:
           curl -fsSL -o xray.zip "$BASE/${{ matrix.asset }}"
           curl -fsSL -o xray.zip.dgst "$BASE/${{ matrix.asset }}.dgst"
           expected="$(awk '/^SHA2-256=/ {print $2}' xray.zip.dgst)"
-          actual="$(sha256sum xray.zip | awk '{print $1}')"
+          # macOS runners have shasum, not sha256sum; Linux runners have both.
+          if command -v sha256sum >/dev/null 2>&1; then
+            actual="$(sha256sum xray.zip | awk '{print $1}')"
+          else
+            actual="$(shasum -a 256 xray.zip | awk '{print $1}')"
+          fi
           echo "xray v$V ${{ matrix.asset }} expected=$expected actual=$actual"
           test -n "$expected"
           test "$expected" = "$actual"


### PR DESCRIPTION
## Problem

`volunteer-desktop-release.yml` has never produced a macOS build. The "Fetch and verify xray (unix)" step runs on both Linux and macOS, but macOS ships `shasum`, not `sha256sum`. The only run before this ([29149133660](https://github.com/openrung/openrung/actions/runs/29149133660), 2026-07-11) failed on macos-14 with:

```
sha256sum: command not found
xray v26.3.27 Xray-macos-arm64-v8a.zip expected=2e93a67e...09eaf actual=
```

`actual` came back empty, so `test "$expected" = "$actual"` failed. Linux and Windows succeeded; `release` was skipped.

This would have blocked any release outright — the `release` job `needs: build`, so a `volunteer-v*` tag push would have shipped nothing rather than shipping a partial set.

## Fix

Prefer `sha256sum` when present, fall back to `shasum -a 256`. The verification itself is unchanged — same `.dgst` hash, same strict comparison.

## Verification

Dispatched on this branch: **[run 29898645422](https://github.com/openrung/openrung/actions/runs/29898645422) — all green.**

| job | result | artifact |
|---|---|---|
| version | success | — |
| macos-14 / darwin-arm64 | success | `OpenRungVolunteer-darwin-arm64` (16.7 MB) |
| ubuntu-22.04 / linux-amd64 | success | `OpenRungVolunteer-linux-amd64` (18.7 MB) |
| windows-latest / windows-amd64 | success | `OpenRungVolunteer-windows-amd64` (19.0 MB) |
| release | skipped | expected — gated on `refs/tags/volunteer-v*`, dispatch is artifact-only |

This also exercises the rest of the darwin path for the first time: `wails build`, bundling xray into `Contents/Resources`, and the ad-hoc `codesign --deep --verify` in `desktop-volunteer/scripts/package-macos.sh`.

## Follow-up (not in this PR)

- `desktop-volunteer/VERSION` is `0.1.0` and no `volunteer-v*` tag exists yet — no volunteer binary has ever been released. After this merges, pushing `volunteer-v0.1.0` publishes the first one. The `version` job hard-fails if the tag and VERSION disagree.
- The macOS build carries only an ad-hoc signature (no Developer ID, no notarization), so Gatekeeper blocks a normal double-click — volunteers need right-click → Open. Same posture as the main desktop app; worth a note in the release notes or README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)