### PR TITLE
Add ECH to Go broker clients

### DIFF
--- a/cmd/client/telemetry.go
+++ b/cmd/client/telemetry.go
@@ -16,16 +16,16 @@ import (
 )
 
 const (
-	relayDialTimeout = 10 * time.Second
-	probeWindow      = 5 * time.Second
-	probeTimeout     = 2 * time.Second
+	relayDialTimeout    = 10 * time.Second
+	probeWindow         = 5 * time.Second
+	probeRequestTimeout = 4 * time.Second
 )
 
 // newConnectManager builds the telemetry manager for a connect session.
 // Telemetry is always on (parity with the mobile apps); if it cannot initialize
 // it is best-effort disabled (nil) so connecting never fails on telemetry.
 func newConnectManager(brokerURL string) *clienttelemetry.Manager {
-	mgr, err := clienttelemetry.New(brokerURL, client.AppVersion(), nil)
+	mgr, err := clienttelemetry.New(brokerURL, client.AppVersion(), client.NewBrokerHTTPClient(0))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: telemetry unavailable: %v\n", err)
 		return nil
@@ -54,11 +54,18 @@ func probeInternet(ctx context.Context, brokerURL string) (int64, bool) {
 	if err != nil {
 		return 0, false
 	}
-	httpClient := &http.Client{Timeout: probeTimeout}
-	deadline := time.Now().Add(probeWindow)
+	// The request timeout deliberately exceeds the shared two-second ECH phase
+	// so a network that blackholes ECH still has time for the verified plain-TLS
+	// fallback. The outer context keeps the complete retry sweep at five seconds.
+	httpClient := client.NewBrokerHTTPClient(probeRequestTimeout)
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, probeWindow)
+	defer cancel()
 	for {
 		started := time.Now()
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		req, reqErr := http.NewRequestWithContext(probeCtx, http.MethodGet, target, nil)
 		if reqErr != nil {
 			return 0, false
 		}
@@ -70,10 +77,16 @@ func probeInternet(ctx context.Context, brokerURL string) (int64, bool) {
 				return time.Since(started).Milliseconds(), true
 			}
 		}
-		if ctx.Err() != nil || time.Now().After(deadline) {
+		if probeCtx.Err() != nil {
 			return 0, false
 		}
-		time.Sleep(250 * time.Millisecond)
+		retryDelay := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-probeCtx.Done():
+			retryDelay.Stop()
+			return 0, false
+		case <-retryDelay.C:
+		}
 	}
 }
 

