### PR TITLE
Complete per-relay WSS fleet rollout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .cache/
 .gocache/
 .build/
+__pycache__/
+*.py[cod]
 
 # Local multi-module workspaces (dev-only; module wiring is via replace directives)
 go.work

--- a/cmd/wssmatrix/main.go
+++ b/cmd/wssmatrix/main.go
@@ -1,0 +1,611 @@
+// Command wssmatrix runs the destructive-free, pre-advertisement acceptance
+// checks for one relay-local WSS front. It signs only short-lived tickets with
+// an explicitly supplied temporary test key; that key must be removed from the
+// sidecar before the front is advertised.
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"openrung/internal/client"
+	"openrung/internal/relay"
+	"openrung/internal/wssbridge"
+)
+
+const (
+	testViewerAddress = "198.51.100.77:443"
+	ticketLifetime    = 2 * time.Minute
+)
+
+type config struct {
+	mode                string
+	url                 string
+	relayID             string
+	frontID             string
+	seedFile            string
+	descriptorFile      string
+	singBox             string
+	probeURL            string
+	originTokenFile     string
+	originTokenNextFile string
+	sourceLimit         int
+	expectCloseWithin   time.Duration
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "WSS matrix failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) > 0 && args[0] == "keygen" {
+		return keygen(args[1:])
+	}
+	if len(args) > 0 && args[0] == "keyring" {
+		return keyring(args[1:])
+	}
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	signer, err := signerFromSeedFile(cfg.seedFile)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	switch cfg.mode {
+	case "edge":
+		err = runEdge(ctx, cfg, signer)
+	case "origin":
+		err = runOrigin(ctx, cfg, signer)
+	case "revoked":
+		err = runRevoked(ctx, cfg, signer)
+	default:
+		err = errors.New("unknown matrix mode")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("mode=%s checks=ok\n", cfg.mode)
+	return nil
+}
+
+type pathList []string
+
+func (p *pathList) String() string { return strings.Join(*p, ",") }
+func (p *pathList) Set(value string) error {
+	*p = append(*p, value)
+	return nil
+}
+
+func parseConfig(args []string) (config, error) {
+	var cfg config
+	fs := flag.NewFlagSet("wssmatrix", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.mode, "mode", "edge", "matrix mode: edge, origin, or revoked")
+	fs.StringVar(&cfg.url, "url", "", "exact WSS bridge URL")
+	fs.StringVar(&cfg.relayID, "relay-id", "", "exact local relay ID")
+	fs.StringVar(&cfg.frontID, "front-id", "", "exact front ID")
+	fs.StringVar(&cfg.seedFile, "seed-file", "", "mode-0600 base64 Ed25519 test seed")
+	fs.StringVar(&cfg.descriptorFile, "descriptor-file", "", "public relay descriptor JSON")
+	fs.StringVar(&cfg.singBox, "sing-box", "sing-box", "sing-box binary")
+	fs.StringVar(&cfg.probeURL, "probe-url", "https://www.cloudflare.com/cdn-cgi/trace", "end-to-end probe URL")
+	fs.StringVar(&cfg.originTokenFile, "origin-token-file", "", "mode-0600 current origin token")
+	fs.StringVar(&cfg.originTokenNextFile, "origin-token-next-file", "", "mode-0600 next origin token")
+	fs.IntVar(&cfg.sourceLimit, "source-limit", 0, "configured per-source session limit to verify")
+	fs.DurationVar(&cfg.expectCloseWithin, "expect-close-within", 0, "maximum expected idle/lifetime cleanup delay")
+	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
+		return config{}, errors.New("invalid WSS matrix arguments")
+	}
+	if cfg.mode != "edge" && cfg.mode != "origin" && cfg.mode != "revoked" {
+		return config{}, errors.New("mode must be edge, origin, or revoked")
+	}
+	if cfg.url == "" || cfg.relayID == "" || cfg.frontID == "" || cfg.seedFile == "" {
+		return config{}, errors.New("url, relay-id, front-id, and seed-file are required")
+	}
+	parsed, err := url.Parse(cfg.url)
+	if err != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != wssbridge.BridgePath {
+		return config{}, errors.New("url must be an exact bridge URL without query or fragment")
+	}
+	if cfg.mode == "edge" {
+		if parsed.Scheme != "wss" || cfg.descriptorFile == "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 {
+			return config{}, errors.New("edge mode requires wss and a descriptor file only")
+		}
+	} else if cfg.mode == "revoked" {
+		if parsed.Scheme != "wss" || cfg.descriptorFile != "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 || cfg.originTokenFile != "" || cfg.originTokenNextFile != "" {
+			return config{}, errors.New("revoked mode requires only a wss endpoint and test signer")
+		}
+	} else {
+		host := net.ParseIP(parsed.Hostname())
+		if parsed.Scheme != "ws" || host == nil || !host.IsLoopback() || cfg.originTokenFile == "" || cfg.originTokenNextFile == "" || cfg.sourceLimit < 1 {
+			return config{}, errors.New("origin mode requires a loopback ws URL, two token files, and a positive source limit")
+		}
+	}
+	return cfg, nil
+}
+
+func runRevoked(ctx context.Context, cfg config, signer *wssbridge.TicketSigner) error {
+	ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	if status, err := dialStatus(ctx, cfg.url, ticket, "", ""); err == nil || status != http.StatusUnauthorized {
+		return fmt.Errorf("removed test ticket key returned HTTP %d", status)
+	}
+	fmt.Println("test_ticket_key_removal=ok")
+	return nil
+}
+
+func keygen(args []string) error {
+	fs := flag.NewFlagSet("wssmatrix keygen", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	seedFile := fs.String("seed-file", "", "new seed output")
+	publicFile := fs.String("public-key-file", "", "new public-key output")
+	if err := fs.Parse(args); err != nil || fs.NArg() != 0 || *seedFile == "" || *publicFile == "" {
+		return errors.New("keygen requires seed-file and public-key-file")
+	}
+	for _, path := range []string{*seedFile, *publicFile} {
+		if !filepath.IsAbs(path) {
+			return errors.New("key output paths must be absolute")
+		}
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			return errors.New("refusing to replace a key output file")
+		}
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return errors.New("generate test ticket key")
+	}
+	if err := writeSecretFile(*seedFile, base64.StdEncoding.EncodeToString(private.Seed())+"\n"); err != nil {
+		return err
+	}
+	if err := writeSecretFile(*publicFile, base64.StdEncoding.EncodeToString(public)+"\n"); err != nil {
+		_ = os.Remove(*seedFile)
+		return err
+	}
+	fmt.Println("test_ticket_key=generated")
+	return nil
+}
+
+func keyring(args []string) error {
+	fs := flag.NewFlagSet("wssmatrix keyring", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	output := fs.String("output", "", "new key-ring output")
+	var inputs pathList
+	fs.Var(&inputs, "public-key-file", "mode-0600 public key input; repeat for overlap")
+	if err := fs.Parse(args); err != nil || fs.NArg() != 0 || *output == "" || len(inputs) < 1 || len(inputs) > 8 {
+		return errors.New("keyring requires output and 1..8 public-key-file inputs")
+	}
+	if !filepath.IsAbs(*output) {
+		return errors.New("key-ring output path must be absolute")
+	}
+	if _, err := os.Lstat(*output); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("refusing to replace a key-ring output file")
+	}
+	keys := make([]string, 0, len(inputs))
+	seen := make(map[string]bool)
+	for _, input := range inputs {
+		value, err := readMode0600Line(input)
+		if err != nil {
+			return err
+		}
+		raw, err := base64.StdEncoding.DecodeString(value)
+		if err != nil || len(raw) != ed25519.PublicKeySize || seen[value] {
+			return errors.New("public key input is invalid or duplicated")
+		}
+		seen[value] = true
+		keys = append(keys, value)
+	}
+	if err := writeSecretFile(*output, strings.Join(keys, ",")+"\n"); err != nil {
+		return err
+	}
+	fmt.Printf("test_ticket_keyring=generated keys=%d\n", len(keys))
+	return nil
+}
+
+func writeSecretFile(path, value string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.New("create key output")
+	}
+	if _, err = io.WriteString(file, value); err != nil {
+		_ = file.Close()
+		return errors.New("write key output")
+	}
+	if err := file.Close(); err != nil {
+		return errors.New("close key output")
+	}
+	return nil
+}
+
+func signerFromSeedFile(path string) (*wssbridge.TicketSigner, error) {
+	raw, err := readMode0600Line(path)
+	if err != nil {
+		return nil, err
+	}
+	seed, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return nil, errors.New("test ticket seed is invalid")
+	}
+	return wssbridge.NewTicketSigner(ed25519.NewKeyFromSeed(seed), wssbridge.TicketOptions{})
+}
+
+func readMode0600Line(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return "", errors.New("secret input must be a mode-0600 regular file")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", errors.New("read secret input")
+	}
+	value := strings.TrimSuffix(string(raw), "\n")
+	if value == "" || strings.ContainsAny(value, "\r\n\t ") {
+		return "", errors.New("secret input must contain one non-whitespace line")
+	}
+	return value, nil
+}
+
+func signedTicket(signer *wssbridge.TicketSigner, relayID, frontID string) (string, error) {
+	var random [16]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", errors.New("generate ticket identifier")
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	return signer.Sign(wssbridge.Claims{
+		Version: wssbridge.TicketVersion, Audience: wssbridge.TicketAudience,
+		JTI: hex.EncodeToString(random[:]), RelayID: relayID, FrontID: frontID,
+		IssuedAt: now.Unix(), NotBefore: now.Unix(), ExpiresAt: now.Add(ticketLifetime).Unix(), MaxStreams: 8,
+	})
+}
+
+func runEdge(ctx context.Context, cfg config, signer *wssbridge.TicketSigner) error {
+	if status, err := dialStatus(ctx, cfg.url, "", "", ""); err == nil || status != http.StatusUnauthorized {
+		return errors.New("missing ticket was not rejected")
+	}
+	wrongRelay, err := signedTicket(signer, cfg.relayID+"_wrong", cfg.frontID)
+	if err != nil {
+		return err
+	}
+	if status, err := dialStatus(ctx, cfg.url, wrongRelay, "", ""); err == nil || status != http.StatusUnauthorized {
+		return errors.New("wrong-relay ticket was not rejected")
+	}
+	wrongFront, err := signedTicket(signer, cfg.relayID, cfg.frontID+"-wrong")
+	if err != nil {
+		return err
+	}
+	if status, err := dialStatus(ctx, cfg.url, wrongFront, "", ""); err == nil || status != http.StatusUnauthorized {
+		return errors.New("wrong-front ticket was not rejected")
+	}
+	replay, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	conn, status, err := dialWebSocket(ctx, cfg.url, replay, "", "")
+	if err != nil || status != http.StatusSwitchingProtocols {
+		return errors.New("valid replay probe ticket was rejected")
+	}
+	_ = conn.Close()
+	if status, err = dialStatus(ctx, cfg.url, replay, "", ""); err == nil || status != http.StatusConflict {
+		return errors.New("ticket replay was not rejected")
+	}
+	if err := endToEndProbe(ctx, cfg, signer); err != nil {
+		return err
+	}
+	fmt.Println("edge_authorization=ok edge_binding=ok replay=ok reality_probe=ok")
+	return nil
+}
+
+func runOrigin(ctx context.Context, cfg config, signer *wssbridge.TicketSigner) error {
+	current, err := readMode0600Line(cfg.originTokenFile)
+	if err != nil {
+		return err
+	}
+	next, err := readMode0600Line(cfg.originTokenNextFile)
+	if err != nil {
+		return err
+	}
+	if current == next {
+		return errors.New("origin rotation tokens are not unique")
+	}
+	badTicket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	if status, err := dialStatus(ctx, cfg.url, badTicket, strings.Repeat("x", 48), testViewerAddress); err == nil || status != http.StatusUnauthorized {
+		return fmt.Errorf("invalid origin token rejection returned HTTP %d (%v)", status, err)
+	}
+	for _, token := range []string{current, next} {
+		ticket, signErr := signedTicket(signer, cfg.relayID, cfg.frontID)
+		if signErr != nil {
+			return signErr
+		}
+		conn, status, dialErr := dialWebSocket(ctx, cfg.url, ticket, token, testViewerAddress)
+		if dialErr != nil || status != http.StatusSwitchingProtocols {
+			return errors.New("overlapping origin token was rejected")
+		}
+		_ = conn.Close()
+	}
+	if err := sourceLimitProbe(ctx, cfg, signer, current); err != nil {
+		return err
+	}
+	if cfg.expectCloseWithin > 0 {
+		if err := lifecycleProbe(ctx, cfg, signer, current); err != nil {
+			return err
+		}
+	}
+	fmt.Println("origin_auth=ok origin_rotation=ok source_limit=ok lifecycle_cleanup=ok")
+	return nil
+}
+
+func dialStatus(ctx context.Context, endpoint, ticket, originToken, viewerAddress string) (int, error) {
+	conn, status, err := dialWebSocket(ctx, endpoint, ticket, originToken, viewerAddress)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	return status, err
+}
+
+func dialWebSocket(ctx context.Context, endpoint, ticket, originToken, viewerAddress string) (*websocket.Conn, int, error) {
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second, EnableCompression: false,
+		Subprotocols: []string{wssbridge.Subprotocol}, Proxy: nil,
+		NetDialContext: (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+	}
+	header := make(http.Header)
+	if ticket != "" {
+		header.Set("Authorization", "Bearer "+ticket)
+	}
+	if originToken != "" {
+		header.Set(wssbridge.OriginTokenHeader, originToken)
+	}
+	if viewerAddress != "" {
+		header.Set(wssbridge.DefaultViewerAddressHeader, viewerAddress)
+	}
+	conn, response, err := dialer.DialContext(ctx, endpoint, header)
+	status := 0
+	if response != nil {
+		status = response.StatusCode
+		if response.Body != nil {
+			_ = response.Body.Close()
+		}
+	}
+	if err != nil {
+		return nil, status, fmt.Errorf("WebSocket handshake failed: %w", err)
+	}
+	if conn.Subprotocol() != wssbridge.Subprotocol {
+		_ = conn.Close()
+		return nil, status, errors.New("required subprotocol was not negotiated")
+	}
+	return conn, status, nil
+}
+
+func sourceLimitProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSigner, token string) error {
+	connections := make([]*websocket.Conn, 0, cfg.sourceLimit)
+	defer func() {
+		for _, conn := range connections {
+			_ = conn.Close()
+		}
+	}()
+	for range cfg.sourceLimit {
+		ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+		if err != nil {
+			return err
+		}
+		conn, status, err := dialWebSocket(ctx, cfg.url, ticket, token, testViewerAddress)
+		if err != nil || status != http.StatusSwitchingProtocols {
+			return errors.New("configured per-source capacity was rejected early")
+		}
+		connections = append(connections, conn)
+	}
+	ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	if status, err := dialStatus(ctx, cfg.url, ticket, token, testViewerAddress); err == nil || status != http.StatusTooManyRequests {
+		return errors.New("per-source session limit was not enforced")
+	}
+	_ = connections[0].Close()
+	connections = connections[1:]
+	time.Sleep(250 * time.Millisecond)
+	ticket, err = signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	conn, status, err := dialWebSocket(ctx, cfg.url, ticket, token, testViewerAddress)
+	if err != nil || status != http.StatusSwitchingProtocols {
+		return errors.New("per-source capacity was not released after cleanup")
+	}
+	connections = append(connections, conn)
+	return nil
+}
+
+func lifecycleProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSigner, token string) error {
+	ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	conn, status, err := dialWebSocket(ctx, cfg.url, ticket, token, testViewerAddress)
+	if err != nil || status != http.StatusSwitchingProtocols {
+		return errors.New("lifecycle probe session was rejected")
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(cfg.expectCloseWithin))
+	for {
+		if _, _, err = conn.ReadMessage(); err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				return errors.New("session exceeded configured cleanup deadline")
+			}
+			return nil
+		}
+	}
+}
+
+func endToEndProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSigner) error {
+	raw, err := os.ReadFile(cfg.descriptorFile)
+	if err != nil {
+		return errors.New("read public relay descriptor")
+	}
+	var descriptor relay.Descriptor
+	if err := json.Unmarshal(raw, &descriptor); err != nil {
+		return errors.New("decode public relay descriptor")
+	}
+	if descriptor.ID != cfg.relayID {
+		var list struct {
+			Relays []relay.Descriptor `json:"relays"`
+		}
+		if err := json.Unmarshal(raw, &list); err != nil {
+			return errors.New("decode public relay list")
+		}
+		descriptor = relay.Descriptor{}
+		for _, candidate := range list.Relays {
+			if candidate.ID == cfg.relayID {
+				descriptor = candidate
+				break
+			}
+		}
+	}
+	if descriptor.ID != cfg.relayID {
+		return errors.New("public relay descriptor does not match matrix relay")
+	}
+	ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	bridge, err := wssbridge.DialClient(ctx, wssbridge.ClientOptions{URL: cfg.url, Ticket: ticket})
+	if err != nil {
+		return errors.New("start WSS bridge client")
+	}
+	defer bridge.Close()
+	bridgeCtx, cancelBridge := context.WithCancel(ctx)
+	defer cancelBridge()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- bridge.Serve(bridgeCtx) }()
+
+	proxyPort, err := availableLoopbackPort()
+	if err != nil {
+		return err
+	}
+	bridgeHost, bridgePort := bridge.Endpoint()
+	configJSON, err := client.BuildSingBoxConfig(client.SingBoxConfigInput{
+		Relay: descriptor, Mode: client.ModeProxy,
+		ProxyListenAddress: "127.0.0.1", ProxyListenPort: proxyPort,
+		BridgeHost: bridgeHost, BridgePort: bridgePort,
+	})
+	if err != nil {
+		return errors.New("build sing-box Reality bridge config")
+	}
+	configFile, err := os.CreateTemp("", "openrung-wss-matrix-*.json")
+	if err != nil {
+		return errors.New("create temporary sing-box config")
+	}
+	configPath := configFile.Name()
+	defer os.Remove(configPath)
+	if err := configFile.Chmod(0o600); err != nil {
+		_ = configFile.Close()
+		return errors.New("protect temporary sing-box config")
+	}
+	if _, err := configFile.Write(configJSON); err != nil {
+		_ = configFile.Close()
+		return errors.New("write temporary sing-box config")
+	}
+	if err := configFile.Close(); err != nil {
+		return errors.New("close temporary sing-box config")
+	}
+
+	singCtx, cancelSing := context.WithCancel(ctx)
+	defer cancelSing()
+	runnerDone := make(chan error, 1)
+	go func() {
+		runnerDone <- (client.SingBoxRunner{Path: cfg.singBox, KillGrace: time.Second}).Run(singCtx, configPath)
+	}()
+	if err := waitForListener(ctx, net.JoinHostPort("127.0.0.1", fmt.Sprint(proxyPort)), runnerDone); err != nil {
+		return err
+	}
+	proxy, _ := url.Parse("http://" + net.JoinHostPort("127.0.0.1", fmt.Sprint(proxyPort)))
+	transport := &http.Transport{Proxy: http.ProxyURL(proxy), DisableKeepAlives: true}
+	defer transport.CloseIdleConnections()
+	requestCtx, cancelRequest := context.WithTimeout(ctx, 20*time.Second)
+	defer cancelRequest()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, cfg.probeURL, nil)
+	if err != nil {
+		return errors.New("construct end-to-end probe")
+	}
+	response, err := (&http.Client{Transport: transport}).Do(request)
+	if err != nil {
+		return errors.New("end-to-end Reality probe failed")
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+	if response.StatusCode < 200 || response.StatusCode >= 400 {
+		return errors.New("end-to-end Reality probe returned an unsuccessful status")
+	}
+	cancelSing()
+	select {
+	case <-runnerDone:
+	case <-time.After(5 * time.Second):
+		return errors.New("sing-box cleanup timed out")
+	}
+	cancelBridge()
+	select {
+	case <-serveDone:
+	case <-time.After(5 * time.Second):
+		return errors.New("WSS bridge cleanup timed out")
+	}
+	return nil
+}
+
+func availableLoopbackPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, errors.New("reserve local proxy port")
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
+func waitForListener(ctx context.Context, address string, runnerDone <-chan error) error {
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("matrix timed out before sing-box was ready")
+		case <-deadline.C:
+			return errors.New("sing-box proxy did not become ready")
+		case <-runnerDone:
+			return errors.New("sing-box exited before its proxy became ready")
+		case <-ticker.C:
+			conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+			if err == nil {
+				_ = conn.Close()
+				return nil
+			}
+		}
+	}
+}