--- a/cmd/client/telemetry_test.go
+++ b/cmd/client/telemetry_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHealthURLAppendsToBasePathAndDropsQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		brokerURL string
+		want      string
+	}{
+		{
+			name:      "root",
+			brokerURL: "https://broker.openrung.org/?stale=1",
+			want:      "https://broker.openrung.org/healthz",
+		},
+		{
+			name:      "base path",
+			brokerURL: "https://broker.openrung.org/front/v1/?stale=1",
+			want:      "https://broker.openrung.org/front/v1/healthz",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := healthURL(tc.brokerURL)
+			if err != nil {
+				t.Fatalf("healthURL(%q): %v", tc.brokerURL, err)
+			}
+			if got != tc.want {
+				t.Fatalf("healthURL(%q) = %q, want %q", tc.brokerURL, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProbeInternetRetriesThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(w, "try again", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	if _, ok := probeInternet(t.Context(), server.URL); !ok {
+		t.Fatal("probeInternet did not succeed after the transient failure")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("probe requests = %d, want 2", got)
+	}
+}
+
+func TestProbeInternetDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL+"/healthz", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(origin.Close)
+
+	if _, ok := probeInternet(t.Context(), origin.URL); !ok {
+		t.Fatal("probeInternet rejected the origin's reachable redirect response")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target requests = %d, want 0", got)
+	}
+}
+
+func TestProbeInternetCancellationStopsInflightRequest(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	probeDone := make(chan bool, 1)
+	go func() {
+		_, ok := probeInternet(ctx, server.URL)
+		probeDone <- ok
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("probe request did not start")
+	}
+
+	cancelledAt := time.Now()
+	cancel()
+	select {
+	case ok := <-probeDone:
+		if ok {
+			t.Fatal("canceled probe reported success")
+		}
+		if elapsed := time.Since(cancelledAt); elapsed > time.Second {
+			t.Fatalf("canceled probe returned after %v, want under 1s", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled probe did not return promptly")
+	}
+}

--- a/desktop/discovery/discovery.go
+++ b/desktop/discovery/discovery.go
@@ -83,7 +83,7 @@ func ListRelays(ctx context.Context, brokerURL string, opts Options) (relay.List
 
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: requestTimeout}
+		httpClient = client.NewBrokerHTTPClient(requestTimeout)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)

--- a/desktop/vpnservice/connect_helpers.go
+++ b/desktop/vpnservice/connect_helpers.go
@@ -3,7 +3,6 @@ package vpnservice
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -15,11 +14,10 @@ import (
 	"openrung/internal/relay"
 )
 
-// telemetryHTTPTimeout bounds every telemetry request. Without it the manager
-// falls back to http.DefaultClient (no timeout), so a broker that accepts the
-// connection but stalls the response would hang the synchronous Flush on the
-// connect path — and, since Flush runs before supervision starts, disable
-// mid-session recovery. Matches the mobile client's 15s request deadline.
+// telemetryHTTPTimeout bounds every telemetry request so a broker that accepts
+// the connection but stalls the response cannot hang the synchronous Flush on
+// the connect path and disable mid-session recovery. Matches the mobile
+// client's 15s request deadline.
 const telemetryHTTPTimeout = 15 * time.Second
 
 // newManager builds a best-effort telemetry manager (parity with the mobile
@@ -29,7 +27,7 @@ func newManager(brokerURL string) *clienttelemetry.Manager {
 	if brokerURL == "" {
 		brokerURL = config.TelemetryBrokerURL
 	}
-	mgr, err := clienttelemetry.New(brokerURL, client.AppVersion(), &http.Client{Timeout: telemetryHTTPTimeout})
+	mgr, err := clienttelemetry.New(brokerURL, client.AppVersion(), client.NewBrokerHTTPClient(telemetryHTTPTimeout))
 	if err != nil {
 		return nil
 	}

--- a/desktop/vpnservice/wss.go
+++ b/desktop/vpnservice/wss.go
@@ -131,10 +131,8 @@ func (s *Service) wssTicketRequester() func(context.Context, string, relay.WSSSe
 	}
 	return func(ctx context.Context, brokerURL string, request relay.WSSSessionTicketRequest, clientID, sessionID string) (relay.WSSSessionTicketResponse, error) {
 		brokerClient := client.BrokerClient{
-			BaseURL: brokerURL,
-			HTTPClient: &http.Client{
-				Timeout: wssTicketHTTPTimeout,
-			},
+			BaseURL:    brokerURL,
+			HTTPClient: client.NewBrokerHTTPClient(wssTicketHTTPTimeout),
 		}
 		return brokerClient.RequestWSSSessionTicket(ctx, request, clientID, sessionID)
 	}

--- a/internal/client/broker.go
+++ b/internal/client/broker.go
@@ -44,7 +44,7 @@ func (c BrokerClient) ListRelays(ctx context.Context, limit int, clientID, sessi
 
 	httpClient := c.HTTPClient
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = defaultBrokerHTTPClient
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)

--- a/internal/client/ech.go
+++ b/internal/client/ech.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	cloudflareBrokerHost = "broker.openrung.org"
+
+	// Keep the entire ECH phase below desktop discovery's 2.5-second
+	// cross-front stagger and the WSS ticket path's 5-second per-front limit.
+	// A censor that blackholes ECH therefore reaches the ordinary TLS fallback
+	// while the same Cloudflare request still has time to succeed.
+	brokerECHTimeout = 2 * time.Second
+)
+
+// embeddedCloudflareECHConfigList is a serialized ECHConfigList, including its
+// outer uint16 length. It is deliberately compiled into every Go client: never
+// replace this with an HTTPS/SVCB lookup, because blocking that DNS bootstrap
+// is how the networks this protects disable ECH.
+//
+// This list was captured from Cloudflare's certificate-authenticated ECH retry
+// on 2026-07-24, without an ECH DNS lookup.
+//
+// Cloudflare authenticates a newer list in the outer TLS handshake when this
+// one becomes stale. brokerECHConfigState adopts such a retry list only after
+// a connection using it succeeds.
+var embeddedCloudflareECHConfigList = []byte{
+	0x00, 0x45, 0xfe, 0x0d, 0x00, 0x41, 0x19, 0x00,
+	0x20, 0x00, 0x20, 0xe2, 0xaf, 0xd5, 0x98, 0x82,
+	0xdc, 0xb5, 0xfd, 0xcd, 0xc8, 0x84, 0x9c, 0x8e,
+	0x40, 0x33, 0x7b, 0xff, 0xda, 0xad, 0xca, 0x65,
+	0xac, 0x36, 0xcf, 0xbf, 0x38, 0x9c, 0x56, 0xd1,
+	0xb6, 0x99, 0x14, 0x00, 0x04, 0x00, 0x01, 0x00,
+	0x01, 0x00, 0x12, 0x63, 0x6c, 0x6f, 0x75, 0x64,
+	0x66, 0x6c, 0x61, 0x72, 0x65, 0x2d, 0x65, 0x63,
+	0x68, 0x2e, 0x63, 0x6f, 0x6d, 0x00, 0x00,
+}
+
+type brokerECHConfigState struct {
+	mu         sync.RWMutex
+	configList []byte
+	generation uint64
+}
+
+func newBrokerECHConfigState(configList []byte) *brokerECHConfigState {
+	return &brokerECHConfigState{configList: bytes.Clone(configList)}
+}
+
+func (s *brokerECHConfigState) snapshot() ([]byte, uint64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return bytes.Clone(s.configList), s.generation
+}
+
+// promote installs a certificate-authenticated retry list after a successful
+// ECH retry. The generation check prevents an older concurrent handshake from
+// replacing a config that another request refreshed first.
+func (s *brokerECHConfigState) promote(oldGeneration uint64, configList []byte) {
+	if len(configList) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.generation != oldGeneration {
+		return
+	}
+	s.configList = bytes.Clone(configList)
+	s.generation++
+}
+
+type brokerECHDialer struct {
+	networkDial       func(context.Context, string, string) (net.Conn, error)
+	baseTLSConfig     *tls.Config
+	state             *brokerECHConfigState
+	echTimeout        time.Duration
+	tlsHandshakeLimit time.Duration
+}
+
+func (d *brokerECHDialer) dialTLSContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if !isCloudflareBrokerAddress(address) {
+		return d.dialTLS(ctx, network, address, host, nil, d.tlsHandshakeLimit)
+	}
+
+	configList, generation := d.state.snapshot()
+	echCtx, cancelECH := context.WithTimeout(ctx, d.echTimeout)
+	conn, echErr := d.dialTLS(echCtx, network, address, host, configList, 0)
+	if echErr == nil {
+		cancelECH()
+		return conn, nil
+	}
+
+	var rejection *tls.ECHRejectionError
+	if errors.As(echErr, &rejection) && len(rejection.RetryConfigList) != 0 && echCtx.Err() == nil {
+		retryList := bytes.Clone(rejection.RetryConfigList)
+		conn, retryErr := d.dialTLS(echCtx, network, address, host, retryList, 0)
+		if retryErr == nil {
+			cancelECH()
+			d.state.promote(generation, retryList)
+			return conn, nil
+		}
+	}
+	cancelECH()
+
+	// Cancellation means the caller no longer wants this request (for example,
+	// another desktop discovery front won). Never leak a plain SNI afterward.
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// ECH is an opportunistic privacy layer, not a reachability requirement.
+	// Redial from scratch without ECH so networks that drop ECH handshakes keep
+	// today's broker behavior and certificate verification.
+	return d.dialTLS(ctx, network, address, host, nil, d.tlsHandshakeLimit)
+}
+
+func (d *brokerECHDialer) dialTLS(
+	ctx context.Context,
+	network string,
+	address string,
+	host string,
+	configList []byte,
+	handshakeLimit time.Duration,
+) (net.Conn, error) {
+	plainConn, err := d.networkDial(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &tls.Config{}
+	if d.baseTLSConfig != nil {
+		config = d.baseTLSConfig.Clone()
+	}
+	if config.ServerName == "" {
+		config.ServerName = strings.TrimSuffix(host, ".")
+	}
+	config.EncryptedClientHelloConfigList = bytes.Clone(configList)
+	if len(configList) != 0 && config.MinVersion != 0 && config.MinVersion < tls.VersionTLS13 {
+		config.MinVersion = tls.VersionTLS13
+	}
+
+	tlsConn := tls.Client(plainConn, config)
+	handshakeCtx := ctx
+	if handshakeLimit > 0 {
+		var cancel context.CancelFunc
+		handshakeCtx, cancel = context.WithTimeout(ctx, handshakeLimit)
+		defer cancel()
+	}
+	if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		_ = plainConn.Close()
+		return nil, err
+	}
+	return tlsConn, nil
+}
+
+func isCloudflareBrokerAddress(address string) bool {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return false
+	}
+	host = strings.TrimSuffix(host, ".")
+	return port == "443" && strings.EqualFold(host, cloudflareBrokerHost)
+}
+
+func newBrokerTransport(
+	base *http.Transport,
+	state *brokerECHConfigState,
+	echTimeout time.Duration,
+) *http.Transport {
+	transport := base.Clone()
+	dialer := &brokerECHDialer{
+		networkDial:       transport.DialContext,
+		baseTLSConfig:     transport.TLSClientConfig,
+		state:             state,
+		echTimeout:        echTimeout,
+		tlsHandshakeLimit: transport.TLSHandshakeTimeout,
+	}
+	transport.DialTLSContext = dialer.dialTLSContext
+	return transport
+}
+
+var (
+	defaultBrokerECHState  = newBrokerECHConfigState(embeddedCloudflareECHConfigList)
+	defaultBrokerTransport = newBrokerTransport(
+		http.DefaultTransport.(*http.Transport),
+		defaultBrokerECHState,
+		brokerECHTimeout,
+	)
+	defaultBrokerHTTPClient = &http.Client{Transport: defaultBrokerTransport}
+)
+
+// NewBrokerHTTPClient returns an HTTP client whose direct connections to the
+// Cloudflare broker front opportunistically use the embedded ECH config.
+// CloudFront, custom brokers, loopback development, and proxy CONNECT paths
+// keep the standard transport behavior. All returned clients share connection
+// pools and certificate-authenticated ECH retry-config state.
+func NewBrokerHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: defaultBrokerTransport,
+		Timeout:   timeout,
+	}
+}

--- a/internal/client/ech_test.go
+++ b/internal/client/ech_test.go
@@ -300,6 +300,94 @@ func TestBrokerECHDialerDoesNotForceHTTP2ALPN(t *testing.T) {
 	}
 }
 
+func TestBrokerECHBlackholeFallsBackAtHTTPLevel(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	listener := newPipeListener()
+	tlsListener := tls.NewListener(listener, testBrokerServerConfig(certificate))
+	var handlerCalls atomic.Int64
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlerCalls.Add(1)
+			if r.Method != http.MethodGet || r.URL.Path != "/blackhole-fallback" {
+				t.Errorf("request = %s %s", r.Method, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ErrorLog: log.New(io.Discard, "", 0),
+	}
+	serveDone := make(chan struct{})
+	go func() {
+		_ = server.Serve(tlsListener)
+		close(serveDone)
+	}()
+
+	var dials atomic.Int64
+	var blackhole net.Conn
+	networkDial := func(ctx context.Context, network, address string) (net.Conn, error) {
+		if dials.Add(1) == 1 {
+			clientSide, serverSide := net.Pipe()
+			blackhole = serverSide
+			return clientSide, nil
+		}
+		return listener.DialContext(ctx, network, address)
+	}
+	t.Cleanup(func() {
+		if blackhole != nil {
+			_ = blackhole.Close()
+		}
+		_ = server.Close()
+		_ = listener.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(time.Second):
+			t.Error("HTTP server did not stop")
+		}
+	})
+
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport.Proxy = nil
+	baseTransport.DialContext = networkDial
+	baseTransport.TLSClientConfig = &tls.Config{
+		RootCAs:    roots,
+		MinVersion: tls.VersionTLS13,
+		NextProtos: []string{"http/1.1"},
+	}
+	baseTransport.TLSHandshakeTimeout = time.Second
+	baseTransport.ForceAttemptHTTP2 = false
+
+	httpClient := &http.Client{
+		Transport: newBrokerTransport(
+			baseTransport,
+			newBrokerECHConfigState(embeddedCloudflareECHConfigList),
+			20*time.Millisecond,
+		),
+		Timeout: 2 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"https://"+cloudflareBrokerHost+"/blackhole-fallback",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET through blackholed ECH fallback: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if got := dials.Load(); got != 2 {
+		t.Fatalf("TLS connection attempts = %d, want blackholed ECH + plain fallback = 2", got)
+	}
+	if got := handlerCalls.Load(); got != 1 {
+		t.Fatalf("HTTP handler calls = %d, want exactly one GET", got)
+	}
+}
+
 func TestBrokerECHFallbackDoesNotReplayWSSTicketPOST(t *testing.T) {
 	certificate, roots := testBrokerCertificate(t)
 	listener := newPipeListener()

--- a/internal/client/ech_test.go
+++ b/internal/client/ech_test.go
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"errors"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+const testECHPublicName = "cloudflare-ech.com"
+
+func TestCloudflareBrokerAddress(t *testing.T) {
+	for _, tc := range []struct {
+		address string
+		want    bool
+	}{
+		{"broker.openrung.org:443", true},
+		{"BROKER.OPENRUNG.ORG:443", true},
+		{"broker.openrung.org.:443", true},
+		{"broker.openrung.org:8443", false},
+		{"sub.broker.openrung.org:443", false},
+		{"broker.openrung.org.example:443", false},
+		{"d2r7mdpyevvs1m.cloudfront.net:443", false},
+		{"127.0.0.1:443", false},
+		{"not-an-address", false},
+	} {
+		t.Run(tc.address, func(t *testing.T) {
+			if got := isCloudflareBrokerAddress(tc.address); got != tc.want {
+				t.Fatalf("isCloudflareBrokerAddress(%q) = %t, want %t", tc.address, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBrokerECHDialerRefreshesFromAuthenticatedRetryConfig(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	_, oldList, _ := testECHConfig(t, 17, testECHPublicName)
+	currentConfig, currentList, currentKey := testECHConfig(t, 29, testECHPublicName)
+	serverConfig := testBrokerServerConfig(certificate)
+	serverConfig.EncryptedClientHelloKeys = []tls.EncryptedClientHelloKey{{
+		Config:      currentConfig,
+		PrivateKey:  currentKey.Bytes(),
+		SendAsRetry: true,
+	}}
+
+	networkDial, results, calls := testTLSPipeDialer(serverConfig)
+	state := newBrokerECHConfigState(oldList)
+	dialer := testBrokerECHDialer(networkDial, roots, state)
+
+	conn, err := dialer.dialTLSContext(t.Context(), "tcp", cloudflareBrokerHost+":443")
+	if err != nil {
+		t.Fatalf("dial with stale ECH config: %v", err)
+	}
+	closeTLSConn(conn)
+
+	gotList, generation := state.snapshot()
+	attemptCount := int(calls.Load())
+	if attemptCount != 2 {
+		t.Fatalf("initial TLS connection attempts = %d, want stale + retry = 2", attemptCount)
+	}
+	first := readTLSServerResults(t, results, attemptCount)
+	if !bytes.Equal(gotList, currentList) || generation != 1 {
+		t.Fatalf("retry config was not promoted: generation=%d config=%x, want generation=1 config=%x", generation, gotList, currentList)
+	}
+
+	if first[0].state.ECHAccepted {
+		t.Fatal("server accepted the stale ECH config")
+	}
+	if first[0].err != nil {
+		t.Fatalf("stale ECH outer handshake failed before authenticated rejection: %v", first[0].err)
+	}
+	if first[1].err != nil || !first[1].state.ECHAccepted {
+		t.Fatalf("retry handshake = err %v, ECHAccepted %t", first[1].err, first[1].state.ECHAccepted)
+	}
+
+	// A later connection must start with the refreshed list, rather than pay
+	// the stale-config rejection again.
+	conn, err = dialer.dialTLSContext(t.Context(), "tcp", cloudflareBrokerHost+":443")
+	if err != nil {
+		t.Fatalf("dial with refreshed ECH config: %v", err)
+	}
+	closeTLSConn(conn)
+	later := readTLSServerResults(t, results, 1)[0]
+	if later.err != nil || !later.state.ECHAccepted {
+		t.Fatalf("later handshake = err %v, ECHAccepted %t", later.err, later.state.ECHAccepted)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("TLS connection attempts = %d, want stale + retry + one refreshed = 3", got)
+	}
+}
+
+func TestBrokerECHDialerFallsBackToPlainTLS(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	serverConfig := testBrokerServerConfig(certificate)
+	networkDial, results, calls := testTLSPipeDialer(serverConfig)
+	state := newBrokerECHConfigState(embeddedCloudflareECHConfigList)
+	dialer := testBrokerECHDialer(networkDial, roots, state)
+
+	conn, err := dialer.dialTLSContext(t.Context(), "tcp", cloudflareBrokerHost+":443")
+	if err != nil {
+		t.Fatalf("ECH rejection did not fall back to plain TLS: %v", err)
+	}
+	closeTLSConn(conn)
+
+	handshakes := readTLSServerResults(t, results, 2)
+	if handshakes[0].err != nil || handshakes[0].state.ECHAccepted {
+		t.Fatalf("embedded ECH outer handshake = err %v, ECHAccepted %t; want an authenticated rejection", handshakes[0].err, handshakes[0].state.ECHAccepted)
+	}
+	if handshakes[1].err != nil || handshakes[1].state.ECHAccepted {
+		t.Fatalf("plain fallback = err %v, ECHAccepted %t", handshakes[1].err, handshakes[1].state.ECHAccepted)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("TLS connection attempts = %d, want ECH + plain = 2", got)
+	}
+	gotList, generation := state.snapshot()
+	if !bytes.Equal(gotList, embeddedCloudflareECHConfigList) || generation != 0 {
+		t.Fatal("an empty retry config changed the shared ECH config")
+	}
+}
+
+func TestBrokerECHDialerBlackholeFallsBackWithinBudget(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	serverConfig := testBrokerServerConfig(certificate)
+	plainDial, results, _ := testTLSPipeDialer(serverConfig)
+
+	var calls atomic.Int64
+	var blackhole net.Conn
+	networkDial := func(ctx context.Context, network, address string) (net.Conn, error) {
+		if calls.Add(1) == 1 {
+			clientSide, serverSide := net.Pipe()
+			blackhole = serverSide
+			return clientSide, nil
+		}
+		return plainDial(ctx, network, address)
+	}
+	t.Cleanup(func() {
+		if blackhole != nil {
+			_ = blackhole.Close()
+		}
+	})
+
+	state := newBrokerECHConfigState(embeddedCloudflareECHConfigList)
+	dialer := testBrokerECHDialer(networkDial, roots, state)
+	dialer.echTimeout = 40 * time.Millisecond
+
+	started := time.Now()
+	conn, err := dialer.dialTLSContext(t.Context(), "tcp", cloudflareBrokerHost+":443")
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("blackholed ECH did not fall back: %v", err)
+	}
+	closeTLSConn(conn)
+	if elapsed > time.Second {
+		t.Fatalf("blackholed ECH fallback took %v, want well under 1s in this test", elapsed)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("network dials = %d, want blackholed ECH + plain = 2", got)
+	}
+	plain := readTLSServerResults(t, results, 1)[0]
+	if plain.err != nil || plain.state.ECHAccepted {
+		t.Fatalf("plain fallback = err %v, ECHAccepted %t", plain.err, plain.state.ECHAccepted)
+	}
+}
+
+func TestBrokerECHDialerCancellationDoesNotLeakPlainSNI(t *testing.T) {
+	_, roots := testBrokerCertificate(t)
+	started := make(chan struct{})
+	var calls atomic.Int64
+	var blackhole net.Conn
+	networkDial := func(context.Context, string, string) (net.Conn, error) {
+		calls.Add(1)
+		clientSide, serverSide := net.Pipe()
+		blackhole = serverSide
+		close(started)
+		return clientSide, nil
+	}
+	t.Cleanup(func() {
+		if blackhole != nil {
+			_ = blackhole.Close()
+		}
+	})
+
+	state := newBrokerECHConfigState(embeddedCloudflareECHConfigList)
+	dialer := testBrokerECHDialer(networkDial, roots, state)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := dialer.dialTLSContext(ctx, "tcp", cloudflareBrokerHost+":443")
+		done <- err
+	}()
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("dial error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled ECH handshake did not return")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("network dials after cancellation = %d, want only the ECH attempt", got)
+	}
+}
+
+func TestBrokerECHDialerPreservesCertificateVerification(t *testing.T) {
+	certificate, _ := testBrokerCertificate(t)
+	_, oldList, _ := testECHConfig(t, 41, testECHPublicName)
+	currentConfig, _, currentKey := testECHConfig(t, 42, testECHPublicName)
+	serverConfig := testBrokerServerConfig(certificate)
+	serverConfig.EncryptedClientHelloKeys = []tls.EncryptedClientHelloKey{{
+		Config:      currentConfig,
+		PrivateKey:  currentKey.Bytes(),
+		SendAsRetry: true,
+	}}
+	networkDial, results, calls := testTLSPipeDialer(serverConfig)
+
+	// Deliberately omit the test certificate from RootCAs. Both the outer ECH
+	// authentication and the ordinary broker certificate check must fail, and
+	// the unauthenticated retry list must not enter shared state.
+	state := newBrokerECHConfigState(oldList)
+	dialer := testBrokerECHDialer(networkDial, x509.NewCertPool(), state)
+	conn, err := dialer.dialTLSContext(t.Context(), "tcp", cloudflareBrokerHost+":443")
+	if conn != nil {
+		closeTLSConn(conn)
+	}
+	if err == nil {
+		t.Fatal("untrusted broker certificate was accepted")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("TLS connection attempts = %d, want failed ECH + failed plain = 2", got)
+	}
+	_ = readTLSServerResults(t, results, 2)
+	gotList, generation := state.snapshot()
+	if !bytes.Equal(gotList, oldList) || generation != 0 {
+		t.Fatal("retry config from an untrusted outer certificate changed shared state")
+	}
+}
+
+func TestBrokerECHDialerLeavesCloudFrontPlain(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	serverConfig := testBrokerServerConfig(certificate)
+	networkDial, results, calls := testTLSPipeDialer(serverConfig)
+	dialer := testBrokerECHDialer(networkDial, roots, newBrokerECHConfigState(embeddedCloudflareECHConfigList))
+
+	conn, err := dialer.dialTLSContext(t.Context(), "tcp", "d2r7mdpyevvs1m.cloudfront.net:443")
+	if err != nil {
+		t.Fatalf("CloudFront plain TLS dial: %v", err)
+	}
+	closeTLSConn(conn)
+	result := readTLSServerResults(t, results, 1)[0]
+	if result.err != nil || result.state.ECHAccepted {
+		t.Fatalf("CloudFront handshake = err %v, ECHAccepted %t", result.err, result.state.ECHAccepted)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("CloudFront TLS connection attempts = %d, want one plain attempt", got)
+	}
+}
+
+func TestBrokerECHDialerDoesNotForceHTTP2ALPN(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	serverConfig := testBrokerServerConfig(certificate)
+	serverConfig.NextProtos = []string{"h2", "http/1.1"}
+	networkDial, results, _ := testTLSPipeDialer(serverConfig)
+	dialer := testBrokerECHDialer(networkDial, roots, newBrokerECHConfigState(embeddedCloudflareECHConfigList))
+	dialer.baseTLSConfig.NextProtos = nil
+
+	conn, err := dialer.dialTLSContext(t.Context(), "tcp", "d2r7mdpyevvs1m.cloudfront.net:443")
+	if err != nil {
+		t.Fatalf("plain TLS dial without ALPN: %v", err)
+	}
+	closeTLSConn(conn)
+	result := readTLSServerResults(t, results, 1)[0]
+	if result.err != nil {
+		t.Fatalf("server handshake: %v", result.err)
+	}
+	if got := result.state.NegotiatedProtocol; got != "" {
+		t.Fatalf("negotiated protocol = %q, want none when the base TLS policy advertises none", got)
+	}
+}
+
+func TestBrokerECHFallbackDoesNotReplayWSSTicketPOST(t *testing.T) {
+	certificate, roots := testBrokerCertificate(t)
+	listener := newPipeListener()
+	tlsListener := tls.NewListener(listener, testBrokerServerConfig(certificate))
+	var handlerCalls atomic.Int64
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlerCalls.Add(1)
+			if r.Method != http.MethodPost || r.URL.Path != "/api/v1/wss/tickets" {
+				t.Errorf("request = %s %s", r.Method, r.URL.Path)
+			}
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Errorf("read request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ticket":"opaque","expires_at":"2026-07-24T12:00:00Z","url":"wss://relay.example/bridge"}`)
+		}),
+		ErrorLog: log.New(io.Discard, "", 0),
+	}
+	serveDone := make(chan struct{})
+	go func() {
+		_ = server.Serve(tlsListener)
+		close(serveDone)
+	}()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = listener.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(time.Second):
+			t.Error("HTTP server did not stop")
+		}
+	})
+
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport.Proxy = nil
+	baseTransport.DialContext = listener.DialContext
+	baseTransport.TLSClientConfig = &tls.Config{
+		RootCAs:    roots,
+		MinVersion: tls.VersionTLS13,
+		NextProtos: []string{"http/1.1"},
+	}
+	baseTransport.TLSHandshakeTimeout = time.Second
+	baseTransport.ForceAttemptHTTP2 = false
+
+	httpClient := &http.Client{
+		Transport: newBrokerTransport(
+			baseTransport,
+			newBrokerECHConfigState(embeddedCloudflareECHConfigList),
+			time.Second,
+		),
+		Timeout: 2 * time.Second,
+	}
+	_, err := (BrokerClient{
+		BaseURL:    "https://" + cloudflareBrokerHost,
+		HTTPClient: httpClient,
+	}).RequestWSSSessionTicket(t.Context(), relay.WSSSessionTicketRequest{
+		RelayID: "relay-1",
+		FrontID: "front-1",
+	}, "client-1", "session-1")
+	if err != nil {
+		t.Fatalf("request WSS ticket through ECH fallback: %v", err)
+	}
+	if got := handlerCalls.Load(); got != 1 {
+		t.Fatalf("WSS ticket handler calls = %d, want exactly one HTTP POST", got)
+	}
+	if got := listener.dials.Load(); got != 2 {
+		t.Fatalf("TLS connection attempts = %d, want rejected ECH + plain fallback = 2", got)
+	}
+}
+
+type tlsServerResult struct {
+	attempt int64
+	state   tls.ConnectionState
+	err     error
+}
+
+type pipeListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+	dials  atomic.Int64
+}
+
+func newPipeListener() *pipeListener {
+	return &pipeListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+}
+
+func (l *pipeListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.conns:
+		return conn, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *pipeListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *pipeListener) Addr() net.Addr { return pipeAddr{} }
+
+func (l *pipeListener) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	l.dials.Add(1)
+	clientSide, serverSide := net.Pipe()
+	select {
+	case l.conns <- serverSide:
+		return clientSide, nil
+	case <-ctx.Done():
+		_ = clientSide.Close()
+		_ = serverSide.Close()
+		return nil, ctx.Err()
+	case <-l.closed:
+		_ = clientSide.Close()
+		_ = serverSide.Close()
+		return nil, net.ErrClosed
+	}
+}
+
+type pipeAddr struct{}
+
+func (pipeAddr) Network() string { return "pipe" }
+func (pipeAddr) String() string  { return "pipe" }
+
+func testTLSPipeDialer(serverConfig *tls.Config) (
+	func(context.Context, string, string) (net.Conn, error),
+	<-chan tlsServerResult,
+	*atomic.Int64,
+) {
+	results := make(chan tlsServerResult, 16)
+	var calls atomic.Int64
+	dial := func(context.Context, string, string) (net.Conn, error) {
+		attempt := calls.Add(1)
+		clientSide, serverSide := net.Pipe()
+		go func() {
+			server := tls.Server(serverSide, serverConfig.Clone())
+			err := server.Handshake()
+			state := server.ConnectionState()
+			_ = serverSide.Close()
+			results <- tlsServerResult{attempt: attempt, state: state, err: err}
+		}()
+		return clientSide, nil
+	}
+	return dial, results, &calls
+}
+
+func closeTLSConn(conn net.Conn) {
+	_ = conn.SetDeadline(time.Now())
+	_ = conn.Close()
+}
+
+func readTLSServerResults(t *testing.T, results <-chan tlsServerResult, count int) []tlsServerResult {
+	t.Helper()
+	got := make([]tlsServerResult, 0, count)
+	for len(got) < count {
+		select {
+		case result := <-results:
+			got = append(got, result)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("received %d of %d TLS server results", len(got), count)
+		}
+	}
+	for index := 1; index < len(got); index++ {
+		for current := index; current > 0 && got[current].attempt < got[current-1].attempt; current-- {
+			got[current], got[current-1] = got[current-1], got[current]
+		}
+	}
+	return got
+}
+
+func testBrokerECHDialer(
+	networkDial func(context.Context, string, string) (net.Conn, error),
+	roots *x509.CertPool,
+	state *brokerECHConfigState,
+) *brokerECHDialer {
+	return &brokerECHDialer{
+		networkDial: networkDial,
+		baseTLSConfig: &tls.Config{
+			RootCAs:    roots,
+			MinVersion: tls.VersionTLS13,
+			NextProtos: []string{"http/1.1"},
+		},
+		state:             state,
+		echTimeout:        time.Second,
+		tlsHandshakeLimit: time.Second,
+	}
+}
+
+func testBrokerCertificate(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate certificate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "OpenRung ECH test"},
+		DNSNames: []string{
+			cloudflareBrokerHost,
+			testECHPublicName,
+			"d2r7mdpyevvs1m.cloudfront.net",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(parsed)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: parsed}, roots
+}
+
+func testBrokerServerConfig(certificate tls.Certificate) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"http/1.1"},
+	}
+}
+
+func testECHConfig(t *testing.T, id uint8, publicName string) ([]byte, []byte, *ecdh.PrivateKey) {
+	t.Helper()
+	key, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ECH key: %v", err)
+	}
+	config, configList := marshalTestECHConfig(t, id, key.PublicKey().Bytes(), publicName)
+	return config, configList, key
+}
+
+func marshalTestECHConfig(t *testing.T, id uint8, publicKey []byte, publicName string) ([]byte, []byte) {
+	t.Helper()
+	if len(publicKey) != 32 || len(publicName) > 255 {
+		t.Fatalf("invalid test ECH config input: public key=%d public name=%d", len(publicKey), len(publicName))
+	}
+
+	body := make([]byte, 0, 65)
+	body = append(body, id)
+	body = appendUint16(body, 0x0020) // DHKEM(X25519, HKDF-SHA256)
+	body = appendUint16(body, uint16(len(publicKey)))
+	body = append(body, publicKey...)
+	body = appendUint16(body, 4)
+	body = appendUint16(body, 0x0001) // HKDF-SHA256
+	body = appendUint16(body, 0x0001) // AES-128-GCM
+	body = append(body, 64, byte(len(publicName)))
+	body = append(body, publicName...)
+	body = appendUint16(body, 0) // extensions
+
+	config := make([]byte, 0, len(body)+4)
+	config = appendUint16(config, 0xfe0d)
+	config = appendUint16(config, uint16(len(body)))
+	config = append(config, body...)
+
+	configList := make([]byte, 0, len(config)+2)
+	configList = appendUint16(configList, uint16(len(config)))
+	configList = append(configList, config...)
+	return config, configList
+}
+
+func appendUint16(dst []byte, value uint16) []byte {
+	var encoded [2]byte
+	binary.BigEndian.PutUint16(encoded[:], value)
+	return append(dst, encoded[:]...)
+}

--- a/internal/client/wss_ticket.go
+++ b/internal/client/wss_ticket.go
@@ -79,7 +79,7 @@ func (c BrokerClient) RequestWSSSessionTicket(
 
 	httpClient := c.HTTPClient
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = defaultBrokerHTTPClient
 	}
 	noRedirectClient := *httpClient
 	noRedirectClient.CheckRedirect = func(*http.Request, []*http.Request) error {

--- a/internal/clienttelemetry/client.go
+++ b/internal/clienttelemetry/client.go
@@ -47,10 +47,14 @@ func (c HTTPClient) Send(ctx context.Context, events []Event) error {
 
 	httpClient := c.HTTP
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = client.NewBrokerHTTPClient(0)
+	}
+	noRedirectClient := *httpClient
+	noRedirectClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := noRedirectClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/clienttelemetry/client_test.go
+++ b/internal/clienttelemetry/client_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -70,6 +72,83 @@ func TestSendSetsIdentityHeadersAndBody(t *testing.T) {
 	}
 	if len(gotBatch.Events) != 1 || gotBatch.Events[0].EventID != "e1" {
 		t.Fatalf("unexpected batch body: %+v", gotBatch)
+	}
+}
+
+func TestSendNilHTTPClientUsesBrokerDefault(t *testing.T) {
+	type receivedRequest struct {
+		method    string
+		path      string
+		clientID  string
+		sessionID string
+	}
+	received := make(chan receivedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- receivedRequest{
+			method:    r.Method,
+			path:      r.URL.Path,
+			clientID:  r.Header.Get("X-OpenRung-Client-ID"),
+			sessionID: r.Header.Get("X-OpenRung-Session-ID"),
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	events := []Event{{EventID: "e1", ClientID: "client-1", SessionID: "session-1", Event: "x"}}
+	if err := (HTTPClient{BaseURL: server.URL}).Send(t.Context(), events); err != nil {
+		t.Fatalf("send with nil HTTP client: %v", err)
+	}
+
+	got := <-received
+	if got.method != http.MethodPost || got.path != "/api/v1/telemetry/events" {
+		t.Fatalf("request = %s %s, want POST /api/v1/telemetry/events", got.method, got.path)
+	}
+	if got.clientID != "client-1" || got.sessionID != "session-1" {
+		t.Fatalf("identity headers = client %q, session %q", got.clientID, got.sessionID)
+	}
+}
+
+func TestSendRefusesRedirectWithoutReplayingIdentity(t *testing.T) {
+	var originRequests atomic.Int64
+	var redirectedRequests atomic.Int64
+	var originSawIdentity atomic.Bool
+	var redirectLeakedIdentity atomic.Bool
+
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		if r.Header.Get("X-OpenRung-Client-ID") != "" || r.Header.Get("X-OpenRung-Session-ID") != "" {
+			redirectLeakedIdentity.Store(true)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer redirectTarget.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originRequests.Add(1)
+		if r.Header.Get("X-OpenRung-Client-ID") == "client-1" &&
+			r.Header.Get("X-OpenRung-Session-ID") == "session-1" {
+			originSawIdentity.Store(true)
+		}
+		http.Redirect(w, r, redirectTarget.URL+"/collect", http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	events := []Event{{EventID: "e1", ClientID: "client-1", SessionID: "session-1", Event: "x"}}
+	err := (HTTPClient{BaseURL: origin.URL}).Send(t.Context(), events)
+	if err == nil {
+		t.Fatal("redirected telemetry send succeeded, want redirect refusal")
+	}
+	if !originSawIdentity.Load() {
+		t.Fatal("origin did not receive the expected identity headers")
+	}
+	if got := originRequests.Load(); got != 1 {
+		t.Fatalf("origin requests = %d, want 1", got)
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target requests = %d, want 0", got)
+	}
+	if redirectLeakedIdentity.Load() {
+		t.Fatal("redirect replay leaked persistent identity headers")
 	}
 }
 


### PR DESCRIPTION
## Summary

- compile a Cloudflare ECHConfigList into the Go clients, with no HTTPS/SVCB lookup or runtime ECH DNS bootstrap
- use the shared ECH-aware transport for relay-list, WSS-ticket, CLI/desktop telemetry, CLI broker-health, and desktop discovery requests
- apply ECH only to broker.openrung.org:443; CloudFront, custom brokers, loopback development, and proxy CONNECT paths retain ordinary TLS

## Security and fallback behavior

- keep Go certificate verification enabled for accepted ECH, authenticated retry configs, and plain-TLS fallback
- cache a server retry config only after a verified ECH retry succeeds
- bound the complete ECH phase to two seconds, then redial with plain TLS so ECH remains optional on networks that drop it
- give the CLI health probe a four-second request budget inside its five-second overall window, leaving time for plain TLS after an ECH blackhole
- perform fallback below HTTP so broker POSTs and identity headers are sent only once
- refuse telemetry and health-probe redirects so identity data cannot be replayed and probes cannot escape to a different visible SNI
- leave relay-list Ed25519 signature verification unchanged

Mobile and relay data-path code are untouched.

## Validation

- `go vet ./...`
- `go test -race ./...`
- affected root and desktop race tests under Go 1.25.12
- desktop vet and race tests for every testable package (the packaged desktop build supplies the generated `frontend/dist` embed)
- focused ECH tests with `GODEBUG=http2client=0`
- direct no-DNS TLS validation against the Cloudflare front confirmed the embedded config negotiates ECH