--- a/cmd/wssmatrix/main.go
+++ b/cmd/wssmatrix/main.go
@@ -46,6 +46,7 @@ type config struct {
 	probeURL            string
 	originTokenFile     string
 	originTokenNextFile string
+	ticketResponseFile  string
 	sourceLimit         int
 	expectCloseWithin   time.Duration
 }
@@ -68,9 +69,12 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	signer, err := signerFromSeedFile(cfg.seedFile)
-	if err != nil {
-		return err
+	var signer *wssbridge.TicketSigner
+	if cfg.mode != "issued" {
+		signer, err = signerFromSeedFile(cfg.seedFile)
+		if err != nil {
+			return err
+		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
@@ -82,6 +86,8 @@ func run(args []string) error {
 		err = runOrigin(ctx, cfg, signer)
 	case "revoked":
 		err = runRevoked(ctx, cfg, signer)
+	case "issued":
+		err = runIssued(ctx, cfg)
 	default:
 		err = errors.New("unknown matrix mode")
 	}
@@ -104,7 +110,7 @@ func parseConfig(args []string) (config, error) {
 	var cfg config
 	fs := flag.NewFlagSet("wssmatrix", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	fs.StringVar(&cfg.mode, "mode", "edge", "matrix mode: edge, origin, or revoked")
+	fs.StringVar(&cfg.mode, "mode", "edge", "matrix mode: edge, origin, revoked, or issued")
 	fs.StringVar(&cfg.url, "url", "", "exact WSS bridge URL")
 	fs.StringVar(&cfg.relayID, "relay-id", "", "exact local relay ID")
 	fs.StringVar(&cfg.frontID, "front-id", "", "exact front ID")
@@ -114,36 +120,86 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.probeURL, "probe-url", "https://www.cloudflare.com/cdn-cgi/trace", "end-to-end probe URL")
 	fs.StringVar(&cfg.originTokenFile, "origin-token-file", "", "mode-0600 current origin token")
 	fs.StringVar(&cfg.originTokenNextFile, "origin-token-next-file", "", "mode-0600 next origin token")
+	fs.StringVar(&cfg.ticketResponseFile, "ticket-response-file", "", "mode-0600 broker ticket response")
 	fs.IntVar(&cfg.sourceLimit, "source-limit", 0, "configured per-source session limit to verify")
 	fs.DurationVar(&cfg.expectCloseWithin, "expect-close-within", 0, "maximum expected idle/lifetime cleanup delay")
 	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
 		return config{}, errors.New("invalid WSS matrix arguments")
 	}
-	if cfg.mode != "edge" && cfg.mode != "origin" && cfg.mode != "revoked" {
-		return config{}, errors.New("mode must be edge, origin, or revoked")
+	if cfg.mode != "edge" && cfg.mode != "origin" && cfg.mode != "revoked" && cfg.mode != "issued" {
+		return config{}, errors.New("mode must be edge, origin, revoked, or issued")
 	}
-	if cfg.url == "" || cfg.relayID == "" || cfg.frontID == "" || cfg.seedFile == "" {
-		return config{}, errors.New("url, relay-id, front-id, and seed-file are required")
+	if cfg.url == "" || cfg.relayID == "" || cfg.frontID == "" {
+		return config{}, errors.New("url, relay-id, and front-id are required")
+	}
+	if cfg.mode != "issued" && cfg.seedFile == "" {
+		return config{}, errors.New("seed-file is required")
 	}
 	parsed, err := url.Parse(cfg.url)
 	if err != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != wssbridge.BridgePath {
 		return config{}, errors.New("url must be an exact bridge URL without query or fragment")
 	}
 	if cfg.mode == "edge" {
-		if parsed.Scheme != "wss" || cfg.descriptorFile == "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 {
+		if parsed.Scheme != "wss" || cfg.descriptorFile == "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 || cfg.originTokenFile != "" || cfg.originTokenNextFile != "" || cfg.ticketResponseFile != "" {
 			return config{}, errors.New("edge mode requires wss and a descriptor file only")
 		}
 	} else if cfg.mode == "revoked" {
-		if parsed.Scheme != "wss" || cfg.descriptorFile != "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 || cfg.originTokenFile != "" || cfg.originTokenNextFile != "" {
+		if parsed.Scheme != "wss" || cfg.descriptorFile != "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 || cfg.originTokenFile != "" || cfg.originTokenNextFile != "" || cfg.ticketResponseFile != "" {
 			return config{}, errors.New("revoked mode requires only a wss endpoint and test signer")
+		}
+	} else if cfg.mode == "issued" {
+		if parsed.Scheme != "wss" || cfg.ticketResponseFile == "" || cfg.seedFile != "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 || cfg.originTokenFile != "" || cfg.originTokenNextFile != "" {
+			return config{}, errors.New("issued mode requires a wss endpoint and ticket response file")
 		}
 	} else {
 		host := net.ParseIP(parsed.Hostname())
-		if parsed.Scheme != "ws" || host == nil || !host.IsLoopback() || cfg.originTokenFile == "" || cfg.originTokenNextFile == "" || cfg.sourceLimit < 1 {
+		if parsed.Scheme != "ws" || host == nil || !host.IsLoopback() || cfg.originTokenFile == "" || cfg.originTokenNextFile == "" || cfg.sourceLimit < 1 || cfg.descriptorFile != "" || cfg.ticketResponseFile != "" {
 			return config{}, errors.New("origin mode requires a loopback ws URL, two token files, and a positive source limit")
 		}
 	}
 	return cfg, nil
+}
+
+func runIssued(ctx context.Context, cfg config) error {
+	info, err := os.Lstat(cfg.ticketResponseFile)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || info.Size() < 1 || info.Size() > 64<<10 {
+		return errors.New("ticket response must be a bounded mode-0600 regular file")
+	}
+	raw, err := os.ReadFile(cfg.ticketResponseFile)
+	if err != nil {
+		return errors.New("read ticket response")
+	}
+	var response relay.WSSSessionTicketResponse
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		return errors.New("decode ticket response")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return errors.New("ticket response must contain one JSON object")
+	}
+	if response.URL != cfg.url || len(response.Ticket) < 1 || len(response.Ticket) > wssbridge.MaxTicketBytes {
+		return errors.New("ticket response does not match the expected front")
+	}
+	remaining := time.Until(response.ExpiresAt)
+	if remaining <= 0 || remaining > wssbridge.MaxTicketLifetime {
+		return errors.New("ticket response expiry is outside protocol bounds")
+	}
+	if cfg.descriptorFile != "" {
+		if err := endToEndProbeTicket(ctx, cfg, response.Ticket); err != nil {
+			return err
+		}
+		fmt.Println("broker_ticket_issuance=ok production_reality_probe=ok")
+		return nil
+	}
+	bridge, err := wssbridge.DialClient(ctx, wssbridge.ClientOptions{URL: cfg.url, Ticket: response.Ticket})
+	if err != nil {
+		return errors.New("issued production ticket was rejected")
+	}
+	_ = bridge.Close()
+	fmt.Println("broker_ticket_issuance=ok production_sidecar_acceptance=ok")
+	return nil
 }
 
 func runRevoked(ctx context.Context, cfg config, signer *wssbridge.TicketSigner) error {
@@ -465,6 +521,14 @@ func lifecycleProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSig
 }
 
 func endToEndProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSigner) error {
+	ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
+	if err != nil {
+		return err
+	}
+	return endToEndProbeTicket(ctx, cfg, ticket)
+}
+
+func endToEndProbeTicket(ctx context.Context, cfg config, ticket string) error {
 	raw, err := os.ReadFile(cfg.descriptorFile)
 	if err != nil {
 		return errors.New("read public relay descriptor")
@@ -490,10 +554,6 @@ func endToEndProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSign
 	}
 	if descriptor.ID != cfg.relayID {
 		return errors.New("public relay descriptor does not match matrix relay")
-	}
-	ticket, err := signedTicket(signer, cfg.relayID, cfg.frontID)
-	if err != nil {
-		return err
 	}
 	bridge, err := wssbridge.DialClient(ctx, wssbridge.ClientOptions{URL: cfg.url, Ticket: ticket})
 	if err != nil {

--- a/cmd/wssmatrix/main.go
+++ b/cmd/wssmatrix/main.go
@@ -1,7 +1,7 @@
-// Command wssmatrix runs the destructive-free, pre-advertisement acceptance
-// checks for one relay-local WSS front. It signs only short-lived tickets with
-// an explicitly supplied temporary test key; that key must be removed from the
-// sidecar before the front is advertised.
+// Command wssmatrix runs the destructive-free direct-path and
+// pre-advertisement acceptance checks for one relay-local WSS front. It signs
+// only short-lived tickets with an explicitly supplied temporary test key;
+// that key must be removed from the sidecar before the front is advertised.
 package main
 
 import (
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/openrung/openrung/wsscore"
 
 	"openrung/internal/client"
 	"openrung/internal/relay"
@@ -70,7 +71,7 @@ func run(args []string) error {
 		return err
 	}
 	var signer *wssbridge.TicketSigner
-	if cfg.mode != "issued" {
+	if cfg.mode != "issued" && cfg.mode != "direct" {
 		signer, err = signerFromSeedFile(cfg.seedFile)
 		if err != nil {
 			return err
@@ -80,6 +81,8 @@ func run(args []string) error {
 	defer cancel()
 
 	switch cfg.mode {
+	case "direct":
+		err = runDirect(ctx, cfg)
 	case "edge":
 		err = runEdge(ctx, cfg, signer)
 	case "origin":
@@ -110,7 +113,7 @@ func parseConfig(args []string) (config, error) {
 	var cfg config
 	fs := flag.NewFlagSet("wssmatrix", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	fs.StringVar(&cfg.mode, "mode", "edge", "matrix mode: edge, origin, revoked, or issued")
+	fs.StringVar(&cfg.mode, "mode", "edge", "matrix mode: direct, edge, origin, revoked, or issued")
 	fs.StringVar(&cfg.url, "url", "", "exact WSS bridge URL")
 	fs.StringVar(&cfg.relayID, "relay-id", "", "exact local relay ID")
 	fs.StringVar(&cfg.frontID, "front-id", "", "exact front ID")
@@ -126,10 +129,19 @@ func parseConfig(args []string) (config, error) {
 	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
 		return config{}, errors.New("invalid WSS matrix arguments")
 	}
-	if cfg.mode != "edge" && cfg.mode != "origin" && cfg.mode != "revoked" && cfg.mode != "issued" {
-		return config{}, errors.New("mode must be edge, origin, revoked, or issued")
+	if cfg.mode != "direct" && cfg.mode != "edge" && cfg.mode != "origin" && cfg.mode != "revoked" && cfg.mode != "issued" {
+		return config{}, errors.New("mode must be direct, edge, origin, revoked, or issued")
 	}
-	if cfg.url == "" || cfg.relayID == "" || cfg.frontID == "" {
+	if cfg.relayID == "" {
+		return config{}, errors.New("relay-id is required")
+	}
+	if cfg.mode == "direct" {
+		if cfg.descriptorFile == "" || cfg.url != "" || cfg.frontID != "" || cfg.seedFile != "" || cfg.sourceLimit != 0 || cfg.expectCloseWithin != 0 || cfg.originTokenFile != "" || cfg.originTokenNextFile != "" || cfg.ticketResponseFile != "" {
+			return config{}, errors.New("direct mode requires only a relay id and descriptor file")
+		}
+		return cfg, nil
+	}
+	if cfg.url == "" || cfg.frontID == "" {
 		return config{}, errors.New("url, relay-id, and front-id are required")
 	}
 	if cfg.mode != "issued" && cfg.seedFile == "" {
@@ -158,6 +170,18 @@ func parseConfig(args []string) (config, error) {
 		}
 	}
 	return cfg, nil
+}
+
+func runDirect(ctx context.Context, cfg config) error {
+	descriptor, err := loadRelayDescriptor(cfg.descriptorFile, cfg.relayID)
+	if err != nil {
+		return err
+	}
+	if err := runRealityProbe(ctx, cfg, descriptor, "", 0); err != nil {
+		return err
+	}
+	fmt.Println("direct_reality_probe=ok")
+	return nil
 }
 
 func runIssued(ctx context.Context, cfg config) error {
@@ -193,7 +217,7 @@ func runIssued(ctx context.Context, cfg config) error {
 		fmt.Println("broker_ticket_issuance=ok production_reality_probe=ok")
 		return nil
 	}
-	bridge, err := wssbridge.DialClient(ctx, wssbridge.ClientOptions{URL: cfg.url, Ticket: response.Ticket})
+	bridge, err := wsscore.DialClient(ctx, wsscore.ClientOptions{URL: cfg.url, Ticket: response.Ticket})
 	if err != nil {
 		return errors.New("issued production ticket was rejected")
 	}
@@ -529,33 +553,11 @@ func endToEndProbe(ctx context.Context, cfg config, signer *wssbridge.TicketSign
 }
 
 func endToEndProbeTicket(ctx context.Context, cfg config, ticket string) error {
-	raw, err := os.ReadFile(cfg.descriptorFile)
+	descriptor, err := loadRelayDescriptor(cfg.descriptorFile, cfg.relayID)
 	if err != nil {
-		return errors.New("read public relay descriptor")
+		return err
 	}
-	var descriptor relay.Descriptor
-	if err := json.Unmarshal(raw, &descriptor); err != nil {
-		return errors.New("decode public relay descriptor")
-	}
-	if descriptor.ID != cfg.relayID {
-		var list struct {
-			Relays []relay.Descriptor `json:"relays"`
-		}
-		if err := json.Unmarshal(raw, &list); err != nil {
-			return errors.New("decode public relay list")
-		}
-		descriptor = relay.Descriptor{}
-		for _, candidate := range list.Relays {
-			if candidate.ID == cfg.relayID {
-				descriptor = candidate
-				break
-			}
-		}
-	}
-	if descriptor.ID != cfg.relayID {
-		return errors.New("public relay descriptor does not match matrix relay")
-	}
-	bridge, err := wssbridge.DialClient(ctx, wssbridge.ClientOptions{URL: cfg.url, Ticket: ticket})
+	bridge, err := wsscore.DialClient(ctx, wsscore.ClientOptions{URL: cfg.url, Ticket: ticket})
 	if err != nil {
 		return errors.New("start WSS bridge client")
 	}
@@ -565,11 +567,54 @@ func endToEndProbeTicket(ctx context.Context, cfg config, ticket string) error {
 	serveDone := make(chan error, 1)
 	go func() { serveDone <- bridge.Serve(bridgeCtx) }()
 
+	bridgeHost, bridgePort := bridge.Endpoint()
+	if err := runRealityProbe(ctx, cfg, descriptor, bridgeHost, bridgePort); err != nil {
+		return err
+	}
+	cancelBridge()
+	select {
+	case <-serveDone:
+	case <-time.After(5 * time.Second):
+		return errors.New("WSS bridge cleanup timed out")
+	}
+	return nil
+}
+
+func loadRelayDescriptor(path, relayID string) (relay.Descriptor, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return relay.Descriptor{}, errors.New("read public relay descriptor")
+	}
+	var descriptor relay.Descriptor
+	if err := json.Unmarshal(raw, &descriptor); err != nil {
+		return relay.Descriptor{}, errors.New("decode public relay descriptor")
+	}
+	if descriptor.ID != relayID {
+		var list struct {
+			Relays []relay.Descriptor `json:"relays"`
+		}
+		if err := json.Unmarshal(raw, &list); err != nil {
+			return relay.Descriptor{}, errors.New("decode public relay list")
+		}
+		descriptor = relay.Descriptor{}
+		for _, candidate := range list.Relays {
+			if candidate.ID == relayID {
+				descriptor = candidate
+				break
+			}
+		}
+	}
+	if descriptor.ID != relayID {
+		return relay.Descriptor{}, errors.New("public relay descriptor does not match matrix relay")
+	}
+	return descriptor, nil
+}
+
+func runRealityProbe(ctx context.Context, cfg config, descriptor relay.Descriptor, bridgeHost string, bridgePort int) error {
 	proxyPort, err := availableLoopbackPort()
 	if err != nil {
 		return err
 	}
-	bridgeHost, bridgePort := bridge.Endpoint()
 	configJSON, err := client.BuildSingBoxConfig(client.SingBoxConfigInput{
 		Relay: descriptor, Mode: client.ModeProxy,
 		ProxyListenAddress: "127.0.0.1", ProxyListenPort: proxyPort,
@@ -628,12 +673,6 @@ func endToEndProbeTicket(ctx context.Context, cfg config, ticket string) error {
 	case <-runnerDone:
 	case <-time.After(5 * time.Second):
 		return errors.New("sing-box cleanup timed out")
-	}
-	cancelBridge()
-	select {
-	case <-serveDone:
-	case <-time.After(5 * time.Second):
-		return errors.New("WSS bridge cleanup timed out")
 	}
 	return nil
 }

--- a/cmd/wssmatrix/main_test.go
+++ b/cmd/wssmatrix/main_test.go
@@ -85,4 +85,12 @@ func TestParseConfigSeparatesEdgeAndOriginInputs(t *testing.T) {
 	if err != nil || revoked.mode != "revoked" {
 		t.Fatalf("revoked config: %#v, %v", revoked, err)
 	}
+	issued, err := parseConfig([]string{
+		"-mode", "issued", "-url", "wss://example.cloudfront.net/api/v1/wss-bridge",
+		"-relay-id", "relay_a", "-front-id", "front-a",
+		"-ticket-response-file", "/tmp/ticket-response", "-descriptor-file", "/tmp/descriptor",
+	})
+	if err != nil || issued.mode != "issued" {
+		t.Fatalf("issued config: %#v, %v", issued, err)
+	}
 }

--- a/cmd/wssmatrix/main_test.go
+++ b/cmd/wssmatrix/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"openrung/internal/wssbridge"
+)
+
+func TestKeygenAndOverlappingKeyring(t *testing.T) {
+	temp := t.TempDir()
+	seedA := filepath.Join(temp, "a.seed")
+	publicA := filepath.Join(temp, "a.pub")
+	seedB := filepath.Join(temp, "b.seed")
+	publicB := filepath.Join(temp, "b.pub")
+	for _, pair := range [][2]string{{seedA, publicA}, {seedB, publicB}} {
+		if err := keygen([]string{"-seed-file", pair[0], "-public-key-file", pair[1]}); err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range pair {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("%s mode = %o", path, got)
+			}
+		}
+	}
+	ring := filepath.Join(temp, "ring")
+	if err := keyring([]string{
+		"-output", ring,
+		"-public-key-file", publicA,
+		"-public-key-file", publicB,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := readMode0600Line(ring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := wssbridge.ParseTicketPublicKeys(keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("key ring size = %d", len(parsed))
+	}
+	if err := keygen([]string{"-seed-file", seedA, "-public-key-file", publicA}); err == nil {
+		t.Fatal("keygen replaced existing key files")
+	}
+}
+
+func TestParseConfigSeparatesEdgeAndOriginInputs(t *testing.T) {
+	edge, err := parseConfig([]string{
+		"-mode", "edge", "-url", "wss://example.cloudfront.net/api/v1/wss-bridge",
+		"-relay-id", "relay_a", "-front-id", "front-a", "-seed-file", "/tmp/seed",
+		"-descriptor-file", "/tmp/descriptor",
+	})
+	if err != nil || edge.mode != "edge" {
+		t.Fatalf("edge config: %#v, %v", edge, err)
+	}
+	origin, err := parseConfig([]string{
+		"-mode", "origin", "-url", "ws://127.0.0.1:8081/api/v1/wss-bridge",
+		"-relay-id", "relay_a", "-front-id", "front-a", "-seed-file", "/tmp/seed",
+		"-origin-token-file", "/tmp/current", "-origin-token-next-file", "/tmp/next",
+		"-source-limit", "2", "-expect-close-within", "10s",
+	})
+	if err != nil || origin.mode != "origin" {
+		t.Fatalf("origin config: %#v, %v", origin, err)
+	}
+	if _, err := parseConfig([]string{
+		"-mode", "origin", "-url", "ws://relay.example/api/v1/wss-bridge",
+		"-relay-id", "relay_a", "-front-id", "front-a", "-seed-file", "/tmp/seed",
+		"-origin-token-file", "/tmp/current", "-origin-token-next-file", "/tmp/next",
+		"-source-limit", "2",
+	}); err == nil {
+		t.Fatal("origin mode accepted a non-loopback endpoint")
+	}
+	revoked, err := parseConfig([]string{
+		"-mode", "revoked", "-url", "wss://example.cloudfront.net/api/v1/wss-bridge",
+		"-relay-id", "relay_a", "-front-id", "front-a", "-seed-file", "/tmp/seed",
+	})
+	if err != nil || revoked.mode != "revoked" {
+		t.Fatalf("revoked config: %#v, %v", revoked, err)
+	}
+}

--- a/cmd/wssmatrix/main_test.go
+++ b/cmd/wssmatrix/main_test.go
@@ -53,6 +53,18 @@ func TestKeygenAndOverlappingKeyring(t *testing.T) {
 }
 
 func TestParseConfigSeparatesEdgeAndOriginInputs(t *testing.T) {
+	direct, err := parseConfig([]string{
+		"-mode", "direct", "-relay-id", "relay_a", "-descriptor-file", "/tmp/descriptor",
+	})
+	if err != nil || direct.mode != "direct" {
+		t.Fatalf("direct config: %#v, %v", direct, err)
+	}
+	if _, err := parseConfig([]string{
+		"-mode", "direct", "-relay-id", "relay_a", "-descriptor-file", "/tmp/descriptor",
+		"-url", "wss://example.cloudfront.net/api/v1/wss-bridge",
+	}); err == nil {
+		t.Fatal("direct mode accepted a WSS endpoint")
+	}
 	edge, err := parseConfig([]string{
 		"-mode", "edge", "-url", "wss://example.cloudfront.net/api/v1/wss-bridge",
 		"-relay-id", "relay_a", "-front-id", "front-a", "-seed-file", "/tmp/seed",

--- a/deploy/relay/aws/cloudfront-wss-front.sh
+++ b/deploy/relay/aws/cloudfront-wss-front.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Create or audit one dedicated CloudFront WSS distribution for one relay.
+#
+# The origin token must be supplied in a mode-0600 file through
+# OPENRUNG_ORIGIN_TOKEN_FILE.  It is never accepted in argv or printed.  The
+# resulting state file contains only the distribution ID/domain and public
+# relay/front metadata.
+set -euo pipefail
+{ set +x; } 2>/dev/null
+
+MODE="${1:-}"
+RELAY_NAME="${2:-}"
+ORIGIN_HOST="${3:-}"
+FRONT_ID="${4:-}"
+AWS_PROFILE="${OPENRUNG_AWS_PROFILE:-default}"
+AWS_REGION="us-east-1"
+ORIGIN_REQUEST_POLICY_ID="${OPENRUNG_WSS_ORIGIN_REQUEST_POLICY_ID:-380513fb-b7e5-4c85-8d9e-ec34cc2992dc}"
+CACHE_POLICY_ID="4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+STATE_FILE="${OPENRUNG_WSS_DISTRIBUTION_STATE_FILE:-}"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+[[ "$MODE" == create || "$MODE" == audit ]] || die "usage: $0 create|audit RELAY_NAME ORIGIN_HOST FRONT_ID"
+[[ "$RELAY_NAME" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]] || die "relay name is invalid"
+[[ "$FRONT_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || die "front ID is invalid"
+[[ "$ORIGIN_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]{0,252}[A-Za-z0-9]$ ]] || die "origin hostname is invalid"
+[[ "$ORIGIN_HOST" != *.cloudfront.net ]] || die "origin must be the relay, not another CloudFront distribution"
+command -v aws >/dev/null || die "aws CLI is required"
+command -v jq >/dev/null || die "jq is required"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+umask 077
+
+aws --profile "$AWS_PROFILE" --region "$AWS_REGION" cloudfront list-distributions --output json >"${TMP_DIR}/distributions.json"
+EXISTING_ID="$(jq -r --arg host "$ORIGIN_HOST" '[.DistributionList.Items[]? | select(any(.Origins.Items[]?; .DomainName == $host)) | .Id] | if length == 0 then "" elif length == 1 then .[0] else error("multiple distributions use the same relay origin") end' "${TMP_DIR}/distributions.json")"
+
+if [[ "$MODE" == audit ]]; then
+  [[ -n "$EXISTING_ID" ]] || die "no distribution points to ${ORIGIN_HOST}"
+  DIST_ID="$EXISTING_ID"
+else
+  TOKEN_FILE="${OPENRUNG_ORIGIN_TOKEN_FILE:-}"
+  [[ -n "$TOKEN_FILE" && -f "$TOKEN_FILE" ]] || die "OPENRUNG_ORIGIN_TOKEN_FILE must name a token file"
+  TOKEN_MODE="$(stat -f '%Lp' "$TOKEN_FILE" 2>/dev/null || stat -c '%a' "$TOKEN_FILE")"
+  [[ "$TOKEN_MODE" == 600 ]] || die "origin token file must have mode 0600"
+  TOKEN_LENGTH="$(LC_ALL=C awk 'BEGIN{ok=0} NR==1 && $0 !~ /[[:space:]]/ {n=length($0); if (n >= 32 && n <= 512) {print n; ok=1}} END{if (NR != 1 || !ok) exit 1}' "$TOKEN_FILE")" \
+    || die "origin token must be one 32..512 byte non-whitespace line"
+  [[ "$TOKEN_LENGTH" -ge 32 ]] || die "origin token is invalid"
+  if [[ -n "$EXISTING_ID" ]]; then
+    DIST_ID="$EXISTING_ID"
+  else
+    jq -Rs 'rtrimstr("\n")' "$TOKEN_FILE" >"${TMP_DIR}/token.json"
+    jq -n \
+      --arg relay "$RELAY_NAME" \
+      --arg origin "$ORIGIN_HOST" \
+      --arg policy "$ORIGIN_REQUEST_POLICY_ID" \
+      --arg cache "$CACHE_POLICY_ID" \
+      --slurpfile token "${TMP_DIR}/token.json" '
+      {
+        CallerReference:("openrung-" + $relay + "-wss-front-v1"),
+        Aliases:{Quantity:0},
+        DefaultRootObject:"",
+        Origins:{Quantity:1,Items:[{
+          Id:($relay + "-origin"),DomainName:$origin,OriginPath:"",
+          CustomHeaders:{Quantity:1,Items:[{HeaderName:"X-OpenRung-Origin-Token",HeaderValue:$token[0]}]},
+          CustomOriginConfig:{HTTPPort:80,HTTPSPort:8443,OriginProtocolPolicy:"https-only",OriginSslProtocols:{Quantity:1,Items:["TLSv1.2"]},OriginReadTimeout:10,OriginKeepaliveTimeout:5,IpAddressType:"ipv4"},
+          ConnectionAttempts:1,ConnectionTimeout:5,OriginShield:{Enabled:false},OriginAccessControlId:""
+        }]},
+        OriginGroups:{Quantity:0},
+        DefaultCacheBehavior:{
+          TargetOriginId:($relay + "-origin"),
+          TrustedSigners:{Enabled:false,Quantity:0},TrustedKeyGroups:{Enabled:false,Quantity:0},
+          ViewerProtocolPolicy:"https-only",
+          AllowedMethods:{Quantity:2,Items:["HEAD","GET"],CachedMethods:{Quantity:2,Items:["HEAD","GET"]}},
+          SmoothStreaming:false,Compress:false,
+          LambdaFunctionAssociations:{Quantity:0},FunctionAssociations:{Quantity:0},
+          FieldLevelEncryptionId:"",CachePolicyId:$cache,OriginRequestPolicyId:$policy,
+          GrpcConfig:{Enabled:false}
+        },
+        CacheBehaviors:{Quantity:0},CustomErrorResponses:{Quantity:0},
+        Comment:("OpenRung per-relay WSS front: " + $relay + " only"),
+        Logging:{Enabled:false,IncludeCookies:false,Bucket:"",Prefix:""},
+        PriceClass:"PriceClass_All",Enabled:true,
+        ViewerCertificate:{CloudFrontDefaultCertificate:true,MinimumProtocolVersion:"TLSv1",CertificateSource:"cloudfront"},
+        Restrictions:{GeoRestriction:{RestrictionType:"none",Quantity:0}},
+        WebACLId:"",HttpVersion:"http2and3",IsIPV6Enabled:true,
+        ContinuousDeploymentPolicyId:"",Staging:false
+      }' >"${TMP_DIR}/distribution.json"
+    aws --profile "$AWS_PROFILE" --region "$AWS_REGION" cloudfront create-distribution \
+      --distribution-config "file://${TMP_DIR}/distribution.json" >"${TMP_DIR}/created.json"
+    DIST_ID="$(jq -r '.Distribution.Id' "${TMP_DIR}/created.json")"
+  fi
+  aws --profile "$AWS_PROFILE" --region "$AWS_REGION" cloudfront wait distribution-deployed --id "$DIST_ID"
+fi
+
+aws --profile "$AWS_PROFILE" --region "$AWS_REGION" cloudfront get-distribution --id "$DIST_ID" --output json >"${TMP_DIR}/distribution-state.json"
+jq -e --arg origin "$ORIGIN_HOST" --arg policy "$ORIGIN_REQUEST_POLICY_ID" --arg cache "$CACHE_POLICY_ID" '
+  .Distribution.Status == "Deployed" and .Distribution.DistributionConfig.Enabled == true and
+  .Distribution.DistributionConfig.Origins.Quantity == 1 and
+  .Distribution.DistributionConfig.Origins.Items[0].DomainName == $origin and
+  .Distribution.DistributionConfig.Origins.Items[0].CustomOriginConfig.HTTPSPort == 8443 and
+  .Distribution.DistributionConfig.Origins.Items[0].CustomOriginConfig.OriginProtocolPolicy == "https-only" and
+  .Distribution.DistributionConfig.Origins.Items[0].CustomHeaders.Quantity == 1 and
+  .Distribution.DistributionConfig.Origins.Items[0].CustomHeaders.Items[0].HeaderName == "X-OpenRung-Origin-Token" and
+  (.Distribution.DistributionConfig.Origins.Items[0].CustomHeaders.Items[0].HeaderValue | length) >= 32 and
+  (.Distribution.DistributionConfig.Origins.Items[0].CustomHeaders.Items[0].HeaderValue | length) <= 512 and
+  .Distribution.DistributionConfig.Origins.Items[0].ConnectionAttempts == 1 and
+  .Distribution.DistributionConfig.Origins.Items[0].ConnectionTimeout == 5 and
+  .Distribution.DistributionConfig.DefaultCacheBehavior.ViewerProtocolPolicy == "https-only" and
+  .Distribution.DistributionConfig.DefaultCacheBehavior.AllowedMethods.Items == ["HEAD","GET"] and
+  .Distribution.DistributionConfig.DefaultCacheBehavior.CachePolicyId == $cache and
+  .Distribution.DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId == $policy and
+  .Distribution.DistributionConfig.CacheBehaviors.Quantity == 0 and
+  .Distribution.DistributionConfig.Logging.Enabled == false
+' "${TMP_DIR}/distribution-state.json" >/dev/null || die "distribution failed the structural audit"
+
+jq -n \
+  --arg relay "$RELAY_NAME" --arg origin "$ORIGIN_HOST" --arg front "$FRONT_ID" \
+  --arg id "$(jq -r '.Distribution.Id' "${TMP_DIR}/distribution-state.json")" \
+  --arg domain "$(jq -r '.Distribution.DomainName' "${TMP_DIR}/distribution-state.json")" \
+  '{relay:$relay,origin_host:$origin,front_id:$front,distribution_id:$id,distribution_domain:$domain,url:("wss://"+$domain+"/api/v1/wss-bridge")}' \
+  >"${TMP_DIR}/public-state.json"
+if [[ -n "$STATE_FILE" ]]; then
+  install -m 0600 "${TMP_DIR}/public-state.json" "$STATE_FILE"
+fi
+jq . "${TMP_DIR}/public-state.json"

--- a/deploy/relay/aws/deploy-wss-origin-firewall-sync.sh
+++ b/deploy/relay/aws/deploy-wss-origin-firewall-sync.sh
@@ -122,12 +122,12 @@ if aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda get-function -
   aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda wait function-updated-v2 --function-name "$FUNCTION_NAME"
   aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda update-function-configuration \
     --function-name "$FUNCTION_NAME" --runtime python3.13 --handler lambda_function.lambda_handler \
-    --timeout 30 --memory-size 128 \
+    --timeout 120 --memory-size 128 \
     --environment "file://${TMP_DIR}/environment.json" >/dev/null
 else
   aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda create-function \
     --function-name "$FUNCTION_NAME" --runtime python3.13 --handler lambda_function.lambda_handler \
-    --role "$ROLE_ARN" --timeout 30 --memory-size 128 \
+    --role "$ROLE_ARN" --timeout 120 --memory-size 128 \
     --environment "file://${TMP_DIR}/environment.json" \
     --zip-file "fileb://${TMP_DIR}/function.zip" >/dev/null
 fi
@@ -164,8 +164,18 @@ if [[ "${OPENRUNG_SUBSCRIBE_IP_SPACE:-0}" == 1 ]]; then
     --topic-arn "$SNS_TOPIC" --protocol lambda --notification-endpoint "$FUNCTION_ARN" >/dev/null
 fi
 
-aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda invoke \
-  --function-name "$FUNCTION_NAME" "${TMP_DIR}/invoke.json" >/dev/null
-jq -e '.ok == true and .target_count == $count' --argjson count "$TARGET_COUNT" "${TMP_DIR}/invoke.json" >/dev/null \
-  || die "post-deployment synchronization failed"
+SYNCED=0
+for attempt in $(seq 1 6); do
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda invoke \
+    --function-name "$FUNCTION_NAME" --cli-read-timeout 150 "${TMP_DIR}/invoke.json" >/dev/null
+  if jq -e '.ok == true and .target_count == $count' --argjson count "$TARGET_COUNT" "${TMP_DIR}/invoke.json" >/dev/null; then
+    SYNCED=1
+    break
+  fi
+  jq -e '.ok == true and .skipped == true' "${TMP_DIR}/invoke.json" >/dev/null \
+    || die "post-deployment synchronization failed"
+  [[ "$attempt" -lt 6 ]] || break
+  sleep 10
+done
+[[ "$SYNCED" == 1 ]] || die "post-deployment synchronization remained lease-held"
 printf 'deployed targets=%s function=%s\n' "$TARGET_COUNT" "$FUNCTION_NAME"

--- a/deploy/relay/aws/deploy-wss-origin-firewall-sync.sh
+++ b/deploy/relay/aws/deploy-wss-origin-firewall-sync.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Deploy the aggregate-only CloudFront origin-facing Lightsail firewall sync.
+#
+# Usage:
+#   deploy-wss-origin-firewall-sync.sh check [targets.json]
+#   deploy-wss-origin-firewall-sync.sh apply [targets.json]
+#
+# The target inventory is public configuration and carries only instance names
+# and regions: the exact instance ARNs are resolved from the live account at
+# apply time so no account or instance identifier is checked in.  IAM grants
+# PutInstancePublicPorts only on those resolved ARNs.  GetInstancePortStates
+# must remain Resource "*" because Lightsail does not support resource-level
+# authorization for that read operation.
+set -euo pipefail
+{ set +x; } 2>/dev/null
+
+MODE="${1:-check}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGETS_FILE="${2:-${HERE}/wss-origin-targets.json}"
+AWS_PROFILE="${OPENRUNG_AWS_PROFILE:-default}"
+CONTROL_REGION="${OPENRUNG_AWS_CONTROL_REGION:-us-east-1}"
+FUNCTION_NAME="${OPENRUNG_WSS_FIREWALL_FUNCTION:-openrung-witty-salmon-cloudfront-origin-sync}"
+ROLE_NAME="${OPENRUNG_WSS_FIREWALL_ROLE:-openrung-witty-salmon-cf-origin-sync-role}"
+LOCK_TABLE="${OPENRUNG_WSS_FIREWALL_LOCK_TABLE:-openrung-wss-firewall-sync-lock}"
+DAILY_RULE="${OPENRUNG_WSS_FIREWALL_DAILY_RULE:-openrung-witty-salmon-cf-origin-sync-daily}"
+SNS_TOPIC="arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+command -v aws >/dev/null || die "aws CLI is required"
+command -v jq >/dev/null || die "jq is required"
+command -v zip >/dev/null || die "zip is required"
+[[ "$MODE" == check || "$MODE" == apply ]] || die "mode must be check or apply"
+[[ -f "$TARGETS_FILE" ]] || die "target inventory not found: ${TARGETS_FILE}"
+
+jq -e '
+  type == "array" and length > 0 and length <= 100 and
+  all(.[];
+    (keys | sort) == ["instance","region"] and
+    (.instance | test("^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")) and
+    (.region | test("^[a-z]{2}(-gov)?-[a-z]+-[0-9]$"))
+  ) and
+  ([.[] | (.region + "/" + .instance)] | unique | length) == length
+' "$TARGETS_FILE" >/dev/null || die "target inventory is invalid or contains duplicates"
+
+TARGETS_JSON="$(jq -c '[.[] | {region,instance}]' "$TARGETS_FILE")"
+TARGET_COUNT="$(jq 'length' "$TARGETS_FILE")"
+printf 'validated targets=%s function=%s control_region=%s\n' "$TARGET_COUNT" "$FUNCTION_NAME" "$CONTROL_REGION"
+[[ "$MODE" == apply ]] || exit 0
+
+ACCOUNT_ID="$(aws --profile "$AWS_PROFILE" sts get-caller-identity --query Account --output text)"
+[[ "$ACCOUNT_ID" =~ ^[0-9]{12}$ ]] || die "AWS account ID is invalid"
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+TABLE_ARN="arn:aws:dynamodb:${CONTROL_REGION}:${ACCOUNT_ID}:table/${LOCK_TABLE}"
+LOG_ARN="arn:aws:logs:${CONTROL_REGION}:${ACCOUNT_ID}:log-group:/aws/lambda/${FUNCTION_NAME}:*"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+umask 077
+
+# Resolve each target's instance ARN from the live account so the checked-in
+# inventory never contains the account ID or instance identifiers.
+printf '[]\n' >"${TMP_DIR}/target-arns.json"
+while IFS=$'\t' read -r region instance; do
+  INSTANCE_ARN="$(aws --profile "$AWS_PROFILE" --region "$region" lightsail get-instance \
+    --instance-name "$instance" --query 'instance.arn' --output text)" \
+    || die "could not resolve the instance ARN for ${region}/${instance}"
+  [[ "$INSTANCE_ARN" =~ ^arn:aws:lightsail:${region}:${ACCOUNT_ID}:Instance/[A-Za-z0-9-]+$ ]] \
+    || die "resolved instance ARN for ${region}/${instance} is invalid"
+  jq --arg arn "$INSTANCE_ARN" '. + [$arn]' "${TMP_DIR}/target-arns.json" >"${TMP_DIR}/target-arns.json.tmp"
+  mv "${TMP_DIR}/target-arns.json.tmp" "${TMP_DIR}/target-arns.json"
+done < <(jq -r '.[] | [.region, .instance] | @tsv' "$TARGETS_FILE")
+jq -e --argjson count "$TARGET_COUNT" 'length == $count and (unique | length) == $count' \
+  "${TMP_DIR}/target-arns.json" >/dev/null || die "resolved instance ARNs are incomplete or not unique"
+printf 'resolved instance arns=%s\n' "$TARGET_COUNT"
+
+jq -n '{Version:"2012-10-17",Statement:[{Effect:"Allow",Principal:{Service:"lambda.amazonaws.com"},Action:"sts:AssumeRole"}]}' >"${TMP_DIR}/trust.json"
+jq -n \
+  --arg table "$TABLE_ARN" \
+  --arg logs "$LOG_ARN" \
+  --slurpfile arns "${TMP_DIR}/target-arns.json" '
+  {
+    Version:"2012-10-17",
+    Statement:[
+      {Sid:"ReadFirewallState",Effect:"Allow",Action:"lightsail:GetInstancePortStates",Resource:"*"},
+      {Sid:"WriteExactRelayFirewalls",Effect:"Allow",Action:"lightsail:PutInstancePublicPorts",Resource:$arns[0]},
+      {Sid:"SerializeSync",Effect:"Allow",Action:["dynamodb:PutItem","dynamodb:DeleteItem"],Resource:$table},
+      {Sid:"WriteAggregateLogs",Effect:"Allow",Action:["logs:CreateLogStream","logs:PutLogEvents"],Resource:$logs}
+    ]
+  }' >"${TMP_DIR}/role-policy.json"
+jq -n --arg targets "$TARGETS_JSON" --arg table "$LOCK_TABLE" \
+  '{Variables:{TARGETS_JSON:$targets,LOCK_TABLE:$table}}' >"${TMP_DIR}/environment.json"
+
+if ! aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" dynamodb describe-table --table-name "$LOCK_TABLE" >/dev/null 2>&1; then
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" dynamodb create-table \
+    --table-name "$LOCK_TABLE" --billing-mode PAY_PER_REQUEST \
+    --attribute-definitions AttributeName=LockName,AttributeType=S \
+    --key-schema AttributeName=LockName,KeyType=HASH >/dev/null
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" dynamodb wait table-exists --table-name "$LOCK_TABLE"
+fi
+TTL_STATUS="$(aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" dynamodb describe-time-to-live \
+  --table-name "$LOCK_TABLE" --query TimeToLiveDescription.TimeToLiveStatus --output text)"
+if [[ "$TTL_STATUS" == DISABLED ]]; then
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" dynamodb update-time-to-live \
+    --table-name "$LOCK_TABLE" --time-to-live-specification Enabled=true,AttributeName=ExpiresAt >/dev/null
+elif [[ "$TTL_STATUS" != ENABLED && "$TTL_STATUS" != ENABLING ]]; then
+  die "unexpected DynamoDB TTL status: ${TTL_STATUS}"
+fi
+
+if ! aws --profile "$AWS_PROFILE" iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+  aws --profile "$AWS_PROFILE" iam create-role --role-name "$ROLE_NAME" \
+    --assume-role-policy-document "file://${TMP_DIR}/trust.json" >/dev/null
+fi
+aws --profile "$AWS_PROFILE" iam put-role-policy --role-name "$ROLE_NAME" \
+  --policy-name openrung-wss-origin-firewall-sync \
+  --policy-document "file://${TMP_DIR}/role-policy.json"
+
+(cd "${HERE}/wss_origin_firewall_sync" && zip -q -j "${TMP_DIR}/function.zip" lambda_function.py)
+if aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda get-function --function-name "$FUNCTION_NAME" >/dev/null 2>&1; then
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda update-function-code \
+    --function-name "$FUNCTION_NAME" --zip-file "fileb://${TMP_DIR}/function.zip" >/dev/null
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda wait function-updated-v2 --function-name "$FUNCTION_NAME"
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda update-function-configuration \
+    --function-name "$FUNCTION_NAME" --runtime python3.13 --handler lambda_function.lambda_handler \
+    --timeout 30 --memory-size 128 \
+    --environment "file://${TMP_DIR}/environment.json" >/dev/null
+else
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda create-function \
+    --function-name "$FUNCTION_NAME" --runtime python3.13 --handler lambda_function.lambda_handler \
+    --role "$ROLE_ARN" --timeout 30 --memory-size 128 \
+    --environment "file://${TMP_DIR}/environment.json" \
+    --zip-file "fileb://${TMP_DIR}/function.zip" >/dev/null
+fi
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda wait function-updated-v2 --function-name "$FUNCTION_NAME"
+
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" logs create-log-group \
+  --log-group-name "/aws/lambda/${FUNCTION_NAME}" >/dev/null 2>&1 || true
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" logs put-retention-policy \
+  --log-group-name "/aws/lambda/${FUNCTION_NAME}" --retention-in-days 14
+
+RULE_ARN="$(aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" events put-rule \
+  --name "$DAILY_RULE" --schedule-expression 'rate(1 day)' --state ENABLED --query RuleArn --output text)"
+FUNCTION_ARN="$(aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda get-function-configuration \
+  --function-name "$FUNCTION_NAME" --query FunctionArn --output text)"
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" events put-targets \
+  --rule "$DAILY_RULE" --targets "Id=firewall-sync,Arn=${FUNCTION_ARN}" >/dev/null
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda add-permission \
+  --function-name "$FUNCTION_NAME" --statement-id AllowDailyFirewallSync \
+  --action lambda:InvokeFunction --principal events.amazonaws.com --source-arn "$RULE_ARN" >/dev/null 2>&1 || true
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda add-permission \
+  --function-name "$FUNCTION_NAME" --statement-id AllowAWSIPSpaceChanged \
+  --action lambda:InvokeFunction --principal sns.amazonaws.com --source-arn "$SNS_TOPIC" >/dev/null 2>&1 || true
+
+for metric in Errors Throttles; do
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" cloudwatch put-metric-alarm \
+    --alarm-name "OpenRung-WSS-Origin-Sync-${metric}" \
+    --namespace AWS/Lambda --metric-name "$metric" --dimensions "Name=FunctionName,Value=${FUNCTION_NAME}" \
+    --statistic Sum --period 300 --evaluation-periods 1 --datapoints-to-alarm 1 \
+    --threshold 0 --comparison-operator GreaterThanThreshold --treat-missing-data notBreaching
+done
+
+if [[ "${OPENRUNG_SUBSCRIBE_IP_SPACE:-0}" == 1 ]]; then
+  aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" sns subscribe \
+    --topic-arn "$SNS_TOPIC" --protocol lambda --notification-endpoint "$FUNCTION_ARN" >/dev/null
+fi
+
+aws --profile "$AWS_PROFILE" --region "$CONTROL_REGION" lambda invoke \
+  --function-name "$FUNCTION_NAME" "${TMP_DIR}/invoke.json" >/dev/null
+jq -e '.ok == true and .target_count == $count' --argjson count "$TARGET_COUNT" "${TMP_DIR}/invoke.json" >/dev/null \
+  || die "post-deployment synchronization failed"
+printf 'deployed targets=%s function=%s\n' "$TARGET_COUNT" "$FUNCTION_NAME"

--- a/deploy/relay/aws/wss-fronts.json
+++ b/deploy/relay/aws/wss-fronts.json
@@ -25,5 +25,86 @@
     "distribution_id": "EUR0ML96FEMWU",
     "distribution_domain": "d2ruumwujr6ln0.cloudfront.net",
     "url": "wss://d2ruumwujr6ln0.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "noble-pebble",
+    "relay_id": "relay_1618b1b2866dc23e235e7beee0e3e0df",
+    "origin_host": "noble-pebble-origin.openrung.org",
+    "front_id": "noble-pebble-cf-a",
+    "distribution_id": "EI2CKOQAGGTNT",
+    "distribution_domain": "d1ojfh7p5a3j3i.cloudfront.net",
+    "url": "wss://d1ojfh7p5a3j3i.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "swift-harbor",
+    "relay_id": "relay_931b8ac564cd1a59425c0f9c3af8d039",
+    "origin_host": "swift-harbor-origin.openrung.org",
+    "front_id": "swift-harbor-cf-a",
+    "distribution_id": "E3OGTDZD57XEHJ",
+    "distribution_domain": "d16l8ib5ki8pgm.cloudfront.net",
+    "url": "wss://d16l8ib5ki8pgm.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "silly-lemur",
+    "relay_id": "relay_a14eb0d63b2955b301ed4c3a44a50ee6",
+    "origin_host": "silly-lemur-origin.openrung.org",
+    "front_id": "silly-lemur-cf-a",
+    "distribution_id": "E2A6UAATC7QMRL",
+    "distribution_domain": "d246niwuqj9ptm.cloudfront.net",
+    "url": "wss://d246niwuqj9ptm.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "zesty-tapir",
+    "relay_id": "relay_96af4ac177d8125588ee5fb36c484f6a",
+    "origin_host": "zesty-tapir-origin.openrung.org",
+    "front_id": "zesty-tapir-cf-a",
+    "distribution_id": "E3N7SXFVGB1WO5",
+    "distribution_domain": "d31wn3la53sowp.cloudfront.net",
+    "url": "wss://d31wn3la53sowp.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "sturdy-otter",
+    "relay_id": "relay_7433e9b74deb6ecab7b37b173ad0ed61",
+    "origin_host": "sturdy-otter-origin.openrung.org",
+    "front_id": "sturdy-otter-cf-a",
+    "distribution_id": "E1ZMBIUASJU99Q",
+    "distribution_domain": "dcqyqtg459acp.cloudfront.net",
+    "url": "wss://dcqyqtg459acp.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "cosmic-otter",
+    "relay_id": "relay_0c361e82219f315f8a8da6345854ac0f",
+    "origin_host": "cosmic-otter-origin.openrung.org",
+    "front_id": "cosmic-otter-cf-a",
+    "distribution_id": "E1ZAELEJSCOE59",
+    "distribution_domain": "d2r3j5fc0odli5.cloudfront.net",
+    "url": "wss://d2r3j5fc0odli5.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "grumpy-lantern",
+    "relay_id": "relay_c2e15212f3acf4d0c1f83fca18f646a9",
+    "origin_host": "grumpy-lantern-origin.openrung.org",
+    "front_id": "grumpy-lantern-cf-a",
+    "distribution_id": "E144J9KUZ7LZOJ",
+    "distribution_domain": "d176nwbfbkk114.cloudfront.net",
+    "url": "wss://d176nwbfbkk114.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "lucky-harbor",
+    "relay_id": "relay_a71d67222491c7fa45471003d275c66b",
+    "origin_host": "lucky-harbor-origin.openrung.org",
+    "front_id": "lucky-harbor-cf-a",
+    "distribution_id": "E3TQQG5F41MTSV",
+    "distribution_domain": "d3nm9rb28zt5wx.cloudfront.net",
+    "url": "wss://d3nm9rb28zt5wx.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "sleepy-salmon",
+    "relay_id": "relay_0e66a951e9775ff14ace7bff7eaa3645",
+    "origin_host": "sleepy-salmon-origin.openrung.org",
+    "front_id": "sleepy-salmon-cf-a",
+    "distribution_id": "E3V0KQJGUQK84O",
+    "distribution_domain": "dqlcgxhsgcgub.cloudfront.net",
+    "url": "wss://dqlcgxhsgcgub.cloudfront.net/api/v1/wss-bridge"
   }
 ]

--- a/deploy/relay/aws/wss-fronts.json
+++ b/deploy/relay/aws/wss-fronts.json
@@ -1,0 +1,29 @@
+[
+  {
+    "relay": "witty-salmon",
+    "relay_id": "relay_a986b909a0bdcf85fe2f49e464c9ba07",
+    "origin_host": "witty-salmon-origin.openrung.org",
+    "front_id": "witty-salmon-cf-a",
+    "distribution_id": "E1CPABNGYUNWJA",
+    "distribution_domain": "d1g2q5hgh6r0dw.cloudfront.net",
+    "url": "wss://d1g2q5hgh6r0dw.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "quiet-meadow",
+    "relay_id": "relay_513d3265d3a7580e07cd51c24049a820",
+    "origin_host": "quiet-meadow-origin.openrung.org",
+    "front_id": "quiet-meadow-cf-a",
+    "distribution_id": "E2LQ3YA4RYUJ1D",
+    "distribution_domain": "d2ccasa6pyf0ym.cloudfront.net",
+    "url": "wss://d2ccasa6pyf0ym.cloudfront.net/api/v1/wss-bridge"
+  },
+  {
+    "relay": "witty-otter",
+    "relay_id": "relay_2b33aaa02db7b6c65e7b7b55341edfbc",
+    "origin_host": "witty-otter-origin.openrung.org",
+    "front_id": "witty-otter-cf-a",
+    "distribution_id": "EUR0ML96FEMWU",
+    "distribution_domain": "d2ruumwujr6ln0.cloudfront.net",
+    "url": "wss://d2ruumwujr6ln0.cloudfront.net/api/v1/wss-bridge"
+  }
+]

--- a/deploy/relay/aws/wss-origin-targets.json
+++ b/deploy/relay/aws/wss-origin-targets.json
@@ -10,5 +10,37 @@
   {
     "instance": "witty-otter",
     "region": "ap-south-1"
+  },
+  {
+    "instance": "noble-pebble",
+    "region": "eu-north-1"
+  },
+  {
+    "instance": "swift-harbor",
+    "region": "ap-southeast-1"
+  },
+  {
+    "instance": "silly-lemur",
+    "region": "ap-southeast-1"
+  },
+  {
+    "instance": "zesty-tapir",
+    "region": "ap-east-1"
+  },
+  {
+    "instance": "sturdy-otter",
+    "region": "ap-northeast-2"
+  },
+  {
+    "instance": "grumpy-lantern",
+    "region": "ap-southeast-3"
+  },
+  {
+    "instance": "lucky-harbor",
+    "region": "sa-east-1"
+  },
+  {
+    "instance": "sleepy-salmon",
+    "region": "ap-southeast-2"
   }
 ]

--- a/deploy/relay/aws/wss-origin-targets.json
+++ b/deploy/relay/aws/wss-origin-targets.json
@@ -1,0 +1,14 @@
+[
+  {
+    "instance": "witty-salmon",
+    "region": "us-east-1"
+  },
+  {
+    "instance": "quiet-meadow",
+    "region": "eu-central-1"
+  },
+  {
+    "instance": "witty-otter",
+    "region": "ap-south-1"
+  }
+]

--- a/deploy/relay/aws/wss_origin_firewall_sync/lambda_function.py
+++ b/deploy/relay/aws/wss_origin_firewall_sync/lambda_function.py
@@ -91,6 +91,11 @@ def _notification_sync_token(event: Any) -> int | None:
     raise ValueError("SNS message contains an invalid sync token")
 
 
+def _prefix_sort_key(value: str) -> tuple[int, int]:
+    network = ipaddress.ip_network(value)
+    return int(network.network_address), network.prefixlen
+
+
 def _download_prefixes(
     opener: Callable[..., Any] = urllib.request.urlopen,
 ) -> tuple[list[str], int]:
@@ -135,7 +140,7 @@ def _download_prefixes(
         if network.prefixlen == 0:
             raise ValueError("origin-facing range must not be world-open")
         prefixes.add(raw_prefix)
-    result = sorted(prefixes, key=lambda value: int(ipaddress.ip_network(value).network_address))
+    result = sorted(prefixes, key=_prefix_sort_key)
     if not result or len(result) > MAX_PREFIXES:
         raise ValueError(f"origin-facing IPv4 range count must be 1..{MAX_PREFIXES}")
     return result, int(token)
@@ -159,7 +164,7 @@ def _rule(prefixes: list[str]) -> dict[str, Any]:
 
 
 def _sort_prefixes(prefixes: Any) -> list[str]:
-    return sorted(set(prefixes), key=lambda value: int(ipaddress.ip_network(value).network_address))
+    return sorted(set(prefixes), key=_prefix_sort_key)
 
 
 def _replace_origin_rule(port_infos: list[dict[str, Any]], replacement: dict[str, Any]) -> list[dict[str, Any]]:

--- a/deploy/relay/aws/wss_origin_firewall_sync/lambda_function.py
+++ b/deploy/relay/aws/wss_origin_firewall_sync/lambda_function.py
@@ -28,7 +28,10 @@ LOCK_NAME = "cloudfront-origin-firewall-sync"
 MAX_FEED_BYTES = 5 << 20
 MAX_PREFIXES = 60
 MAX_TARGETS = 100
-LOCK_SECONDS = 120
+# The provider calls span every configured region sequentially. Keep the lease
+# longer than the Lambda timeout so a timed-out invocation remains fail-closed
+# and cannot overlap its successor while AWS finishes tearing it down.
+LOCK_SECONDS = 180
 NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
 REGION_RE = re.compile(r"^[a-z]{2}(?:-gov)?-[a-z]+-\d$")
 

--- a/deploy/relay/aws/wss_origin_firewall_sync/lambda_function.py
+++ b/deploy/relay/aws/wss_origin_firewall_sync/lambda_function.py
@@ -1,0 +1,293 @@
+"""Keep relay-local Lightsail WSS origins restricted to CloudFront.
+
+The function intentionally logs only aggregate, label-free counters.  Target
+names and regions are configuration, never log fields.  A single invocation
+updates every configured relay with add-before-remove semantics and preserves
+the last known-good firewall on feed or validation failure.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import os
+import re
+import time
+import urllib.request
+import uuid
+from typing import Any, Callable
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+AWS_IP_RANGES_URL = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+ORIGIN_SERVICE = "CLOUDFRONT_ORIGIN_FACING"
+LOCK_NAME = "cloudfront-origin-firewall-sync"
+MAX_FEED_BYTES = 5 << 20
+MAX_PREFIXES = 60
+MAX_TARGETS = 100
+LOCK_SECONDS = 120
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+REGION_RE = re.compile(r"^[a-z]{2}(?:-gov)?-[a-z]+-\d$")
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _targets(raw: str) -> list[dict[str, str]]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("TARGETS_JSON must be valid JSON") from exc
+    if not isinstance(value, list) or not value or len(value) > MAX_TARGETS:
+        raise ValueError(f"TARGETS_JSON must contain 1..{MAX_TARGETS} targets")
+    result: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value:
+        if not isinstance(item, dict) or set(item) != {"region", "instance"}:
+            raise ValueError("each target must contain only region and instance")
+        region, instance = item.get("region"), item.get("instance")
+        if not isinstance(region, str) or not REGION_RE.fullmatch(region):
+            raise ValueError("target region is invalid")
+        if not isinstance(instance, str) or not NAME_RE.fullmatch(instance):
+            raise ValueError("target instance is invalid")
+        key = (region, instance)
+        if key in seen:
+            raise ValueError("TARGETS_JSON contains a duplicate target")
+        seen.add(key)
+        result.append({"region": region, "instance": instance})
+    return result
+
+
+def _notification_sync_token(event: Any) -> int | None:
+    """Validate an AWS IP-space SNS event without trusting a supplied URL."""
+    if not isinstance(event, dict) or "Records" not in event:
+        return None
+    records = event.get("Records")
+    if not isinstance(records, list) or len(records) != 1:
+        raise ValueError("SNS invocation must contain exactly one record")
+    record = records[0]
+    if not isinstance(record, dict) or record.get("EventSource") != "aws:sns":
+        raise ValueError("unexpected event source")
+    message = record.get("Sns", {}).get("Message")
+    if not isinstance(message, str):
+        raise ValueError("SNS message is missing")
+    try:
+        payload = json.loads(message)
+    except json.JSONDecodeError as exc:
+        raise ValueError("SNS message is not valid JSON") from exc
+    if payload.get("url") != AWS_IP_RANGES_URL:
+        raise ValueError("SNS message contains an unexpected feed URL")
+    token = payload.get("syncToken")
+    if isinstance(token, str) and token.isdigit():
+        return int(token)
+    if isinstance(token, int) and token >= 0:
+        return token
+    raise ValueError("SNS message contains an invalid sync token")
+
+
+def _download_prefixes(
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> tuple[list[str], int]:
+    request = urllib.request.Request(
+        AWS_IP_RANGES_URL,
+        headers={"User-Agent": "openrung-cloudfront-origin-sync/1"},
+    )
+    with opener(request, timeout=10) as response:
+        status = getattr(response, "status", 200)
+        if status != 200:
+            raise ValueError("AWS IP range feed returned a non-200 response")
+        length = response.headers.get("Content-Length")
+        if length is not None and int(length) > MAX_FEED_BYTES:
+            raise ValueError("AWS IP range feed exceeds the size bound")
+        raw = response.read(MAX_FEED_BYTES + 1)
+    if len(raw) > MAX_FEED_BYTES:
+        raise ValueError("AWS IP range feed exceeds the size bound")
+    try:
+        feed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("AWS IP range feed is not valid JSON") from exc
+    if not isinstance(feed, dict) or not isinstance(feed.get("prefixes"), list):
+        raise ValueError("AWS IP range feed has an invalid schema")
+    token = feed.get("syncToken")
+    if not isinstance(token, str) or not token.isdigit():
+        raise ValueError("AWS IP range feed has an invalid sync token")
+    prefixes: set[str] = set()
+    for item in feed["prefixes"]:
+        if not isinstance(item, dict):
+            raise ValueError("AWS IP range feed contains an invalid prefix item")
+        if item.get("service") != ORIGIN_SERVICE:
+            continue
+        raw_prefix = item.get("ip_prefix")
+        if not isinstance(raw_prefix, str):
+            raise ValueError("origin-facing range has no IPv4 prefix")
+        try:
+            network = ipaddress.ip_network(raw_prefix, strict=True)
+        except ValueError as exc:
+            raise ValueError("origin-facing range is not canonical") from exc
+        if network.version != 4 or str(network) != raw_prefix:
+            raise ValueError("origin-facing range is not canonical IPv4")
+        if network.prefixlen == 0:
+            raise ValueError("origin-facing range must not be world-open")
+        prefixes.add(raw_prefix)
+    result = sorted(prefixes, key=lambda value: int(ipaddress.ip_network(value).network_address))
+    if not result or len(result) > MAX_PREFIXES:
+        raise ValueError(f"origin-facing IPv4 range count must be 1..{MAX_PREFIXES}")
+    return result, int(token)
+
+
+def _port_info(state: dict[str, Any]) -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "fromPort": state["fromPort"],
+        "toPort": state["toPort"],
+        "protocol": state["protocol"],
+    }
+    for key in ("cidrs", "ipv6Cidrs", "cidrListAliases"):
+        values = state.get(key)
+        if values:
+            info[key] = sorted(set(values))
+    return info
+
+
+def _rule(prefixes: list[str]) -> dict[str, Any]:
+    return {"fromPort": 8443, "toPort": 8443, "protocol": "tcp", "cidrs": prefixes}
+
+
+def _sort_prefixes(prefixes: Any) -> list[str]:
+    return sorted(set(prefixes), key=lambda value: int(ipaddress.ip_network(value).network_address))
+
+
+def _replace_origin_rule(port_infos: list[dict[str, Any]], replacement: dict[str, Any]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    replaced = False
+    for info in port_infos:
+        if info["fromPort"] == 8443 or info["toPort"] == 8443:
+            if info["fromPort"] != 8443 or info["toPort"] != 8443 or info["protocol"] != "tcp" or replaced:
+                raise ValueError("port 8443 has an ambiguous firewall configuration")
+            if info.get("ipv6Cidrs") or info.get("cidrListAliases"):
+                raise ValueError("port 8443 must be IPv4 CIDR-only")
+            for prefix in info.get("cidrs", []):
+                network = ipaddress.ip_network(prefix, strict=True)
+                if network.version != 4 or network.prefixlen == 0:
+                    raise ValueError("port 8443 contains an unsafe CIDR")
+            result.append(replacement)
+            replaced = True
+        else:
+            result.append(info)
+    if not replaced:
+        result.append(replacement)
+    return sorted(result, key=lambda item: (item["fromPort"], item["toPort"], item["protocol"]))
+
+
+def _current(lightsail: Any, instance: str) -> list[dict[str, Any]]:
+    response = lightsail.get_instance_port_states(instanceName=instance)
+    states = response.get("portStates")
+    if not isinstance(states, list):
+        raise ValueError("Lightsail returned invalid port state")
+    return [_port_info(item) for item in states if item.get("state", "open") == "open"]
+
+
+def _origin_prefixes(port_infos: list[dict[str, Any]]) -> list[str] | None:
+    matches = [item for item in port_infos if item["fromPort"] <= 8443 <= item["toPort"]]
+    if not matches:
+        return None
+    if len(matches) != 1 or matches[0]["fromPort"] != 8443 or matches[0]["toPort"] != 8443 or matches[0]["protocol"] != "tcp":
+        raise ValueError("port 8443 has an ambiguous firewall configuration")
+    item = matches[0]
+    if item.get("ipv6Cidrs") or item.get("cidrListAliases"):
+        raise ValueError("port 8443 must be IPv4 CIDR-only")
+    prefixes = item.get("cidrs", [])
+    for prefix in prefixes:
+        network = ipaddress.ip_network(prefix, strict=True)
+        if network.version != 4 or network.prefixlen == 0:
+            raise ValueError("port 8443 contains an unsafe CIDR")
+    return _sort_prefixes(prefixes)
+
+
+def _put_and_verify(lightsail: Any, instance: str, infos: list[dict[str, Any]], expected: list[str]) -> None:
+    lightsail.put_instance_public_ports(instanceName=instance, portInfos=infos)
+    observed = _origin_prefixes(_current(lightsail, instance))
+    if observed != _sort_prefixes(expected):
+        raise RuntimeError("Lightsail did not converge to the requested port 8443 rule")
+
+
+def _sync_target(lightsail: Any, instance: str, desired: list[str]) -> bool:
+    current_infos = _current(lightsail, instance)
+    current_prefixes = _origin_prefixes(current_infos)
+    if current_prefixes == desired:
+        return False
+    union = _sort_prefixes(set(current_prefixes or []).union(desired))
+    if len(union) > MAX_PREFIXES:
+        raise ValueError("add-before-remove union exceeds the provider source-address quota")
+    union_infos = _replace_origin_rule(current_infos, _rule(union))
+    _put_and_verify(lightsail, instance, union_infos, union)
+    if union != desired:
+        final_infos = _replace_origin_rule(union_infos, _rule(desired))
+        _put_and_verify(lightsail, instance, final_infos, desired)
+    return True
+
+
+def _acquire_lock(table: Any, owner: str, now: int) -> bool:
+    try:
+        table.put_item(
+            Item={"LockName": LOCK_NAME, "LeaseOwner": owner, "ExpiresAt": now + LOCK_SECONDS},
+            ConditionExpression="attribute_not_exists(LockName) OR ExpiresAt < :now",
+            ExpressionAttributeValues={":now": now},
+        )
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _release_lock(table: Any, owner: str) -> None:
+    table.delete_item(
+        Key={"LockName": LOCK_NAME},
+        ConditionExpression="#lease_owner = :owner",
+        ExpressionAttributeNames={"#lease_owner": "LeaseOwner"},
+        ExpressionAttributeValues={":owner": owner},
+    )
+
+
+def lambda_handler(event: Any, context: Any) -> dict[str, Any]:
+    targets = _targets(os.environ.get("TARGETS_JSON", ""))
+    notification_token = _notification_sync_token(event)
+    prefixes, sync_token = _download_prefixes()
+    if notification_token is not None and notification_token > sync_token:
+        raise ValueError("notification sync token is newer than the downloaded feed")
+
+    table_name = os.environ.get("LOCK_TABLE", "")
+    if not NAME_RE.fullmatch(table_name):
+        raise ValueError("LOCK_TABLE is invalid")
+    table = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION", "us-east-1")).Table(table_name)
+    owner = getattr(context, "aws_request_id", None) or str(uuid.uuid4())
+    now = int(time.time())
+    if not _acquire_lock(table, owner, now):
+        logger.info(json.dumps({"event": "sync_skipped", "reason": "lease_held"}, separators=(",", ":")))
+        return {"ok": True, "skipped": True}
+
+    changed = 0
+    try:
+        for target in targets:
+            client = boto3.client("lightsail", region_name=target["region"])
+            if _sync_target(client, target["instance"], prefixes):
+                changed += 1
+        logger.info(json.dumps({
+            "event": "sync_complete",
+            "target_count": len(targets),
+            "changed_count": changed,
+            "prefix_count": len(prefixes),
+            "sync_token": sync_token,
+        }, separators=(",", ":")))
+        return {
+            "ok": True,
+            "target_count": len(targets),
+            "changed_count": changed,
+            "prefix_count": len(prefixes),
+            "sync_token": sync_token,
+        }
+    finally:
+        _release_lock(table, owner)

--- a/deploy/relay/aws/wss_origin_firewall_sync/test_lambda_function.py
+++ b/deploy/relay/aws/wss_origin_firewall_sync/test_lambda_function.py
@@ -1,0 +1,113 @@
+import io
+import json
+import sys
+import types
+import unittest
+from unittest import mock
+
+try:
+    import boto3  # noqa: F401
+except ModuleNotFoundError:
+    boto3_stub = types.ModuleType("boto3")
+    boto3_stub.client = mock.Mock()
+    boto3_stub.resource = mock.Mock()
+    botocore_stub = types.ModuleType("botocore")
+    exceptions_stub = types.ModuleType("botocore.exceptions")
+
+    class StubClientError(Exception):
+        def __init__(self, response=None, operation_name=""):
+            super().__init__(operation_name)
+            self.response = response or {}
+
+    exceptions_stub.ClientError = StubClientError
+    sys.modules["boto3"] = boto3_stub
+    sys.modules["botocore"] = botocore_stub
+    sys.modules["botocore.exceptions"] = exceptions_stub
+
+import lambda_function as sync
+
+
+class Response(io.BytesIO):
+    status = 200
+
+    def __init__(self, value):
+        super().__init__(value)
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+class FakeLightsail:
+    def __init__(self, states):
+        self.states = states
+        self.writes = []
+
+    def get_instance_port_states(self, instanceName):
+        return {"portStates": self.states}
+
+    def put_instance_public_ports(self, instanceName, portInfos):
+        self.writes.append(portInfos)
+        self.states = [dict(item, state="open") for item in portInfos]
+
+
+class FirewallSyncTest(unittest.TestCase):
+    def test_targets_are_strict_and_unique(self):
+        self.assertEqual(sync._targets('[{"region":"eu-central-1","instance":"relay-a"}]')[0]["instance"], "relay-a")
+        for raw in ("[]", '[{"region":"bad","instance":"relay-a"}]', '[{"region":"eu-central-1","instance":"relay-a","extra":1}]'):
+            with self.assertRaises(ValueError):
+                sync._targets(raw)
+
+    def test_feed_is_canonical_ipv4_origin_only(self):
+        feed = {"syncToken": "7", "prefixes": [
+            {"ip_prefix": "203.0.113.0/24", "service": sync.ORIGIN_SERVICE},
+            {"ip_prefix": "198.51.100.0/24", "service": "CLOUDFRONT"},
+        ]}
+        result, token = sync._download_prefixes(lambda *_args, **_kwargs: Response(json.dumps(feed).encode()))
+        self.assertEqual(result, ["203.0.113.0/24"])
+        self.assertEqual(token, 7)
+
+    def test_sync_adds_before_removing(self):
+        client = FakeLightsail([
+            {"fromPort": 443, "toPort": 443, "protocol": "tcp", "state": "open", "cidrs": ["0.0.0.0/0"]},
+            {"fromPort": 8443, "toPort": 8443, "protocol": "tcp", "state": "open", "cidrs": ["192.0.2.0/24"]},
+        ])
+        self.assertTrue(sync._sync_target(client, "relay-a", ["203.0.113.0/24"]))
+        self.assertEqual(len(client.writes), 2)
+        self.assertEqual(sync._origin_prefixes(client.writes[0]), ["192.0.2.0/24", "203.0.113.0/24"])
+        self.assertEqual(sync._origin_prefixes(client.writes[1]), ["203.0.113.0/24"])
+        self.assertEqual(client.writes[1][0]["cidrs"], ["0.0.0.0/0"])
+
+    def test_world_open_origin_is_rejected_without_write(self):
+        client = FakeLightsail([
+            {"fromPort": 8443, "toPort": 8443, "protocol": "tcp", "state": "open", "cidrs": ["0.0.0.0/0"]},
+        ])
+        with self.assertRaises(ValueError):
+            sync._sync_target(client, "relay-a", ["203.0.113.0/24"])
+        self.assertEqual(client.writes, [])
+
+    def test_unchanged_network_order_is_a_noop(self):
+        client = FakeLightsail([
+            {"fromPort": 8443, "toPort": 8443, "protocol": "tcp", "state": "open", "cidrs": [
+                "13.124.199.0/24", "3.172.0.0/18", "130.176.0.0/18"
+            ]},
+        ])
+        desired = ["3.172.0.0/18", "13.124.199.0/24", "130.176.0.0/18"]
+        self.assertFalse(sync._sync_target(client, "relay-a", desired))
+        self.assertEqual(client.writes, [])
+
+    def test_notification_url_is_exact(self):
+        event = {"Records": [{"EventSource": "aws:sns", "Sns": {"Message": json.dumps({
+            "url": sync.AWS_IP_RANGES_URL, "syncToken": "9"
+        })}}]}
+        self.assertEqual(sync._notification_sync_token(event), 9)
+        event["Records"][0]["Sns"]["Message"] = json.dumps({"url": "https://example.com/feed", "syncToken": "9"})
+        with self.assertRaises(ValueError):
+            sync._notification_sync_token(event)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/relay/aws/wss_origin_firewall_sync/test_lambda_function.py
+++ b/deploy/relay/aws/wss_origin_firewall_sync/test_lambda_function.py
@@ -70,6 +70,28 @@ class FirewallSyncTest(unittest.TestCase):
         self.assertEqual(result, ["203.0.113.0/24"])
         self.assertEqual(token, 7)
 
+    def test_prefix_sort_includes_prefix_length(self):
+        prefixes = ["3.172.0.0/22", "3.172.0.0/18", "13.124.199.0/24"]
+        expected = ["3.172.0.0/18", "3.172.0.0/22", "13.124.199.0/24"]
+        self.assertEqual(sync._sort_prefixes(prefixes), expected)
+
+        feed = {"syncToken": "8", "prefixes": [
+            {"ip_prefix": prefix, "service": sync.ORIGIN_SERVICE}
+            for prefix in prefixes
+        ]}
+        result, _ = sync._download_prefixes(lambda *_args, **_kwargs: Response(json.dumps(feed).encode()))
+        self.assertEqual(result, expected)
+
+        client = FakeLightsail([{
+            "fromPort": 8443,
+            "toPort": 8443,
+            "protocol": "tcp",
+            "state": "open",
+            "cidrs": list(reversed(expected)),
+        }])
+        self.assertFalse(sync._sync_target(client, "relay-a", expected))
+        self.assertEqual(client.writes, [])
+
     def test_sync_adds_before_removing(self):
         client = FakeLightsail([
             {"fromPort": 443, "toPort": 443, "protocol": "tcp", "state": "open", "cidrs": ["0.0.0.0/0"]},

--- a/deploy/relay/cloudfront-wss.md
+++ b/deploy/relay/cloudfront-wss.md
@@ -299,12 +299,23 @@ The synchronizer must:
 4. Alert and fail closed if the provider quota cannot hold the new set.
 5. Update IPv4 and IPv6 independently.
 
-As verified on 2026-07-21, the feed contained 45 IPv4 and 3 IPv6
+As verified on 2026-07-22, the feed contained 45 IPv4 and 3 IPv6
 `CLOUDFRONT_ORIGIN_FACING` ranges. That is an observation, not a guaranteed
 limit. Lightsail currently documents up to 60 source addresses per address
 family; see [Control instance traffic with firewalls in
 Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/understanding-firewall-and-port-mappings-in-amazon-lightsail.html).
 Keep origin IPv4-only unless IPv6 is operationally required.
+
+The checked-in Lambda synchronizer covers only the explicit Lightsail targets
+in `wss-origin-targets.json`. A non-Lightsail relay, such as a Hetzner origin,
+must have a dedicated provider firewall with TCP `8443` restricted to the same
+official IPv4 set. Do not attach the origin to a shared volunteer firewall.
+Refresh that dedicated rule set whenever `ip-ranges.json` changes, adding new
+ranges before removing retired ranges, and repeat the unauthenticated-origin
+and full WSS probes before considering the refresh complete. Until provider
+automation is installed, this is a manual operational obligation; stale rules
+fail closed and can make only that relay's WSS front unavailable, without
+affecting direct Reality on `443`.
 
 ## Quotas and capacity planning
 
@@ -374,10 +385,14 @@ AWS IP-range maintenance is shared control-plane automation:
   deploys the least-privilege Lambda and immediately converges every listed
   relay to the official `CLOUDFRONT_ORIGIN_FACING` IPv4 ranges on TCP `8443`.
   It preserves every unrelated port rule and updates add-before-remove.
-- `foundation-wss-host.sh` migrates one legacy Foundation relay to a pinned
-  image and stable identity, installs its own loopback sidecar, installs its
-  own Caddy TLS origin on `8443`, and audits the result. Secret files are
-  streamed over SSH stdin, must be mode `0600`, and are never command-line
+  The 120-second function bound and 180-second distributed lease allow a full
+  multi-region fleet pass while overlapping invocations remain serialized.
+- `foundation-wss-host.sh migrate` moves a legacy Foundation relay to a pinned
+  image and stable identity. `stabilize` handles a host that already has the
+  canonical environment file but lacks a persistent identity. Both paths keep
+  recoverable checkpoints. The same helper installs the relay's own loopback
+  sidecar and Caddy TLS origin on `8443`, then audits the result. Secret files
+  are streamed over SSH stdin, must be mode `0600`, and are never command-line
   arguments.
 - `cloudfront-wss-front.sh` creates or audits exactly one distribution whose
   only origin is that relay's origin hostname. The origin token comes from a
@@ -389,6 +404,23 @@ Do not put `OPENRUNG_WSS_FRONTS` in the relay environment until the complete
 matrix below passes for that exact distribution. Generate a temporary ticket
 key, add only its public key to the relay's overlapping verifier set, and keep
 its private seed on the operator workstation:
+
+Before changing the host, fetch its signed public descriptor and prove direct
+Reality end to end. Direct mode starts sing-box against only the selected relay
+and never requests or accepts a WSS ticket:
+
+```sh
+go run ./cmd/wssmatrix \
+  -mode direct \
+  -relay-id relay_EXACT \
+  -descriptor-file /absolute/private/public-relay-descriptor.json \
+  -sing-box /absolute/path/to/sing-box
+```
+
+Use `foundation-wss-host.sh migrate` when the host still has the legacy
+`volunteer.env`. Use `stabilize` when it already has `relay.env` but lacks
+`OPENRUNG_IDENTITY_SEED`. Stop if the direct probe, checkpoint preconditions,
+or post-transition registration fails.
 
 ```sh
 go run ./cmd/wssmatrix keygen \

--- a/deploy/relay/cloudfront-wss.md
+++ b/deploy/relay/cloudfront-wss.md
@@ -361,6 +361,92 @@ Roll out one relay and one front at a time:
 7. Canary the desktop fallback while continuing to measure direct Reality
    independently. Add further relays/fronts only after the canary is stable.
 
+### Fleet automation and pre-advertisement matrix
+
+The checked-in fleet tooling keeps the data plane per-relay even though the
+AWS IP-range maintenance is shared control-plane automation:
+
+- `deploy/relay/aws/wss-origin-targets.json` is the explicit Lightsail origin
+  firewall inventory. It carries only instance names and regions; `apply`
+  resolves the exact instance ARNs from the live account, so the AWS account ID
+  and instance identifiers are never checked in.
+  `deploy-wss-origin-firewall-sync.sh check` validates the inventory; `apply`
+  deploys the least-privilege Lambda and immediately converges every listed
+  relay to the official `CLOUDFRONT_ORIGIN_FACING` IPv4 ranges on TCP `8443`.
+  It preserves every unrelated port rule and updates add-before-remove.
+- `foundation-wss-host.sh` migrates one legacy Foundation relay to a pinned
+  image and stable identity, installs its own loopback sidecar, installs its
+  own Caddy TLS origin on `8443`, and audits the result. Secret files are
+  streamed over SSH stdin, must be mode `0600`, and are never command-line
+  arguments.
+- `cloudfront-wss-front.sh` creates or audits exactly one distribution whose
+  only origin is that relay's origin hostname. The origin token comes from a
+  mode-`0600` file; the written state file is public metadata only.
+  `wss-fronts.json` inventories that public distribution metadata and does not
+  imply that a listed front is advertised by its relay.
+
+Do not put `OPENRUNG_WSS_FRONTS` in the relay environment until the complete
+matrix below passes for that exact distribution. Generate a temporary ticket
+key, add only its public key to the relay's overlapping verifier set, and keep
+its private seed on the operator workstation:
+
+```sh
+go run ./cmd/wssmatrix keygen \
+  -seed-file /absolute/private/test-ticket.seed \
+  -public-key-file /absolute/private/test-ticket.pub
+
+go run ./cmd/wssmatrix \
+  -mode edge \
+  -url wss://DIST.cloudfront.net/api/v1/wss-bridge \
+  -relay-id relay_EXACT \
+  -front-id relay-name-cf-a \
+  -seed-file /absolute/private/test-ticket.seed \
+  -descriptor-file /absolute/private/public-relay-descriptor.json \
+  -sing-box /absolute/path/to/sing-box
+```
+
+Edge mode verifies missing-ticket rejection, wrong-relay and wrong-front
+binding, single-use replay enforcement, and a real end-to-end Internet request
+through sing-box and Reality inside the WebSocket. It never sends a ticket in
+a URL or query parameter and never prints a ticket or response payload.
+
+For relay-local controls, temporarily set a small
+`OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE` and short
+`OPENRUNG_WSS_NO_STREAM_IDLE_TIMEOUT`, restart only the unadvertised sidecar,
+and forward its loopback listener over SSH. Origin mode verifies rejection of
+an invalid origin token, acceptance of both rotation-overlap tokens, exact
+per-source saturation and release, and bounded idle/lifetime cleanup:
+
+```sh
+go run ./cmd/wssmatrix \
+  -mode origin \
+  -url ws://127.0.0.1:LOCAL_FORWARD/api/v1/wss-bridge \
+  -relay-id relay_EXACT \
+  -front-id relay-name-cf-a \
+  -seed-file /absolute/private/test-ticket.seed \
+  -origin-token-file /absolute/private/origin-current \
+  -origin-token-next-file /absolute/private/origin-next \
+  -source-limit 2 \
+  -expect-close-within 10s
+```
+
+Restore the production source/idle limits, restore the production-only ticket
+verification key set, restart and audit the sidecar, and prove a ticket signed
+by the temporary key is rejected:
+
+```sh
+go run ./cmd/wssmatrix \
+  -mode revoked \
+  -url wss://DIST.cloudfront.net/api/v1/wss-bridge \
+  -relay-id relay_EXACT \
+  -front-id relay-name-cf-a \
+  -seed-file /absolute/private/test-ticket.seed
+```
+
+Delete the temporary private seed. Only then may rollout step 6 advertise the
+front. Run this sequence independently for every relay/front; one passing
+distribution never authorizes another relay's advertisement.
+
 ## Rollback
 
 Rollback is additive and does not touch public Reality on `443`:

--- a/deploy/relay/cloudfront-wss.md
+++ b/deploy/relay/cloudfront-wss.md
@@ -447,6 +447,43 @@ Delete the temporary private seed. Only then may rollout step 6 advertise the
 front. Run this sequence independently for every relay/front; one passing
 distribution never authorizes another relay's advertisement.
 
+Advertise with the transactional host command. It preserves a mode-`0600`
+pre-advertisement relay environment at
+`/etc/openrung/relay.env.pre-wss-advertise`, restores it automatically if the
+new relay process does not register, and never changes the sidecar or Reality
+credentials:
+
+```sh
+deploy/relay/foundation-wss-host.sh advertise \
+  RELAY PUBLIC_IP FRONT_ID \
+  wss://DIST.cloudfront.net/api/v1/wss-bridge \
+  ghcr.io/openrung/openrung-relay:sha-REVISION
+```
+
+Fetch a fresh signed directory and require the relay descriptor to contain
+exactly that one front. Request a ticket from `POST /api/v1/wss/tickets` into a
+pre-created mode-`0600` file without printing it, then consume it through the
+production sidecar. Supplying the public descriptor file also runs an actual
+sing-box/Reality Internet probe:
+
+```sh
+go run ./cmd/wssmatrix \
+  -mode issued \
+  -url wss://DIST.cloudfront.net/api/v1/wss-bridge \
+  -relay-id relay_EXACT \
+  -front-id FRONT_ID \
+  -ticket-response-file /absolute/private/ticket-response.json \
+  -descriptor-file /absolute/private/public-relay-list.json \
+  -sing-box /absolute/path/to/sing-box
+
+deploy/relay/foundation-wss-host.sh audit \
+  RELAY PUBLIC_IP ghcr.io/openrung/openrung-relay:sha-REVISION \
+  FRONT_ID wss://DIST.cloudfront.net/api/v1/wss-bridge
+```
+
+Delete the consumed ticket response immediately after the audit. Never put its
+ticket in shell arguments, URLs, logs, or the public distribution inventory.
+
 ## Rollback
 
 Rollback is additive and does not touch public Reality on `443`:

--- a/deploy/relay/foundation-wss-host.sh
+++ b/deploy/relay/foundation-wss-host.sh
@@ -6,7 +6,8 @@
 #   sidecar RELAY HOST RELAY_ID FRONT_ID IMAGE
 #   origin-tls RELAY HOST ORIGIN_HOST
 #   matrix-limits RELAY HOST enable|restore
-#   audit RELAY HOST IMAGE
+#   advertise RELAY HOST FRONT_ID FRONT_URL IMAGE
+#   audit RELAY HOST IMAGE [FRONT_ID FRONT_URL]
 #
 # `migrate` is the one-time legacy-to-stable transition.  It preserves the
 # currently active VLESS UUID, Reality private key, and short ID directly on
@@ -29,7 +30,7 @@ KNOWN_HOSTS="${OPENRUNG_KNOWN_HOSTS:-$HOME/.ssh/known_hosts}"
 SSH_OPTS=(-i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=${KNOWN_HOSTS}")
 
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
-[[ "$COMMAND" =~ ^(migrate|sidecar|origin-tls|matrix-limits|audit)$ ]] || die "unknown command"
+[[ "$COMMAND" =~ ^(migrate|sidecar|origin-tls|matrix-limits|advertise|audit)$ ]] || die "unknown command"
 [[ "$RELAY" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]] || die "relay name is invalid"
 [[ "$HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.:-]{0,254}$ ]] || die "host is invalid"
 [[ -f "$SSH_KEY" && -f "$KNOWN_HOSTS" ]] || die "SSH key or known_hosts is missing"
@@ -284,9 +285,69 @@ EOF
     printf 'relay=%s matrix_limits=%s advertised=false\n' "$RELAY" "$ACTION"
     ;;
 
+  advertise)
+    FRONT_ID="${4:-}"
+    FRONT_URL="${5:-}"
+    IMAGE="${6:-}"
+    [[ "$FRONT_ID" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]] || die "front ID is invalid"
+    [[ "$FRONT_URL" =~ ^wss://[a-z0-9]+\.cloudfront\.net/api/v1/wss-bridge$ ]] || die "front URL is invalid"
+    [[ "$IMAGE" =~ ^[A-Za-z0-9][A-Za-z0-9:/@._-]*$ ]] || die "image is invalid"
+    REMOTE_SCRIPT="$(mktemp)"
+    trap 'rm -f "$REMOTE_SCRIPT"' EXIT
+    cat >"$REMOTE_SCRIPT" <<'REMOTE'
+set -euo pipefail
+front_id="$1" front_url="$2" image="$3"
+env=/etc/openrung/relay.env
+backup=/etc/openrung/relay.env.pre-wss-advertise
+
+test "$(sudo docker inspect -f '{{.Config.Image}} {{.State.Running}}' openrung-relay)" = "$image true"
+sudo test -f "$env"
+! sudo test -e "$backup"
+! sudo grep -q '^OPENRUNG_WSS_FRONTS=' "$env"
+sudo install -m 0600 -o root -g root "$env" "$backup"
+sudo sed -i "\$aOPENRUNG_WSS_FRONTS=${front_id}=${front_url}" "$env"
+
+start_relay() {
+  sudo docker rm -f openrung-relay >/dev/null 2>&1 || true
+  sudo docker run -d --name openrung-relay --restart unless-stopped \
+    --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
+    --env-file "$env" "$image" >/dev/null
+}
+rollback() {
+  sudo install -m 0600 -o root -g root "$backup" "$env"
+  start_relay
+}
+trap rollback ERR
+start_relay
+for _ in $(seq 1 30); do
+  state="$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' openrung-relay 2>/dev/null || true)"
+  if [ "$state" = "true 0" ] && sudo docker logs openrung-relay 2>&1 | grep -q 'registered relay'; then
+    break
+  fi
+  sleep 2
+done
+test "$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' openrung-relay)" = 'true 0'
+test "$(sudo grep -c '^OPENRUNG_WSS_FRONTS=' "$env")" = 1
+sudo grep -Fqx "OPENRUNG_WSS_FRONTS=${front_id}=${front_url}" "$env"
+trap - ERR
+REMOTE
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${HOST}" \
+      "sudo bash -s -- '$FRONT_ID' '$FRONT_URL' '$IMAGE'" <"$REMOTE_SCRIPT"
+    printf 'relay=%s front=%s advertised=pending-broker-verification\n' "$RELAY" "$FRONT_ID"
+    ;;
+
   audit)
     IMAGE="${4:-}"
+    FRONT_ID="${5:-}"
+    FRONT_URL="${6:-}"
     [[ "$IMAGE" =~ ^[A-Za-z0-9][A-Za-z0-9:/@._-]*$ ]] || die "image is invalid"
+    if [[ -n "$FRONT_ID" || -n "$FRONT_URL" ]]; then
+      [[ "$FRONT_ID" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]] || die "front ID is invalid"
+      [[ "$FRONT_URL" =~ ^wss://[a-z0-9]+\.cloudfront\.net/api/v1/wss-bridge$ ]] || die "front URL is invalid"
+      FRONT_CHECK="test \"\$(sudo grep -c '^OPENRUNG_WSS_FRONTS=' /etc/openrung/relay.env)\" = 1 && sudo grep -Fqx 'OPENRUNG_WSS_FRONTS=${FRONT_ID}=${FRONT_URL}' /etc/openrung/relay.env && sudo test -f /etc/openrung/relay.env.pre-wss-advertise && test \"\$(sudo stat -c '%a %U:%G' /etc/openrung/relay.env.pre-wss-advertise)\" = '600 root:root'"
+    else
+      FRONT_CHECK="! sudo grep -q '^OPENRUNG_WSS_FRONTS=' /etc/openrung/relay.env"
+    fi
     ssh_run "set -e
       test \"\$(sudo docker inspect -f '{{.Config.Image}} {{.State.Running}} {{.RestartCount}} {{.HostConfig.NetworkMode}} {{.HostConfig.ReadonlyRootfs}}' openrung-relay)\" = '$IMAGE true 0 host true'
       test \"\$(sudo docker inspect -f '{{.Config.Image}} {{.State.Running}} {{.RestartCount}} {{.HostConfig.NetworkMode}} {{.HostConfig.ReadonlyRootfs}}' openrung-wss-sidecar)\" = '$IMAGE true 0 host true'
@@ -297,7 +358,7 @@ EOF
       ! sudo test -e /etc/openrung/wss.env.pre-matrix
       test \"\$(sudo stat -c '%a %U:%G' /etc/openrung/relay.env)\" = '600 root:root'
       test \"\$(sudo stat -c '%a %U:%G' /etc/openrung/wss.env)\" = '600 root:root'
-      ! sudo grep -q '^OPENRUNG_WSS_FRONTS=' /etc/openrung/relay.env
+      $FRONT_CHECK
       test \"\$(sudo grep -c '^OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE=512\$' /etc/openrung/wss.env)\" = 1
       ! sudo grep -q '^OPENRUNG_WSS_NO_STREAM_IDLE_TIMEOUT=' /etc/openrung/wss.env
       ! sudo grep -q '^OPENRUNG_WSS_FIXED_TARGET=' /etc/openrung/wss.env
@@ -307,6 +368,10 @@ EOF
       test \"\$(sudo grep -c 'reverse_proxy 127.0.0.1:8081' /etc/caddy/Caddyfile)\" = 1
       ! sudo grep -Eq '^[[:space:]]*log([[:space:]]|\{)' /etc/caddy/Caddyfile
       sudo systemctl is-active --quiet caddy"
-    printf 'relay=%s host_audit=ok advertised=false\n' "$RELAY"
+    if [[ -n "$FRONT_ID" ]]; then
+      printf 'relay=%s front=%s host_audit=ok advertised=true\n' "$RELAY" "$FRONT_ID"
+    else
+      printf 'relay=%s host_audit=ok advertised=false\n' "$RELAY"
+    fi
     ;;
 esac

--- a/deploy/relay/foundation-wss-host.sh
+++ b/deploy/relay/foundation-wss-host.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Prepare one Foundation relay for an unadvertised, relay-local WSS front.
+#
+# Commands:
+#   migrate RELAY HOST REALITY_PUBLIC_KEY IMAGE
+#   sidecar RELAY HOST RELAY_ID FRONT_ID IMAGE
+#   origin-tls RELAY HOST ORIGIN_HOST
+#   matrix-limits RELAY HOST enable|restore
+#   audit RELAY HOST IMAGE
+#
+# `migrate` is the one-time legacy-to-stable transition.  It preserves the
+# currently active VLESS UUID, Reality private key, and short ID directly on
+# the host, adds a new persistent Ed25519 identity seed, and transactionally
+# starts the pinned image.  No private key or Foundation token is read back.
+#
+# `sidecar` requires these local mode-0600 files:
+#   OPENRUNG_WSS_TICKET_PUBLIC_KEYS_FILE  public verification key ring
+#   OPENRUNG_WSS_ORIGIN_TOKENS_FILE       JSON array with 1..2 unique tokens
+# They are streamed over SSH stdin and are never accepted in argv or printed.
+set -euo pipefail
+{ set +x; } 2>/dev/null
+
+COMMAND="${1:-}"
+RELAY="${2:-}"
+HOST="${3:-}"
+SSH_KEY="${OPENRUNG_SSH_KEY:-$HOME/.ssh/id_ed25519_openrung}"
+SSH_USER="${OPENRUNG_SSH_USER:-ubuntu}"
+KNOWN_HOSTS="${OPENRUNG_KNOWN_HOSTS:-$HOME/.ssh/known_hosts}"
+SSH_OPTS=(-i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=${KNOWN_HOSTS}")
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+[[ "$COMMAND" =~ ^(migrate|sidecar|origin-tls|matrix-limits|audit)$ ]] || die "unknown command"
+[[ "$RELAY" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]] || die "relay name is invalid"
+[[ "$HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.:-]{0,254}$ ]] || die "host is invalid"
+[[ -f "$SSH_KEY" && -f "$KNOWN_HOSTS" ]] || die "SSH key or known_hosts is missing"
+ssh-keygen -F "$HOST" -f "$KNOWN_HOSTS" >/dev/null || die "host key is not pinned: ${HOST}"
+
+ssh_run() { ssh "${SSH_OPTS[@]}" "${SSH_USER}@${HOST}" "$@"; }
+
+case "$COMMAND" in
+  migrate)
+    REALITY_PUBLIC_KEY="${4:-}"
+    IMAGE="${5:-}"
+    [[ "$REALITY_PUBLIC_KEY" =~ ^[A-Za-z0-9_-]{40,64}$ ]] || die "Reality public key is invalid"
+    [[ "$IMAGE" =~ ^[A-Za-z0-9][A-Za-z0-9:/@._-]*$ ]] || die "image is invalid"
+    CHECKPOINT="openrung-relay-pre-wss-$(date -u +%Y%m%d%H%M%S)"
+    REMOTE_SCRIPT="$(mktemp)"
+    trap 'rm -f "$REMOTE_SCRIPT"' EXIT
+    umask 077
+    cat >"$REMOTE_SCRIPT" <<'REMOTE'
+set -euo pipefail
+relay="$1" public_key="$2" image="$3" checkpoint="$4"
+canonical=/etc/openrung/relay.env
+legacy=/etc/openrung/volunteer.env
+candidate=openrung-relay
+xray_snapshot="/run/openrung-${relay}-xray-config.json"
+
+test "$(sudo docker inspect -f '{{.State.Running}}' "$candidate" 2>/dev/null)" = true
+sudo test -f "$legacy"
+! sudo test -e "$canonical"
+! sudo docker ps -a --format '{{.Names}}' | grep -qx "$checkpoint"
+sudo docker exec "$candidate" test -f /tmp/openrung-xray-config.json
+sudo sh -c "umask 077; docker exec '$candidate' cat /tmp/openrung-xray-config.json > '$xray_snapshot'"
+sudo chown root:root "$xray_snapshot"
+sudo chmod 0600 "$xray_snapshot"
+trap 'sudo rm -f "$xray_snapshot" "$canonical.tmp"' EXIT
+
+sudo install -d -m 0700 -o root -g root /etc/openrung
+sudo python3 - "$legacy" "$canonical.tmp" "$public_key" "$xray_snapshot" <<'PY'
+import base64, json, os, re, secrets, sys
+legacy, output, public_key, xray_snapshot = sys.argv[1:]
+with open(legacy, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+managed = {
+    "OPENRUNG_IDENTITY_SEED", "OPENRUNG_CLIENT_ID", "OPENRUNG_REALITY_PRIVATE_KEY",
+    "OPENRUNG_REALITY_PUBLIC_KEY", "OPENRUNG_SHORT_ID", "OPENRUNG_CONNECTION_LOG",
+    "OPENRUNG_LISTEN_HOST", "OPENRUNG_WSS_FRONTS", "OPENRUNG_XRAY_PATH", "OPENRUNG_CONFIG_OUT",
+}
+kept = []
+seen = set()
+for line in lines:
+    if not line or line.startswith("#"):
+        continue
+    if "=" not in line:
+        raise SystemExit("legacy env contains an invalid line")
+    key, value = line.split("=", 1)
+    if not re.fullmatch(r"OPENRUNG_[A-Z0-9_]+", key) or key in seen:
+        raise SystemExit("legacy env contains an invalid or duplicate key")
+    seen.add(key)
+    if key not in managed:
+        kept.append((key, value))
+required = {"OPENRUNG_FOUNDATION_TOKEN", "OPENRUNG_PUBLIC_HOST", "OPENRUNG_LABEL"}
+values = dict(kept)
+if not required.issubset(values) or any(not values[key] or any(ch.isspace() for ch in values[key]) for key in required):
+    raise SystemExit("legacy env is missing a required value")
+with open(xray_snapshot, encoding="utf-8") as handle:
+    config = json.load(handle)
+inbound = config["inbounds"][0]
+client_id = inbound["settings"]["clients"][0]["id"]
+reality = inbound["streamSettings"]["realitySettings"]
+private_key = reality["privateKey"]
+short_id = reality["shortIds"][0]
+checks = {
+    "OPENRUNG_CLIENT_ID": (client_id, r"[0-9a-fA-F-]{36}"),
+    "OPENRUNG_REALITY_PRIVATE_KEY": (private_key, r"[A-Za-z0-9_-]{40,64}"),
+    "OPENRUNG_REALITY_PUBLIC_KEY": (public_key, r"[A-Za-z0-9_-]{40,64}"),
+    "OPENRUNG_SHORT_ID": (short_id, r"[0-9a-fA-F]{16}"),
+}
+for key, (value, pattern) in checks.items():
+    if not re.fullmatch(pattern, value):
+        raise SystemExit(f"generated Xray config contains invalid {key}")
+kept.extend([
+    ("OPENRUNG_LISTEN_HOST", "0.0.0.0"),
+    ("OPENRUNG_CONNECTION_LOG", "false"),
+    ("OPENRUNG_CLIENT_ID", client_id),
+    ("OPENRUNG_REALITY_PRIVATE_KEY", private_key),
+    ("OPENRUNG_REALITY_PUBLIC_KEY", public_key),
+    ("OPENRUNG_SHORT_ID", short_id),
+    ("OPENRUNG_IDENTITY_SEED", base64.b64encode(secrets.token_bytes(32)).decode("ascii")),
+])
+fd = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as handle:
+    for key, value in kept:
+        if "\n" in value or "\r" in value:
+            raise SystemExit("env value contains a newline")
+        handle.write(f"{key}={value}\n")
+PY
+sudo chown root:root "$canonical.tmp"
+sudo chmod 0600 "$canonical.tmp"
+sudo mv "$canonical.tmp" "$canonical"
+sudo rm -f "$xray_snapshot"
+
+rollback() {
+  sudo docker rm -f "$candidate" >/dev/null 2>&1 || true
+  if sudo docker ps -a --format '{{.Names}}' | grep -qx "$checkpoint"; then
+    sudo docker rename "$checkpoint" "$candidate" || true
+    sudo docker update --restart unless-stopped "$candidate" >/dev/null 2>&1 || true
+    sudo docker start "$candidate" >/dev/null 2>&1 || true
+  fi
+  sudo rm -f "$canonical"
+}
+trap rollback ERR
+sudo docker pull "$image" >/dev/null
+sudo docker stop "$candidate" >/dev/null
+sudo docker rename "$candidate" "$checkpoint"
+sudo docker update --restart no "$checkpoint" >/dev/null
+sudo docker run -d --name "$candidate" --restart unless-stopped \
+  --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
+  --env-file "$canonical" "$image" >/dev/null
+
+for _ in $(seq 1 30); do
+  state="$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' "$candidate" 2>/dev/null || true)"
+  if [ "$state" = "true 0" ] && sudo docker logs "$candidate" 2>&1 | grep -q 'registered relay'; then
+    break
+  fi
+  sleep 2
+done
+test "$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' "$candidate")" = "true 0"
+line="$(sudo docker logs "$candidate" 2>&1 | grep 'registered relay' | tail -1)"
+relay_id="$(printf '%s\n' "$line" | sed -n 's/.* id=\(relay_[0-9a-f]\{32\}\).*/\1/p')"
+test -n "$relay_id"
+sudo mv "$legacy" "${legacy}.pre-wss-$(date -u +%Y%m%d%H%M%S)"
+trap - ERR
+printf 'relay=%s relay_id=%s checkpoint=%s\n' "$relay" "$relay_id" "$checkpoint"
+REMOTE
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${HOST}" \
+      "sudo bash -s -- '$RELAY' '$REALITY_PUBLIC_KEY' '$IMAGE' '$CHECKPOINT'" <"$REMOTE_SCRIPT"
+    ;;
+
+  sidecar)
+    RELAY_ID="${4:-}"
+    FRONT_ID="${5:-}"
+    IMAGE="${6:-}"
+    TICKET_FILE="${OPENRUNG_WSS_TICKET_PUBLIC_KEYS_FILE:-}"
+    TOKENS_FILE="${OPENRUNG_WSS_ORIGIN_TOKENS_FILE:-}"
+    [[ "$RELAY_ID" =~ ^relay_[0-9a-f]{32}$ ]] || die "relay ID is invalid"
+    [[ "$FRONT_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || die "front ID is invalid"
+    [[ "$IMAGE" =~ ^[A-Za-z0-9][A-Za-z0-9:/@._-]*$ ]] || die "image is invalid"
+    for file in "$TICKET_FILE" "$TOKENS_FILE"; do
+      [[ -f "$file" ]] || die "required sidecar input file is missing"
+      mode="$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file")"
+      [[ "$mode" == 600 ]] || die "sidecar input files must have mode 0600"
+    done
+    jq -e 'type == "array" and length >= 1 and length <= 2 and unique == . and all(.[]; type == "string" and length >= 32 and length <= 512 and test("^[^[:space:]]+$"))' "$TOKENS_FILE" >/dev/null \
+      || die "origin token ring is invalid"
+    grep -Eq '^[A-Za-z0-9+/=]+(,[A-Za-z0-9+/=]+)*$' "$TICKET_FILE" || die "ticket public-key file is invalid"
+    TMP_ENV="$(mktemp)"
+    trap 'rm -f "$TMP_ENV"' EXIT
+    umask 077
+    jq -n --arg front "$FRONT_ID" --slurpfile tokens "$TOKENS_FILE" '{($front):$tokens[0]}' >"${TMP_ENV}.tokens"
+    {
+      printf 'OPENRUNG_WSS_RELAY_ID=%s\n' "$RELAY_ID"
+      printf 'OPENRUNG_WSS_TICKET_PUBLIC_KEYS='
+      tr -d '\r\n' <"$TICKET_FILE"
+      printf '\nOPENRUNG_WSS_FRONT_ORIGIN_TOKENS='
+      jq -c . "${TMP_ENV}.tokens"
+      printf 'OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE=512\n'
+      printf 'OPENRUNG_WSS_MAX_STREAMS_PER_SOURCE=4096\n'
+      printf 'OPENRUNG_WSS_MAX_PENDING_HANDSHAKES=4096\n'
+      printf 'OPENRUNG_WSS_GLOBAL_HANDSHAKE_RATE=2000\n'
+      printf 'OPENRUNG_WSS_GLOBAL_HANDSHAKE_BURST=10000\n'
+    } >"$TMP_ENV"
+    chmod 0600 "$TMP_ENV"
+    ssh_run "sudo install -d -m 0700 -o root -g root /etc/openrung && sudo install -m 0600 -o root -g root /dev/stdin /etc/openrung/wss.env" <"$TMP_ENV"
+    ssh_run "set -e
+      sudo grep -q '^OPENRUNG_IDENTITY_SEED=' /etc/openrung/relay.env
+      ! sudo grep -q '^OPENRUNG_WSS_FRONTS=' /etc/openrung/relay.env
+      test \"\$(sudo docker inspect -f '{{.Config.Image}}' openrung-relay)\" = '$IMAGE'
+      if sudo docker ps -a --format '{{.Names}}' | grep -qx openrung-wss-sidecar; then sudo docker rm -f openrung-wss-sidecar >/dev/null; fi
+      sudo docker volume create openrung-wss-replay-${RELAY} >/dev/null
+      sudo docker run -d --name openrung-wss-sidecar --restart unless-stopped \
+        --network host --cap-drop ALL --security-opt no-new-privileges:true --read-only --tmpfs /tmp \
+        --mount source=openrung-wss-replay-${RELAY},target=/var/lib/openrung \
+        --env-file /etc/openrung/wss.env --entrypoint /usr/local/bin/wss-sidecar '$IMAGE' >/dev/null
+      sleep 2
+      test \"\$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' openrung-wss-sidecar)\" = 'true 0'
+      sudo ss -ltn | grep -q '127.0.0.1:8081'
+      ! sudo ss -ltn | grep -Eq '(^|[[:space:]])(0.0.0.0|\*|\[::\]):8081([[:space:]]|$)'"
+    printf 'relay=%s relay_id=%s sidecar=ready advertised=false\n' "$RELAY" "$RELAY_ID"
+    ;;
+
+  origin-tls)
+    ORIGIN_HOST="${4:-}"
+    [[ "$ORIGIN_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]{0,252}[A-Za-z0-9]$ ]] || die "origin hostname is invalid"
+    CADDYFILE="$(mktemp)"
+    trap 'rm -f "$CADDYFILE"' EXIT
+    cat >"$CADDYFILE" <<EOF
+{
+	admin 127.0.0.1:2019
+}
+
+https://${ORIGIN_HOST}:8443 {
+	@bridge path /api/v1/wss-bridge
+
+	handle @bridge {
+		reverse_proxy 127.0.0.1:8081
+	}
+
+	handle {
+		respond 404
+	}
+}
+EOF
+    ssh_run "sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq caddy >/dev/null"
+    ssh_run "sudo install -m 0644 -o root -g root /dev/stdin /etc/caddy/Caddyfile" <"$CADDYFILE"
+    ssh_run "set -e
+      sudo caddy validate --config /etc/caddy/Caddyfile >/dev/null
+      sudo systemctl enable --now caddy >/dev/null
+      sudo systemctl restart caddy
+      for _ in \$(seq 1 30); do sudo ss -ltn | grep -q ':8443 ' && exit 0; sleep 2; done
+      exit 1"
+    printf 'relay=%s origin=%s tls=ready\n' "$RELAY" "$ORIGIN_HOST"
+    ;;
+
+  matrix-limits)
+    ACTION="${4:-}"
+    [[ "$ACTION" == enable || "$ACTION" == restore ]] || die "matrix-limits action must be enable or restore"
+    ssh_run "set -e
+      env=/etc/openrung/wss.env
+      backup=/etc/openrung/wss.env.pre-matrix
+      sudo test -f \"\$env\"
+      ! sudo grep -q '^OPENRUNG_WSS_FRONTS=' /etc/openrung/relay.env
+      if [ '$ACTION' = enable ]; then
+        ! sudo test -e \"\$backup\"
+        test \"\$(sudo grep -c '^OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE=512\$' \"\$env\")\" = 1
+        ! sudo grep -q '^OPENRUNG_WSS_NO_STREAM_IDLE_TIMEOUT=' \"\$env\"
+        sudo install -m 0600 -o root -g root \"\$env\" \"\$backup\"
+        sudo sed -i \
+          -e 's/^OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE=512\$/OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE=2/' \
+          -e '\$aOPENRUNG_WSS_NO_STREAM_IDLE_TIMEOUT=3s' \"\$env\"
+      else
+        sudo test -f \"\$backup\"
+        sudo install -m 0600 -o root -g root \"\$backup\" \"\$env\"
+        sudo rm -f \"\$backup\"
+      fi
+      image=\"\$(sudo docker inspect -f '{{.Config.Image}}' openrung-wss-sidecar)\"
+      sudo docker rm -f openrung-wss-sidecar >/dev/null
+      sudo docker run -d --name openrung-wss-sidecar --restart unless-stopped \
+        --network host --cap-drop ALL --security-opt no-new-privileges:true --read-only --tmpfs /tmp \
+        --mount source=openrung-wss-replay-${RELAY},target=/var/lib/openrung \
+        --env-file \"\$env\" --entrypoint /usr/local/bin/wss-sidecar \"\$image\" >/dev/null
+      sleep 2
+      test \"\$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' openrung-wss-sidecar)\" = 'true 0'"
+    printf 'relay=%s matrix_limits=%s advertised=false\n' "$RELAY" "$ACTION"
+    ;;
+
+  audit)
+    IMAGE="${4:-}"
+    [[ "$IMAGE" =~ ^[A-Za-z0-9][A-Za-z0-9:/@._-]*$ ]] || die "image is invalid"
+    ssh_run "set -e
+      test \"\$(sudo docker inspect -f '{{.Config.Image}} {{.State.Running}} {{.RestartCount}} {{.HostConfig.NetworkMode}} {{.HostConfig.ReadonlyRootfs}}' openrung-relay)\" = '$IMAGE true 0 host true'
+      test \"\$(sudo docker inspect -f '{{.Config.Image}} {{.State.Running}} {{.RestartCount}} {{.HostConfig.NetworkMode}} {{.HostConfig.ReadonlyRootfs}}' openrung-wss-sidecar)\" = '$IMAGE true 0 host true'
+      test \"\$(sudo docker inspect -f '{{json .Config.Entrypoint}} {{json .Config.Cmd}} {{json .HostConfig.CapDrop}} {{json .HostConfig.SecurityOpt}}' openrung-wss-sidecar)\" = '[\"/usr/local/bin/wss-sidecar\"] null [\"ALL\"] [\"no-new-privileges:true\"]'
+      test \"\$(sudo docker inspect -f '{{range .Mounts}}{{if eq .Destination \"/var/lib/openrung\"}}{{.Type}} {{.Name}} {{.RW}}{{end}}{{end}}' openrung-wss-sidecar)\" = 'volume openrung-wss-replay-${RELAY} true'
+      sudo test -f /etc/openrung/relay.env
+      sudo test -f /etc/openrung/wss.env
+      ! sudo test -e /etc/openrung/wss.env.pre-matrix
+      test \"\$(sudo stat -c '%a %U:%G' /etc/openrung/relay.env)\" = '600 root:root'
+      test \"\$(sudo stat -c '%a %U:%G' /etc/openrung/wss.env)\" = '600 root:root'
+      ! sudo grep -q '^OPENRUNG_WSS_FRONTS=' /etc/openrung/relay.env
+      test \"\$(sudo grep -c '^OPENRUNG_WSS_MAX_SESSIONS_PER_SOURCE=512\$' /etc/openrung/wss.env)\" = 1
+      ! sudo grep -q '^OPENRUNG_WSS_NO_STREAM_IDLE_TIMEOUT=' /etc/openrung/wss.env
+      ! sudo grep -q '^OPENRUNG_WSS_FIXED_TARGET=' /etc/openrung/wss.env
+      sudo ss -ltn | grep -q '127.0.0.1:8081'
+      ! sudo ss -ltn | grep -Eq '(^|[[:space:]])(0.0.0.0|\*|\[::\]):8081([[:space:]]|\$)'
+      sudo ss -ltn | grep -q ':8443 '
+      test \"\$(sudo grep -c 'reverse_proxy 127.0.0.1:8081' /etc/caddy/Caddyfile)\" = 1
+      ! sudo grep -Eq '^[[:space:]]*log([[:space:]]|\{)' /etc/caddy/Caddyfile
+      sudo systemctl is-active --quiet caddy"
+    printf 'relay=%s host_audit=ok advertised=false\n' "$RELAY"
+    ;;
+esac

--- a/deploy/relay/foundation-wss-host.sh
+++ b/deploy/relay/foundation-wss-host.sh
@@ -325,7 +325,7 @@ REMOTE
       || die "origin token ring is invalid"
     grep -Eq '^[A-Za-z0-9+/=]+(,[A-Za-z0-9+/=]+)*$' "$TICKET_FILE" || die "ticket public-key file is invalid"
     TMP_ENV="$(mktemp)"
-    trap 'rm -f "$TMP_ENV"' EXIT
+    trap 'rm -f "$TMP_ENV" "${TMP_ENV}.tokens"' EXIT
     umask 077
     jq -n --arg front "$FRONT_ID" --slurpfile tokens "$TOKENS_FILE" '{($front):$tokens[0]}' >"${TMP_ENV}.tokens"
     {

--- a/deploy/relay/foundation-wss-host.sh
+++ b/deploy/relay/foundation-wss-host.sh
@@ -3,6 +3,7 @@
 #
 # Commands:
 #   migrate RELAY HOST REALITY_PUBLIC_KEY IMAGE
+#   stabilize RELAY HOST REALITY_PUBLIC_KEY IMAGE
 #   sidecar RELAY HOST RELAY_ID FRONT_ID IMAGE
 #   origin-tls RELAY HOST ORIGIN_HOST
 #   matrix-limits RELAY HOST enable|restore
@@ -13,6 +14,9 @@
 # currently active VLESS UUID, Reality private key, and short ID directly on
 # the host, adds a new persistent Ed25519 identity seed, and transactionally
 # starts the pinned image.  No private key or Foundation token is read back.
+# `stabilize` provides the same recoverable identity transition for a host that
+# already uses /etc/openrung/relay.env but predates OPENRUNG_IDENTITY_SEED.  It
+# keeps both a stopped-container checkpoint and a mode-0600 environment backup.
 #
 # `sidecar` requires these local mode-0600 files:
 #   OPENRUNG_WSS_TICKET_PUBLIC_KEYS_FILE  public verification key ring
@@ -30,7 +34,7 @@ KNOWN_HOSTS="${OPENRUNG_KNOWN_HOSTS:-$HOME/.ssh/known_hosts}"
 SSH_OPTS=(-i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=${KNOWN_HOSTS}")
 
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
-[[ "$COMMAND" =~ ^(migrate|sidecar|origin-tls|matrix-limits|advertise|audit)$ ]] || die "unknown command"
+[[ "$COMMAND" =~ ^(migrate|stabilize|sidecar|origin-tls|matrix-limits|advertise|audit)$ ]] || die "unknown command"
 [[ "$RELAY" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]] || die "relay name is invalid"
 [[ "$HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.:-]{0,254}$ ]] || die "host is invalid"
 [[ -f "$SSH_KEY" && -f "$KNOWN_HOSTS" ]] || die "SSH key or known_hosts is missing"
@@ -168,6 +172,141 @@ REMOTE
       "sudo bash -s -- '$RELAY' '$REALITY_PUBLIC_KEY' '$IMAGE' '$CHECKPOINT'" <"$REMOTE_SCRIPT"
     ;;
 
+  stabilize)
+    REALITY_PUBLIC_KEY="${4:-}"
+    IMAGE="${5:-}"
+    [[ "$REALITY_PUBLIC_KEY" =~ ^[A-Za-z0-9_-]{40,64}$ ]] || die "Reality public key is invalid"
+    [[ "$IMAGE" =~ ^[A-Za-z0-9][A-Za-z0-9:/@._-]*$ ]] || die "image is invalid"
+    CHECKPOINT="openrung-relay-pre-wss-$(date -u +%Y%m%d%H%M%S)"
+    ENV_BACKUP="/etc/openrung/relay.env.pre-wss-stabilize-$(date -u +%Y%m%d%H%M%S)"
+    REMOTE_SCRIPT="$(mktemp)"
+    trap 'rm -f "$REMOTE_SCRIPT"' EXIT
+    umask 077
+    cat >"$REMOTE_SCRIPT" <<'REMOTE'
+set -euo pipefail
+relay="$1" public_key="$2" image="$3" checkpoint="$4" env_backup="$5"
+canonical=/etc/openrung/relay.env
+legacy=/etc/openrung/volunteer.env
+candidate=openrung-relay
+xray_snapshot="/run/openrung-${relay}-xray-config.json"
+
+test "$(sudo docker inspect -f '{{.State.Running}}' "$candidate" 2>/dev/null)" = true
+sudo test -f "$canonical"
+! sudo grep -q '^OPENRUNG_IDENTITY_SEED=' "$canonical"
+! sudo grep -q '^OPENRUNG_WSS_FRONTS=' "$canonical"
+! sudo test -e "$env_backup"
+! sudo docker ps -a --format '{{.Names}}' | grep -qx "$checkpoint"
+sudo docker exec "$candidate" test -f /tmp/openrung-xray-config.json
+sudo sh -c "umask 077; docker exec '$candidate' cat /tmp/openrung-xray-config.json > '$xray_snapshot'"
+sudo chown root:root "$xray_snapshot"
+sudo chmod 0600 "$xray_snapshot"
+trap 'sudo rm -f "$xray_snapshot" "$canonical.tmp"' EXIT
+
+sudo install -d -m 0700 -o root -g root /etc/openrung
+sudo install -m 0600 -o root -g root "$canonical" "$env_backup"
+sudo python3 - "$canonical" "$canonical.tmp" "$public_key" "$xray_snapshot" <<'PY'
+import base64, json, os, re, secrets, sys
+source, output, public_key, xray_snapshot = sys.argv[1:]
+with open(source, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+managed = {
+    "OPENRUNG_IDENTITY_SEED", "OPENRUNG_CLIENT_ID", "OPENRUNG_REALITY_PRIVATE_KEY",
+    "OPENRUNG_REALITY_PUBLIC_KEY", "OPENRUNG_SHORT_ID", "OPENRUNG_CONNECTION_LOG",
+    "OPENRUNG_LISTEN_HOST", "OPENRUNG_WSS_FRONTS", "OPENRUNG_XRAY_PATH", "OPENRUNG_CONFIG_OUT",
+}
+kept = []
+seen = set()
+for line in lines:
+    if not line or line.startswith("#"):
+        continue
+    if "=" not in line:
+        raise SystemExit("canonical env contains an invalid line")
+    key, value = line.split("=", 1)
+    if not re.fullmatch(r"OPENRUNG_[A-Z0-9_]+", key) or key in seen:
+        raise SystemExit("canonical env contains an invalid or duplicate key")
+    seen.add(key)
+    if key not in managed:
+        kept.append((key, value))
+required = {"OPENRUNG_FOUNDATION_TOKEN", "OPENRUNG_PUBLIC_HOST", "OPENRUNG_LABEL"}
+values = dict(kept)
+if not required.issubset(values) or any(not values[key] or any(ch.isspace() for ch in values[key]) for key in required):
+    raise SystemExit("canonical env is missing a required value")
+with open(xray_snapshot, encoding="utf-8") as handle:
+    config = json.load(handle)
+inbound = config["inbounds"][0]
+client_id = inbound["settings"]["clients"][0]["id"]
+reality = inbound["streamSettings"]["realitySettings"]
+private_key = reality["privateKey"]
+short_id = reality["shortIds"][0]
+checks = {
+    "OPENRUNG_CLIENT_ID": (client_id, r"[0-9a-fA-F-]{36}"),
+    "OPENRUNG_REALITY_PRIVATE_KEY": (private_key, r"[A-Za-z0-9_-]{40,64}"),
+    "OPENRUNG_REALITY_PUBLIC_KEY": (public_key, r"[A-Za-z0-9_-]{40,64}"),
+    "OPENRUNG_SHORT_ID": (short_id, r"[0-9a-fA-F]{16}"),
+}
+for key, (value, pattern) in checks.items():
+    if not re.fullmatch(pattern, value):
+        raise SystemExit(f"generated Xray config contains invalid {key}")
+kept.extend([
+    ("OPENRUNG_LISTEN_HOST", "0.0.0.0"),
+    ("OPENRUNG_CONNECTION_LOG", "false"),
+    ("OPENRUNG_CLIENT_ID", client_id),
+    ("OPENRUNG_REALITY_PRIVATE_KEY", private_key),
+    ("OPENRUNG_REALITY_PUBLIC_KEY", public_key),
+    ("OPENRUNG_SHORT_ID", short_id),
+    ("OPENRUNG_IDENTITY_SEED", base64.b64encode(secrets.token_bytes(32)).decode("ascii")),
+])
+fd = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as handle:
+    for key, value in kept:
+        if "\n" in value or "\r" in value:
+            raise SystemExit("env value contains a newline")
+        handle.write(f"{key}={value}\n")
+PY
+sudo chown root:root "$canonical.tmp"
+sudo chmod 0600 "$canonical.tmp"
+sudo mv "$canonical.tmp" "$canonical"
+sudo rm -f "$xray_snapshot"
+
+rollback() {
+  sudo docker rm -f "$candidate" >/dev/null 2>&1 || true
+  sudo install -m 0600 -o root -g root "$env_backup" "$canonical" || true
+  if sudo docker ps -a --format '{{.Names}}' | grep -qx "$checkpoint"; then
+    sudo docker rename "$checkpoint" "$candidate" || true
+    sudo docker update --restart unless-stopped "$candidate" >/dev/null 2>&1 || true
+    sudo docker start "$candidate" >/dev/null 2>&1 || true
+  fi
+}
+trap rollback ERR
+sudo docker pull "$image" >/dev/null
+sudo docker stop "$candidate" >/dev/null
+sudo docker rename "$candidate" "$checkpoint"
+sudo docker update --restart no "$checkpoint" >/dev/null
+sudo docker run -d --name "$candidate" --restart unless-stopped \
+  --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
+  --env-file "$canonical" "$image" >/dev/null
+
+for _ in $(seq 1 30); do
+  state="$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' "$candidate" 2>/dev/null || true)"
+  if [ "$state" = "true 0" ] && sudo docker logs "$candidate" 2>&1 | grep -q 'registered relay'; then
+    break
+  fi
+  sleep 2
+done
+test "$(sudo docker inspect -f '{{.State.Running}} {{.RestartCount}}' "$candidate")" = "true 0"
+line="$(sudo docker logs "$candidate" 2>&1 | grep 'registered relay' | tail -1)"
+relay_id="$(printf '%s\n' "$line" | sed -n 's/.* id=\(relay_[0-9a-f]\{32\}\).*/\1/p')"
+test -n "$relay_id"
+if sudo test -f "$legacy"; then
+  sudo mv "$legacy" "${legacy}.pre-wss-$(date -u +%Y%m%d%H%M%S)"
+fi
+trap - ERR
+printf 'relay=%s relay_id=%s checkpoint=%s env_backup=%s\n' "$relay" "$relay_id" "$checkpoint" "$env_backup"
+REMOTE
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${HOST}" \
+      "sudo bash -s -- '$RELAY' '$REALITY_PUBLIC_KEY' '$IMAGE' '$CHECKPOINT' '$ENV_BACKUP'" <"$REMOTE_SCRIPT"
+    ;;
+
   sidecar)
     RELAY_ID="${4:-}"
     FRONT_ID="${5:-}"
@@ -182,7 +321,7 @@ REMOTE
       mode="$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file")"
       [[ "$mode" == 600 ]] || die "sidecar input files must have mode 0600"
     done
-    jq -e 'type == "array" and length >= 1 and length <= 2 and unique == . and all(.[]; type == "string" and length >= 32 and length <= 512 and test("^[^[:space:]]+$"))' "$TOKENS_FILE" >/dev/null \
+    jq -e 'type == "array" and length >= 1 and length <= 2 and (length == (unique | length)) and all(.[]; type == "string" and length >= 32 and length <= 512 and test("^[^[:space:]]+$"))' "$TOKENS_FILE" >/dev/null \
       || die "origin token ring is invalid"
     grep -Eq '^[A-Za-z0-9+/=]+(,[A-Za-z0-9+/=]+)*$' "$TICKET_FILE" || die "ticket public-key file is invalid"
     TMP_ENV="$(mktemp)"


### PR DESCRIPTION
## Summary

- add the tested per-relay host, CloudFront, and origin-firewall rollout tooling
- inventory all 12 independent CloudFront fronts and all 11 Lightsail origin-firewall targets
- add direct Reality preflight mode, stable-identity migration support, and multi-region firewall synchronization bounds
- document the Hetzner fail-closed firewall refresh obligation and the complete pre-advertisement matrix

## Production verification

- all 12 eligible direct Foundation relays advertise exactly one relay-local WSS front
- all 9 newly added fronts passed wrong-relay, wrong-front, replay, origin-token overlap, source-limit, lifecycle, issued-ticket, and end-to-end Reality-over-WSS checks before advertisement
- all 12 relays passed a final direct Reality probe without requesting a WSS ticket

## Tests

- go test -race ./...
- go vet ./...
- deploy/broker-proxy: npm test
- Python firewall synchronizer unit tests
- deploy/relay/foundation-up_test.sh
- shell syntax, JSON uniqueness, and git diff checks