### PR TITLE
Add one-line volunteer relay bring-up script (volunteer-up.sh)

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -23,11 +23,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Foundation deploy state matrix
+      - name: Relay deploy state matrices
         run: |
           bash -n deploy/relay/foundation-up.sh
           bash -n deploy/relay/foundation-up_test.sh
           bash deploy/relay/foundation-up_test.sh
+          sh -n deploy/relay/volunteer-up.sh
+          sh -n deploy/relay/volunteer-up_test.sh
+          OPENRUNG_TEST_SHELL=/bin/dash sh deploy/relay/volunteer-up_test.sh
+          OPENRUNG_TEST_SHELL=/bin/bash sh deploy/relay/volunteer-up_test.sh
+          docker run --rm -v "$PWD:/src:ro" -w /src alpine:3 sh deploy/relay/volunteer-up_test.sh
 
   go:
     runs-on: ubuntu-latest

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -225,6 +225,36 @@ UUID for the client id, or let the first run generate them and copy from the log
 
 ## Run
 
+### One-line volunteer VPS bring-up
+
+For volunteers with any Linux VPS (public IPv4, inbound TCP 443 open), one
+line brings up a volunteer-class relay from the public image:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/openrung/openrung/main/deploy/relay/volunteer-up.sh | sudo sh
+```
+
+[`volunteer-up.sh`](volunteer-up.sh) applies the exact container posture of
+the Foundation fleet — host networking, `--cap-drop ALL --cap-add
+NET_BIND_SERVICE`, read-only rootfs with a `/tmp` tmpfs, settings in a
+root-owned mode-`0600` `/etc/openrung/relay.env`, registration against the
+broker's direct TLS origin — except that no `OPENRUNG_FOUNDATION_TOKEN` is
+installed, so the broker attests the relay volunteer-class. It auto-detects
+the public IPv4 address, mints a stable `OPENRUNG_IDENTITY_SEED` once, and
+verifies the relay registers before declaring success. Re-running the same
+line is the update path: the image is pulled and the container recreated
+while the env file (and with it the relay identity) is preserved.
+
+Overrides pass through `sudo env`, e.g.:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/openrung/openrung/main/deploy/relay/volunteer-up.sh | sudo env OPENRUNG_PUBLIC_HOST=203.0.113.7 OPENRUNG_LABEL=my-relay sh
+```
+
+To change settings later, edit `/etc/openrung/relay.env` and re-run the same
+command. A host set up this way is already in the canonical layout that
+`foundation-up.sh convert` expects, should it ever be promoted.
+
 ### Compose (recommended)
 
 [`docker-compose.yml`](docker-compose.yml) uses **host networking**, drops all

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -242,8 +242,11 @@ broker's direct TLS origin — except that no `OPENRUNG_FOUNDATION_TOKEN` is
 installed, so the broker attests the relay volunteer-class. It auto-detects
 the public IPv4 address, mints a stable `OPENRUNG_IDENTITY_SEED` once, and
 verifies the relay registers before declaring success. Re-running the same
-line is the update path: the image is pulled and the container recreated
-while the env file (and with it the relay identity) is preserved.
+line is the update path: the image is pulled, the serving container is retained
+as a stopped backup, and a separately named candidate must register and remain
+running without restarts before it is promoted. A failed start, crash loop, or
+registration timeout automatically restores the previous container. The env
+file (and with it the relay identity) is preserved throughout.
 
 Overrides pass through `sudo env`, e.g.:
 
@@ -254,6 +257,10 @@ curl -fsSL https://raw.githubusercontent.com/openrung/openrung/main/deploy/relay
 To change settings later, edit `/etc/openrung/relay.env` and re-run the same
 command. A host set up this way is already in the canonical layout that
 `foundation-up.sh convert` expects, should it ever be promoted.
+
+After promotion, this volunteer-only helper refuses the Foundation credential
+in `/etc/openrung/relay.env` without pulling an image or touching the relay.
+Use `foundation-up.sh update` for every subsequent Foundation-managed update.
 
 ### Compose (recommended)
 

--- a/deploy/relay/volunteer-up.sh
+++ b/deploy/relay/volunteer-up.sh
@@ -1,0 +1,256 @@
+#!/bin/sh
+#
+# One-line bring-up for a volunteer-run OpenRung relay on any Linux VPS:
+#
+#   curl -fsSL https://raw.githubusercontent.com/openrung/openrung/main/deploy/relay/volunteer-up.sh | sudo sh
+#
+# Runs the public relay image with the exact container posture of the
+# Foundation fleet (see foundation-up.sh / lightsail-up.sh): host networking,
+# --cap-drop ALL --cap-add NET_BIND_SERVICE, read-only rootfs with a /tmp
+# tmpfs, configuration in a root-owned mode-0600 /etc/openrung/relay.env —
+# except that no OPENRUNG_FOUNDATION_TOKEN is installed, so the broker attests
+# the relay volunteer-class.
+#
+# Re-running the same line is the update path: it pulls the image and recreates
+# the container but preserves the env file, so the stable relay identity
+# (OPENRUNG_IDENTITY_SEED, minted once on first run) survives. To change other
+# settings, edit /etc/openrung/relay.env and re-run.
+#
+# Overridable via env — pass through sudo, e.g.
+#   curl -fsSL .../volunteer-up.sh | sudo env OPENRUNG_PUBLIC_HOST=203.0.113.7 sh
+#   OPENRUNG_IMAGE        image to run (default ghcr.io/openrung/openrung-relay:main)
+#   OPENRUNG_BROKER_URL   broker to register with (default the broker's direct
+#                         TLS origin — the CDN front challenges datacenter IPs)
+#   OPENRUNG_PUBLIC_HOST  public IP/DNS clients use to reach this relay
+#                         (skips auto-detection; required on the first run when
+#                         detection is unavailable)
+#   OPENRUNG_LABEL        optional friendly name shown in the broker dashboard
+# Overrides configure the FIRST run; once /etc/openrung/relay.env exists it is
+# authoritative and overrides are ignored (edit the file instead).
+#
+# POSIX sh on purpose: this must run on whatever /bin/sh the volunteer's
+# distro ships (dash, busybox ash, bash).
+#
+# Everything except helper definitions lives in main(), invoked on the last
+# line: if the curl|sh stream is truncated mid-download, the shell hits EOF
+# inside an unterminated function and parses nothing — a partial download can
+# never execute a destructive prefix (like removing the serving container).
+set -eu
+
+# A private key (the identity seed) transits this script's variables: keep
+# xtrace off even when a volunteer debugs with 'sudo sh -x', so the seed can
+# never appear in trace output — same guard as foundation-up.sh and the fleet
+# bootstrap user-data.
+{ set +x; } 2>/dev/null
+
+die() { echo "volunteer-up: error: $*" >&2; exit 1; }
+log() { echo "volunteer-up: $*"; }
+
+# Strict dotted-quad, publicly-routable IPv4. The detection services' responses
+# are untrusted input headed for the env file and the public relay directory: a
+# glitched or truncated body must not register garbage, loopback, or private
+# space as this relay's public address.
+is_public_ipv4() {
+    case "$1" in *[!0-9.]* | '' | .* | *. | *.*.*.*.* | *..*) return 1 ;; esac
+    old_ifs=$IFS
+    IFS=.
+    # shellcheck disable=SC2086
+    set -- $1
+    IFS=$old_ifs
+    [ "$#" -eq 4 ] || return 1
+    for octet in "$@"; do
+        # Reject leading zeros: some client IP parsers refuse (or read as
+        # octal) addresses like 1.2.3.04, and no detection service emits them.
+        case "$octet" in 0) ;; 0*) return 1 ;; esac
+        [ "${#octet}" -le 3 ] || return 1
+        [ "$octet" -le 255 ] || return 1
+    done
+    if [ "$1" -eq 0 ] || [ "$1" -eq 10 ] || [ "$1" -eq 127 ] || [ "$1" -ge 224 ]; then return 1; fi
+    if [ "$1" -eq 100 ] && [ "$2" -ge 64 ] && [ "$2" -le 127 ]; then return 1; fi   # CGNAT
+    if [ "$1" -eq 169 ] && [ "$2" -eq 254 ]; then return 1; fi
+    if [ "$1" -eq 172 ] && [ "$2" -ge 16 ] && [ "$2" -le 31 ]; then return 1; fi
+    if [ "$1" -eq 192 ] && [ "$2" -eq 168 ]; then return 1; fi
+    return 0
+}
+
+detect_public_ipv4() {
+    # The relay's public address is published in the relay directory anyway, so
+    # a detection service learns nothing new. IPv4 on purpose: it matches the
+    # rest of the fleet, and an IPv4 relay is reachable from v6-only clients
+    # via their carrier's 464XLAT while the reverse is not true.
+    #
+    # Each attempt is captured and validated separately — a partial body from
+    # a failed attempt must never concatenate with a later one. Command
+    # substitution strips the trailing newline; is_public_ipv4 rejects any
+    # other stray byte. busybox wget has no -4 flag, hence the plain-wget
+    # retry; a dual-stack IPv6 answer from it fails validation harmlessly.
+    for url in https://api.ipify.org https://checkip.amazonaws.com; do
+        if command -v curl >/dev/null 2>&1; then
+            ip="$(curl -fsS4 --max-time 10 "$url" 2>/dev/null)" || ip=""
+        elif command -v wget >/dev/null 2>&1; then
+            ip="$(wget -4 -q -T 10 -O - "$url" 2>/dev/null)" \
+                || ip="$(wget -q -T 10 -O - "$url" 2>/dev/null)" \
+                || ip=""
+        else
+            return 1
+        fi
+        if is_public_ipv4 "$ip"; then
+            printf '%s' "$ip"
+            return 0
+        fi
+    done
+    return 1
+}
+
+main() {
+    IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
+    BROKER_URL="${OPENRUNG_BROKER_URL:-https://broker-origin.openrung.org}"
+    ENV_FILE=/etc/openrung/relay.env
+    CONTAINER=openrung-relay
+
+    [ "$(id -u)" = 0 ] \
+        || die "must run as root — rerun as:  curl -fsSL .../volunteer-up.sh | sudo sh"
+
+    # Operator-set values end up in an env file and in docker arguments; refuse
+    # whitespace and control characters (an embedded newline would inject extra
+    # variables into the file). case patterns match the whole string, so a
+    # value containing a newline cannot sneak past a per-line check.
+    case "$BROKER_URL" in *[![:graph:]]* | '') die "OPENRUNG_BROKER_URL is empty or contains whitespace/control characters" ;; esac
+    case "$IMAGE" in *[!A-Za-z0-9:/@._-]* | '') die "OPENRUNG_IMAGE contains unexpected characters" ;; esac
+    if [ -n "${OPENRUNG_LABEL:-}" ]; then
+        case "$OPENRUNG_LABEL" in *[!A-Za-z0-9._-]*) die "OPENRUNG_LABEL may use only letters, digits, '.', '_', '-'" ;; esac
+    fi
+
+    # Same package the Foundation fleet bootstrap installs (lightsail-up.sh
+    # user-data). On non-apt distros, installing Docker is the volunteer's step.
+    if ! command -v docker >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            log "installing docker.io"
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get -o DPkg::Lock::Timeout=300 update </dev/null
+            apt-get -o DPkg::Lock::Timeout=300 install -y docker.io </dev/null
+            if command -v systemctl >/dev/null 2>&1; then systemctl enable --now docker; fi
+        else
+            die "docker is not installed and this is not an apt-based system; install Docker (https://docs.docker.com/engine/install/) and re-run"
+        fi
+    fi
+
+    # Legacy artifacts mean an old deploy/volunteer setup is (or was) serving
+    # here; both would contend for port 443 on the host network, and
+    # foundation-up.sh refuses hosts carrying them. Refuse rather than guess —
+    # the migration steps are in deploy/relay/README.md.
+    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx openrung-volunteer; then
+        die "legacy 'openrung-volunteer' container found; migrate it first (see deploy/relay/README.md), or remove it with: docker rm -f openrung-volunteer"
+    fi
+    if [ -e /etc/openrung/volunteer.env ] || [ -L /etc/openrung/volunteer.env ]; then
+        die "legacy /etc/openrung/volunteer.env found; migrate its settings into $ENV_FILE (see deploy/relay/README.md) and remove it, then re-run"
+    fi
+
+    # An existing openrung-relay container this script did not set up — a
+    # Compose project (docker-compose.yml pins the same container name) or a
+    # hand-run container with its settings in docker -e arguments — must not be
+    # silently destroyed: recreating it from $ENV_FILE would rotate its relay
+    # identity and drop its settings.
+    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
+        compose_project="$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project"}}' "$CONTAINER" 2>/dev/null)" || compose_project=""
+        if [ -n "$compose_project" ]; then
+            die "existing '$CONTAINER' container is managed by docker compose (project '$compose_project'); update it with compose (see deploy/relay/README.md) instead of this script"
+        fi
+        if [ ! -f "$ENV_FILE" ]; then
+            die "existing '$CONTAINER' container was not set up by this script (no $ENV_FILE); refusing to replace it — its identity and settings live only in that container. To hand management to this script, remove it first: docker rm -f $CONTAINER"
+        fi
+    fi
+
+    if [ -f "$ENV_FILE" ]; then
+        log "reusing existing $ENV_FILE (stable relay identity preserved)"
+        if [ -n "${OPENRUNG_BROKER_URL:-}" ] || [ -n "${OPENRUNG_PUBLIC_HOST:-}" ] || [ -n "${OPENRUNG_LABEL:-}" ]; then
+            log "note: OPENRUNG_* overrides do not change an existing $ENV_FILE — edit that file and re-run instead"
+        fi
+        # Diagnostics below must name the broker the relay actually uses: the
+        # env file is authoritative, last occurrence wins (docker --env-file
+        # semantics).
+        effective_broker="$(sed -n 's/^OPENRUNG_BROKER_URL=//p' "$ENV_FILE" | tail -1)" || effective_broker=""
+        if [ -n "$effective_broker" ]; then BROKER_URL="$effective_broker"; fi
+    else
+        PUBLIC_HOST="${OPENRUNG_PUBLIC_HOST:-}"
+        if [ -z "$PUBLIC_HOST" ]; then
+            PUBLIC_HOST="$(detect_public_ipv4)" || PUBLIC_HOST=""
+            [ -n "$PUBLIC_HOST" ] \
+                || die "could not auto-detect a public IPv4 address; re-run with OPENRUNG_PUBLIC_HOST=<public IP or DNS name>"
+        else
+            case "$PUBLIC_HOST" in *[!A-Za-z0-9.:-]* | '') die "OPENRUNG_PUBLIC_HOST contains unexpected characters" ;; esac
+        fi
+
+        umask 077
+        install -d -m 700 /etc/openrung
+        # Minted once per host: the broker derives the stable relay ID from
+        # this seed (spec openrung-relay-identity-v1), so the relay keeps one
+        # identity across restarts and updates. The seed IS the relay's Ed25519
+        # private key: it lives only in the root-owned 0600 env file and is
+        # never echoed or traced.
+        SEED="$(head -c 32 /dev/urandom | base64 | tr -d '\n')"
+        [ -n "$SEED" ] || die "could not generate an identity seed"
+        {
+            printf 'OPENRUNG_BROKER_URL=%s\n' "$BROKER_URL"
+            printf 'OPENRUNG_PUBLIC_HOST=%s\n' "$PUBLIC_HOST"
+            printf 'OPENRUNG_IDENTITY_SEED=%s\n' "$SEED"
+            if [ -n "${OPENRUNG_LABEL:-}" ]; then printf 'OPENRUNG_LABEL=%s\n' "$OPENRUNG_LABEL"; fi
+            # The binary's default listen host is '::' (dual-stack, the fleet
+            # posture). Pin the IPv4 wildcard only when the kernel has no IPv6
+            # support at all, where a '::' bind cannot work.
+            if [ ! -e /proc/net/if_inet6 ]; then printf 'OPENRUNG_LISTEN_HOST=0.0.0.0\n'; fi
+        } >"$ENV_FILE.tmp"
+        mv "$ENV_FILE.tmp" "$ENV_FILE"
+        log "wrote $ENV_FILE (root-owned, mode 0600) with public host ${PUBLIC_HOST}"
+    fi
+
+    log "pulling $IMAGE"
+    docker pull "$IMAGE" >/dev/null
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    # Exact Foundation fleet container posture (foundation-up.sh run_candidate /
+    # lightsail-up.sh user-data): drop every capability, re-add only
+    # NET_BIND_SERVICE so the binary's cap_net_bind_service file capability can
+    # bind the privileged public port 443 — deliberately NO
+    # --security-opt no-new-privileges, which would make the kernel ignore file
+    # capabilities and break that bind. Read-only rootfs; the only writable
+    # path the relay needs is the generated xray config under the /tmp tmpfs.
+    docker run -d --name "$CONTAINER" --restart unless-stopped \
+        --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
+        --env-file "$ENV_FILE" \
+        "$IMAGE" >/dev/null
+
+    log "waiting for the relay to register with the broker"
+    i=0
+    while :; do
+        if docker logs "$CONTAINER" 2>&1 | grep -q 'registered relay'; then
+            if [ "$(docker inspect -f '{{.State.Running}} {{.RestartCount}}' "$CONTAINER" 2>/dev/null)" = "true 0" ]; then
+                log "$(docker logs "$CONTAINER" 2>&1 | grep 'registered relay' | tail -1)"
+                break
+            fi
+        fi
+        # unless-stopped restarts a crashing container forever; a nonzero
+        # RestartCount this early means a config problem (port 443 already in
+        # use, no IPv6, broker unreachable) — fail fast with the logs instead
+        # of spinning.
+        if [ "$(docker inspect -f '{{.RestartCount}}' "$CONTAINER" 2>/dev/null || echo 0)" != 0 ]; then
+            echo "volunteer-up: error: the relay is crash-looping; recent logs:" >&2
+            docker logs --tail 25 "$CONTAINER" >&2 || true
+            die "fix the cause above and re-run (the container was left in place for inspection: docker logs -f $CONTAINER)"
+        fi
+        i=$((i + 1))
+        if [ "$i" -ge 30 ]; then
+            echo "volunteer-up: error: the relay did not register within 60s; recent logs:" >&2
+            docker logs --tail 25 "$CONTAINER" >&2 || true
+            die "check that outbound HTTPS to ${BROKER_URL} works, then: docker logs -f $CONTAINER"
+        fi
+        sleep 2
+    done
+
+    log "done — this host is now serving as a volunteer-class OpenRung relay"
+    log "  open inbound TCP 443 in your provider's firewall (and 'ufw allow 443/tcp' if you use ufw)"
+    log "  logs:    docker logs -f $CONTAINER"
+    log "  update:  re-run the same one-line command (identity in $ENV_FILE is preserved)"
+    log "  remove:  docker rm -f $CONTAINER   # and delete $ENV_FILE to forget the relay identity"
+}
+
+main "$@"

--- a/deploy/relay/volunteer-up.sh
+++ b/deploy/relay/volunteer-up.sh
@@ -11,8 +11,10 @@
 # except that no OPENRUNG_FOUNDATION_TOKEN is installed, so the broker attests
 # the relay volunteer-class.
 #
-# Re-running the same line is the update path: it pulls the image and recreates
-# the container but preserves the env file, so the stable relay identity
+# Re-running the same line is the update path: it preserves the old container
+# until a separately named candidate registers and stays running, then promotes
+# the candidate and removes the backup. A failed candidate automatically rolls
+# back. The env file is preserved, so the stable relay identity
 # (OPENRUNG_IDENTITY_SEED, minted once on first run) survives. To change other
 # settings, edit /etc/openrung/relay.env and re-run.
 #
@@ -69,7 +71,13 @@ is_public_ipv4() {
     if [ "$1" -eq 100 ] && [ "$2" -ge 64 ] && [ "$2" -le 127 ]; then return 1; fi   # CGNAT
     if [ "$1" -eq 169 ] && [ "$2" -eq 254 ]; then return 1; fi
     if [ "$1" -eq 172 ] && [ "$2" -ge 16 ] && [ "$2" -le 31 ]; then return 1; fi
-    if [ "$1" -eq 192 ] && [ "$2" -eq 168 ]; then return 1; fi
+    # Special-purpose ranges that are not usable as a unique, globally
+    # reachable VPS endpoint: IETF protocol assignments, TEST-NET-1/2/3,
+    # deprecated 6to4 relay anycast, RFC1918, and benchmarking space.
+    case "$1.$2.$3" in
+        192.0.0 | 192.0.2 | 192.88.99 | 192.168.* \
+            | 198.18.* | 198.19.* | 198.51.100 | 203.0.113) return 1 ;;
+    esac
     return 0
 }
 
@@ -102,11 +110,147 @@ detect_public_ipv4() {
     return 1
 }
 
+container_inspect() {
+    docker inspect --type container "$@"
+}
+
+container_exists() {
+    container_inspect "$1" >/dev/null 2>&1
+}
+
+container_id() {
+    container_inspect -f '{{.Id}}' "$1" 2>/dev/null
+}
+
+assert_volunteer_env() {
+    if [ ! -e "$ENV_FILE" ] && [ ! -L "$ENV_FILE" ]; then return 0; fi
+    [ -f "$ENV_FILE" ] || die "$ENV_FILE exists but is not a regular file"
+    if grep -Eq '^OPENRUNG_FOUNDATION_TOKEN(=|[[:space:]]|$)' "$ENV_FILE"; then
+        die "$ENV_FILE contains an OPENRUNG_FOUNDATION_TOKEN assignment; this host is Foundation-managed — use deploy/relay/foundation-up.sh update"
+    else
+        grep_status=$?
+        [ "$grep_status" -eq 1 ] || die "could not inspect $ENV_FILE for Foundation ownership"
+    fi
+}
+
+container_foundation_marker() {
+    container_inspect -f '{{range .Config.Env}}{{if eq (index (split . "=") 0) "OPENRUNG_FOUNDATION_TOKEN"}}present{{end}}{{end}}' \
+        "$1" 2>/dev/null
+}
+
+# Best-effort rollback for a transaction that has already moved the previous
+# relay aside. This function deliberately does not call die(): it runs from the
+# exit trap, where recursive exits could strand the host in a worse state.
+rollback_transaction() {
+    set +e
+    rollback_cleanup_ok=1
+
+    if container_exists "$CONTAINER"; then
+        rollback_current_id="$(container_id "$CONTAINER")"
+        if [ -n "$OLD_ID" ] && [ "$rollback_current_id" = "$OLD_ID" ]; then
+            rollback_running="$(container_inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)"
+            if [ "$rollback_running" != true ]; then docker start "$CONTAINER" >/dev/null; fi
+            [ "$(container_inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" = true ]
+            return
+        fi
+        # A signal can arrive after the verified candidate was renamed but
+        # before the transaction flag was cleared. Never overwrite it.
+        if [ -n "$CANDIDATE_ID" ] && [ "$rollback_current_id" = "$CANDIDATE_ID" ]; then
+            return 0
+        fi
+        echo "volunteer-up: error: rollback found an unexpected '$CONTAINER' container; refusing to overwrite it" >&2
+        return 1
+    fi
+
+    if [ -n "$CANDIDATE_ID" ] && container_exists "$CANDIDATE_ID"; then
+        if [ "$(container_id "$CANDIDATE_ID")" != "$CANDIDATE_ID" ] \
+            || ! docker rm -f "$CANDIDATE_ID" >/dev/null 2>&1; then
+            rollback_cleanup_ok=0
+        fi
+    elif container_exists "$NEW_CONTAINER"; then
+        echo "volunteer-up: error: rollback does not own '$NEW_CONTAINER'; refusing to remove that ambiguous container" >&2
+        rollback_cleanup_ok=0
+    fi
+
+    if [ "$HAD_PREVIOUS" = 0 ]; then
+        [ "$rollback_cleanup_ok" = 1 ]
+        return
+    fi
+    container_exists "$OLD_CONTAINER" || {
+        echo "volunteer-up: error: rollback could not find the previous '$OLD_CONTAINER' container" >&2
+        return 1
+    }
+    rollback_old_id="$(container_id "$OLD_CONTAINER")"
+    if [ -z "$OLD_ID" ] || [ "$rollback_old_id" != "$OLD_ID" ]; then
+        echo "volunteer-up: error: rollback found that '$OLD_CONTAINER' changed identity; refusing to rename it" >&2
+        return 1
+    fi
+    docker rename "$OLD_CONTAINER" "$CONTAINER" >/dev/null || return 1
+    rollback_running="$(container_inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)"
+    if [ "$rollback_running" != true ]; then docker start "$CONTAINER" >/dev/null || return 1; fi
+    if [ "$(container_inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" != true ]; then
+        return 1
+    fi
+    log "restored the previous relay after the failed update"
+    [ "$rollback_cleanup_ok" = 1 ]
+    return
+}
+
+transaction_exit() {
+    transaction_status=$1
+    trap - 0 HUP INT TERM
+    if [ "$TRANSACTION_ACTIVE" = 1 ]; then
+        if ! rollback_transaction; then
+            echo "volunteer-up: error: automatic rollback was incomplete; inspect '$CONTAINER', '$OLD_CONTAINER', and '$NEW_CONTAINER' before making changes" >&2
+            transaction_status=1
+        fi
+    fi
+    exit "$transaction_status"
+}
+
+verify_candidate() {
+    verify_container=$1
+    log "waiting for the relay candidate to register with the broker"
+    verify_i=0
+    while :; do
+        verify_state="$(container_inspect -f '{{.State.Running}} {{.RestartCount}}' "$verify_container" 2>/dev/null)" \
+            || verify_state=""
+        if [ "$verify_state" = "true 0" ] \
+            && docker logs "$verify_container" 2>&1 | grep -q 'registered relay'; then
+            log "$(docker logs "$verify_container" 2>&1 | grep 'registered relay' | tail -1)"
+            return 0
+        fi
+
+        case "$verify_state" in
+            true\ 0) ;;
+            *)
+                echo "volunteer-up: error: the relay candidate stopped or restarted (state: ${verify_state:-unavailable}); recent logs:" >&2
+                docker logs --tail 25 "$verify_container" >&2 || true
+                return 1
+                ;;
+        esac
+
+        verify_i=$((verify_i + 1))
+        if [ "$verify_i" -ge 30 ]; then
+            echo "volunteer-up: error: the relay candidate did not register within 60s; recent logs:" >&2
+            docker logs --tail 25 "$verify_container" >&2 || true
+            return 1
+        fi
+        sleep 2
+    done
+}
+
 main() {
     IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
     BROKER_URL="${OPENRUNG_BROKER_URL:-https://broker-origin.openrung.org}"
     ENV_FILE=/etc/openrung/relay.env
     CONTAINER=openrung-relay
+    OLD_CONTAINER=openrung-relay-old
+    NEW_CONTAINER=openrung-relay-new
+    TRANSACTION_ACTIVE=0
+    HAD_PREVIOUS=0
+    OLD_ID=""
+    CANDIDATE_ID=""
 
     [ "$(id -u)" = 0 ] \
         || die "must run as root — rerun as:  curl -fsSL .../volunteer-up.sh | sudo sh"
@@ -119,6 +263,17 @@ main() {
     case "$IMAGE" in *[!A-Za-z0-9:/@._-]* | '') die "OPENRUNG_IMAGE contains unexpected characters" ;; esac
     if [ -n "${OPENRUNG_LABEL:-}" ]; then
         case "$OPENRUNG_LABEL" in *[!A-Za-z0-9._-]*) die "OPENRUNG_LABEL may use only letters, digits, '.', '_', '-'" ;; esac
+    fi
+
+    # The Foundation conversion workflow deliberately uses this same canonical
+    # env path. A Foundation token is therefore an ownership boundary, not an
+    # override this volunteer-only helper may preserve. Reject the key itself
+    # (even empty or duplicated) before installing Docker, pulling an image, or
+    # touching a container; Docker's last-duplicate-wins semantics must not let
+    # an ambiguous credential file be mistaken for volunteer state.
+    assert_volunteer_env
+    if [ -e /etc/openrung/volunteer.env ] || [ -L /etc/openrung/volunteer.env ]; then
+        die "legacy /etc/openrung/volunteer.env found; migrate its settings into $ENV_FILE (see deploy/relay/README.md) and remove it, then re-run"
     fi
 
     # Same package the Foundation fleet bootstrap installs (lightsail-up.sh
@@ -135,15 +290,19 @@ main() {
         fi
     fi
 
+    docker_names="$(docker ps -a --format '{{.Names}}' 2>/dev/null)" \
+        || die "could not inspect Docker containers; is the Docker daemon running?"
+
     # Legacy artifacts mean an old deploy/volunteer setup is (or was) serving
     # here; both would contend for port 443 on the host network, and
     # foundation-up.sh refuses hosts carrying them. Refuse rather than guess —
     # the migration steps are in deploy/relay/README.md.
-    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx openrung-volunteer; then
+    if printf '%s\n' "$docker_names" | grep -qx openrung-volunteer; then
         die "legacy 'openrung-volunteer' container found; migrate it first (see deploy/relay/README.md), or remove it with: docker rm -f openrung-volunteer"
     fi
-    if [ -e /etc/openrung/volunteer.env ] || [ -L /etc/openrung/volunteer.env ]; then
-        die "legacy /etc/openrung/volunteer.env found; migrate its settings into $ENV_FILE (see deploy/relay/README.md) and remove it, then re-run"
+    if printf '%s\n' "$docker_names" | grep -qx "$OLD_CONTAINER" \
+        || printf '%s\n' "$docker_names" | grep -qx "$NEW_CONTAINER"; then
+        die "an interrupted relay update is present; refusing to guess between '$OLD_CONTAINER' and '$NEW_CONTAINER'. Inspect them, restore the known-good container as '$CONTAINER', and re-run"
     fi
 
     # An existing openrung-relay container this script did not set up — a
@@ -151,14 +310,25 @@ main() {
     # hand-run container with its settings in docker -e arguments — must not be
     # silently destroyed: recreating it from $ENV_FILE would rotate its relay
     # identity and drop its settings.
-    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
-        compose_project="$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project"}}' "$CONTAINER" 2>/dev/null)" || compose_project=""
+    LIVE_EXISTS=0
+    if printf '%s\n' "$docker_names" | grep -qx "$CONTAINER"; then
+        LIVE_EXISTS=1
+        compose_project="$(container_inspect -f '{{index .Config.Labels "com.docker.compose.project"}}' "$CONTAINER" 2>/dev/null)" \
+            || die "could not inspect existing '$CONTAINER' container"
         if [ -n "$compose_project" ]; then
             die "existing '$CONTAINER' container is managed by docker compose (project '$compose_project'); update it with compose (see deploy/relay/README.md) instead of this script"
         fi
         if [ ! -f "$ENV_FILE" ]; then
             die "existing '$CONTAINER' container was not set up by this script (no $ENV_FILE); refusing to replace it — its identity and settings live only in that container. To hand management to this script, remove it first: docker rm -f $CONTAINER"
         fi
+        foundation_container_marker="$(container_foundation_marker "$CONTAINER")" \
+            || die "could not inspect '$CONTAINER' for Foundation ownership"
+        [ -z "$foundation_container_marker" ] \
+            || die "existing '$CONTAINER' carries OPENRUNG_FOUNDATION_TOKEN; this host is Foundation-managed — use deploy/relay/foundation-up.sh update"
+        live_running="$(container_inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" \
+            || die "could not inspect whether '$CONTAINER' is running"
+        [ "$live_running" = true ] \
+            || die "existing '$CONTAINER' is not running; inspect and recover it before attempting an update"
     fi
 
     if [ -f "$ENV_FILE" ]; then
@@ -206,7 +376,37 @@ main() {
 
     log "pulling $IMAGE"
     docker pull "$IMAGE" >/dev/null
-    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+
+    # Updates are a recoverable transaction. Host networking prevents the old
+    # and new relay from listening on 443 simultaneously, so retain the exact
+    # previous container under OLD_CONTAINER, stop it, and verify a separately
+    # named candidate. The exit/signal trap restores the old container on every
+    # ordinary failure; only a verified candidate is promoted to the canonical
+    # name, and the backup is removed last.
+    assert_volunteer_env
+    HAD_PREVIOUS=$LIVE_EXISTS
+    if [ "$HAD_PREVIOUS" = 1 ]; then
+        foundation_container_marker="$(container_foundation_marker "$CONTAINER")" \
+            || die "could not recheck '$CONTAINER' for Foundation ownership"
+        [ -z "$foundation_container_marker" ] \
+            || die "existing '$CONTAINER' became Foundation-managed during preflight; use deploy/relay/foundation-up.sh update"
+        OLD_ID="$(container_id "$CONTAINER")" \
+            || die "could not capture the identity of the existing '$CONTAINER' container"
+        [ -n "$OLD_ID" ] || die "existing '$CONTAINER' returned an empty container ID"
+    fi
+    TRANSACTION_ACTIVE=1
+    trap 'transaction_exit "$?"' 0
+    trap 'exit 1' HUP INT TERM
+
+    if [ "$HAD_PREVIOUS" = 1 ]; then
+        docker rename "$CONTAINER" "$OLD_CONTAINER" >/dev/null \
+            || die "could not preserve the previous relay as '$OLD_CONTAINER'"
+        [ "$(container_id "$OLD_CONTAINER")" = "$OLD_ID" ] \
+            || die "previous relay changed identity while it was being preserved"
+        docker stop "$OLD_CONTAINER" >/dev/null \
+            || die "could not stop the previous relay; automatic rollback will restore it"
+    fi
+
     # Exact Foundation fleet container posture (foundation-up.sh run_candidate /
     # lightsail-up.sh user-data): drop every capability, re-add only
     # NET_BIND_SERVICE so the binary's cap_net_bind_service file capability can
@@ -214,37 +414,54 @@ main() {
     # --security-opt no-new-privileges, which would make the kernel ignore file
     # capabilities and break that bind. Read-only rootfs; the only writable
     # path the relay needs is the generated xray config under the /tmp tmpfs.
-    docker run -d --name "$CONTAINER" --restart unless-stopped \
+    # Create and capture the candidate ID before starting it. Unlike inferring
+    # ownership from a name after `docker run` fails, this cannot claim or
+    # remove a container concurrently created by another process.
+    if ! CANDIDATE_ID="$(docker create --name "$NEW_CONTAINER" --restart unless-stopped \
         --network host --cap-drop ALL --cap-add NET_BIND_SERVICE --read-only --tmpfs /tmp \
+        --label org.openrung.managed-by=volunteer-up \
         --env-file "$ENV_FILE" \
-        "$IMAGE" >/dev/null
+        "$IMAGE")"; then
+        CANDIDATE_ID=""
+        die "the relay candidate could not be created; automatic rollback will restore the previous relay"
+    fi
+    [ -n "$CANDIDATE_ID" ] || die "relay candidate returned an empty container ID"
+    [ "$(container_id "$NEW_CONTAINER")" = "$CANDIDATE_ID" ] \
+        || die "relay candidate name does not resolve to the container this transaction created"
+    docker start "$CANDIDATE_ID" >/dev/null \
+        || die "the relay candidate failed to start; automatic rollback will restore the previous relay"
 
-    log "waiting for the relay to register with the broker"
-    i=0
-    while :; do
-        if docker logs "$CONTAINER" 2>&1 | grep -q 'registered relay'; then
-            if [ "$(docker inspect -f '{{.State.Running}} {{.RestartCount}}' "$CONTAINER" 2>/dev/null)" = "true 0" ]; then
-                log "$(docker logs "$CONTAINER" 2>&1 | grep 'registered relay' | tail -1)"
-                break
-            fi
-        fi
-        # unless-stopped restarts a crashing container forever; a nonzero
-        # RestartCount this early means a config problem (port 443 already in
-        # use, no IPv6, broker unreachable) — fail fast with the logs instead
-        # of spinning.
-        if [ "$(docker inspect -f '{{.RestartCount}}' "$CONTAINER" 2>/dev/null || echo 0)" != 0 ]; then
-            echo "volunteer-up: error: the relay is crash-looping; recent logs:" >&2
-            docker logs --tail 25 "$CONTAINER" >&2 || true
-            die "fix the cause above and re-run (the container was left in place for inspection: docker logs -f $CONTAINER)"
-        fi
-        i=$((i + 1))
-        if [ "$i" -ge 30 ]; then
-            echo "volunteer-up: error: the relay did not register within 60s; recent logs:" >&2
-            docker logs --tail 25 "$CONTAINER" >&2 || true
-            die "check that outbound HTTPS to ${BROKER_URL} works, then: docker logs -f $CONTAINER"
-        fi
-        sleep 2
-    done
+    verify_candidate "$NEW_CONTAINER" \
+        || die "the relay candidate failed verification; automatic rollback will restore the previous relay"
+
+    # Recheck the exact objects and health immediately before committing. These
+    # guards prevent a concurrent operator action from making the rollback
+    # delete or rename a container other than the ones this transaction owns.
+    [ "$(container_id "$NEW_CONTAINER")" = "$CANDIDATE_ID" ] \
+        || die "relay candidate changed identity before commit"
+    [ "$(container_inspect -f '{{.State.Running}} {{.RestartCount}}' "$NEW_CONTAINER" 2>/dev/null)" = "true 0" ] \
+        || die "relay candidate stopped or restarted before commit"
+    docker logs "$NEW_CONTAINER" 2>&1 | grep -q 'registered relay' \
+        || die "relay candidate registration evidence disappeared before commit"
+    if [ "$HAD_PREVIOUS" = 1 ]; then
+        [ "$(container_id "$OLD_CONTAINER")" = "$OLD_ID" ] \
+            || die "previous relay changed identity before commit"
+        [ "$(container_inspect -f '{{.State.Running}}' "$OLD_CONTAINER" 2>/dev/null)" = false ] \
+            || die "previous relay restarted unexpectedly before commit"
+    fi
+    if container_exists "$CONTAINER"; then
+        die "canonical container name '$CONTAINER' reappeared during the update"
+    fi
+
+    docker rename "$NEW_CONTAINER" "$CONTAINER" >/dev/null \
+        || die "could not promote the verified relay candidate"
+    TRANSACTION_ACTIVE=0
+    trap - 0 HUP INT TERM
+
+    if [ "$HAD_PREVIOUS" = 1 ]; then
+        docker rm "$OLD_CONTAINER" >/dev/null \
+            || die "the verified relay is live, but the stopped backup '$OLD_CONTAINER' could not be removed; inspect and remove that backup before the next update"
+    fi
 
     log "done — this host is now serving as a volunteer-class OpenRung relay"
     log "  open inbound TCP 443 in your provider's firewall (and 'ufw allow 443/tcp' if you use ufw)"

--- a/deploy/relay/volunteer-up_test.sh
+++ b/deploy/relay/volunteer-up_test.sh
@@ -1,0 +1,591 @@
+#!/bin/sh
+#
+# Regression tests for volunteer-up.sh.
+#
+# The helper is deliberately a POSIX-sh, curl-to-sh entry point rather than a
+# sourceable library.  These tests therefore exercise it as an operator would:
+# under dash (when available), with a file-backed Docker stub.  A temporary
+# copy changes only the two absolute /etc paths so the suite never needs root
+# and never touches the host's real relay configuration.
+set -u
+
+HERE=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT=$HERE/volunteer-up.sh
+
+if [ -n "${OPENRUNG_TEST_SHELL:-}" ]; then
+    TEST_SHELL=$OPENRUNG_TEST_SHELL
+elif command -v dash >/dev/null 2>&1; then
+    TEST_SHELL=$(command -v dash)
+else
+    TEST_SHELL=/bin/sh
+fi
+[ -x "$TEST_SHELL" ] || {
+    echo "FAIL: requested test shell is not executable: $TEST_SHELL" >&2
+    exit 1
+}
+
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/openrung-volunteer-test.XXXXXX") || exit 1
+trap 'rm -rf "$TEST_TMP"' 0
+trap 'exit 1' HUP INT TERM
+
+ENV_FILE=$TEST_TMP/relay.env
+LEGACY_ENV_FILE=$TEST_TMP/volunteer.env
+RUN_SCRIPT=$TEST_TMP/volunteer-up.sh
+LIB_SCRIPT=$TEST_TMP/volunteer-up-lib.sh
+FAKE_BIN=$TEST_TMP/bin
+SIM_DIR=$TEST_TMP/docker
+CONTAINERS=$SIM_DIR/containers
+DOCKER_LOG=$TEST_TMP/docker.log
+OUTPUT=$TEST_TMP/output
+
+mkdir -p "$FAKE_BIN" "$CONTAINERS" || exit 1
+
+# Keep this transformation intentionally narrow.  If the production helper's
+# entry point or path assignments change, fail loudly instead of accidentally
+# running an unmodified root-oriented script from the test suite.
+if [ "$(tail -n 1 "$SCRIPT")" != 'main "$@"' ]; then
+    echo "FAIL: volunteer-up.sh no longer ends with its guarded main entry point" >&2
+    exit 1
+fi
+
+sed \
+    -e "s|^    ENV_FILE=/etc/openrung/relay.env$|    ENV_FILE='$ENV_FILE'|" \
+    -e "s|/etc/openrung/volunteer.env|$LEGACY_ENV_FILE|g" \
+    "$SCRIPT" >"$RUN_SCRIPT" || exit 1
+sed '$d' "$RUN_SCRIPT" >"$LIB_SCRIPT" || exit 1
+
+cat >"$FAKE_BIN/id" <<'EOF'
+#!/bin/sh
+printf '0\n'
+EOF
+
+cat >"$FAKE_BIN/sleep" <<'EOF'
+#!/bin/sh
+# Registration timeout tests must not take a real minute.
+exit 0
+EOF
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/bin/sh
+set -u
+
+containers=$SIM_DIR/containers
+log=$DOCKER_LOG
+scenario=${SIM_SCENARIO:-ok}
+op=${1:-}
+[ "$#" -gt 0 ] && shift
+
+last_arg() {
+    last=
+    for value do last=$value; done
+    printf '%s' "$last"
+}
+
+read_state() {
+    state_name=$1
+    [ -f "$containers/$state_name" ] || return 1
+    read -r state_running state_restarts state_registered state_generation state_id \
+        <"$containers/$state_name"
+}
+
+resolve_name() {
+    resolve_ref=$1
+    if [ -f "$containers/$resolve_ref" ]; then
+        printf '%s' "$resolve_ref"
+        return 0
+    fi
+    for resolve_path in "$containers"/*; do
+        [ -f "$resolve_path" ] || continue
+        resolve_candidate=${resolve_path##*/}
+        read_state "$resolve_candidate" || continue
+        if [ "$state_id" = "$resolve_ref" ]; then
+            printf '%s' "$resolve_candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+write_state() {
+    printf '%s %s %s %s %s\n' "$2" "$3" "$4" "$5" "$6" >"$containers/$1"
+}
+
+case "$op" in
+    ps)
+        for state_path in "$containers"/*; do
+            [ -f "$state_path" ] || continue
+            printf '%s\n' "${state_path##*/}"
+        done
+        ;;
+    inspect)
+        format=
+        name=
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                -f | --format)
+                    format=$2
+                    shift 2
+                    ;;
+                *)
+                    name=$1
+                    shift
+                    ;;
+            esac
+        done
+        name=$(resolve_name "$name") || exit 1
+        read_state "$name" || exit 1
+        case "$format" in
+            *com.docker.compose.project*)
+                printf '\n'
+                ;;
+            *'{{.Id}}'*)
+                printf '%s\n' "$state_id"
+                ;;
+            *State.Running*RestartCount*)
+                printf '%s %s\n' "$state_running" "$state_restarts"
+                ;;
+            *RestartCount*)
+                printf '%s\n' "$state_restarts"
+                ;;
+            *State.Running*)
+                printf '%s\n' "$state_running"
+                ;;
+            *)
+                printf '\n'
+                ;;
+        esac
+        ;;
+    pull)
+        printf 'pull %s\n' "${1:-}" >>"$log"
+        ;;
+    stop)
+        stop_ref=$(last_arg "$@")
+        name=$(resolve_name "$stop_ref") || exit 1
+        printf 'stop %s\n' "$stop_ref" >>"$log"
+        read_state "$name" || exit 1
+        write_state "$name" false "$state_restarts" "$state_registered" "$state_generation" "$state_id"
+        ;;
+    rename)
+        source_ref=${1:-}
+        target_name=${2:-}
+        source_name=$(resolve_name "$source_ref") || exit 1
+        printf 'rename %s %s\n' "$source_name" "$target_name" >>"$log"
+        [ -f "$containers/$source_name" ] || exit 1
+        [ ! -e "$containers/$target_name" ] || exit 1
+        mv "$containers/$source_name" "$containers/$target_name"
+        ;;
+    create)
+        name=
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --name)
+                    name=$2
+                    shift 2
+                    ;;
+                --name=*)
+                    name=${1#--name=}
+                    shift
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        printf 'create %s\n' "$name" >>"$log"
+        [ -n "$name" ] || exit 2
+        [ ! -e "$containers/$name" ] || exit 1
+        if [ "$scenario" = create_fail ]; then
+            # Model a concurrent name-conflict race: create returns no ID, so
+            # the helper must not claim or remove the object that now owns the
+            # requested name.
+            write_state "$name" false 0 no alien id-alien
+            exit 1
+        fi
+        case "$scenario" in
+            crash_loop)
+                write_state "$name" false 1 no candidate id-candidate
+                ;;
+            no_register)
+                write_state "$name" false 0 no candidate id-candidate
+                ;;
+            *)
+                write_state "$name" false 0 yes candidate id-candidate
+                ;;
+        esac
+        printf 'id-candidate\n'
+        ;;
+    logs)
+        logs_ref=$(last_arg "$@")
+        name=$(resolve_name "$logs_ref") || exit 1
+        read_state "$name" || exit 1
+        if [ "$state_registered" = yes ]; then
+            printf 'registered relay (simulated)\n'
+        elif [ "$state_restarts" != 0 ]; then
+            printf 'simulated relay crash\n'
+        else
+            printf 'simulated relay awaiting registration\n'
+        fi
+        ;;
+    rm)
+        status=0
+        for rm_ref do
+            case "$rm_ref" in -*) continue ;; esac
+            name=$(resolve_name "$rm_ref") || {
+                status=1
+                continue
+            }
+            printf 'rm %s\n' "$name" >>"$log"
+            if [ -e "$containers/$name" ]; then
+                rm "$containers/$name"
+            else
+                status=1
+            fi
+        done
+        exit "$status"
+        ;;
+    start)
+        start_ref=$(last_arg "$@")
+        name=$(resolve_name "$start_ref") || exit 1
+        printf 'start %s\n' "$start_ref" >>"$log"
+        read_state "$name" || exit 1
+        if [ "$scenario" = start_fail ] && [ "$state_generation" = candidate ]; then
+            exit 1
+        fi
+        write_state "$name" true "$state_restarts" "$state_registered" "$state_generation" "$state_id"
+        printf '%s\n' "$start_ref"
+        ;;
+    *)
+        echo "unexpected docker operation: $op $*" >&2
+        exit 2
+        ;;
+esac
+EOF
+
+chmod +x "$FAKE_BIN/id" "$FAKE_BIN/sleep" "$FAKE_BIN/docker" || exit 1
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAIL=$((FAIL + 1))
+}
+
+assert_nonzero() {
+    if [ "$1" -ne 0 ]; then
+        pass
+    else
+        fail "$2: expected failure, got success"
+    fi
+}
+
+assert_log_has_create() {
+    if grep -q '^create ' "$DOCKER_LOG"; then
+        pass
+    else
+        fail "$1: candidate docker create was not exercised"
+    fi
+}
+
+assert_no_mutating_docker_calls() {
+    if grep -q \
+        -e '^pull ' \
+        -e '^stop ' \
+        -e '^rename ' \
+        -e '^create ' \
+        -e '^rm ' \
+        -e '^start ' \
+        "$DOCKER_LOG"; then
+        fail "$1: rejected configuration reached a Docker mutation"
+    else
+        pass
+    fi
+}
+
+assert_prior_is_live() {
+    if [ ! -f "$CONTAINERS/openrung-relay" ]; then
+        fail "$1: openrung-relay was not restored"
+        return
+    fi
+    read -r restored_running restored_restarts restored_registered restored_generation restored_id \
+        <"$CONTAINERS/openrung-relay"
+    if [ "$restored_running" = true ] \
+        && [ "$restored_generation" = prior ] \
+        && [ "$restored_id" = id-prior ] \
+        && [ ! -e "$CONTAINERS/openrung-relay-old" ] \
+        && [ ! -e "$CONTAINERS/openrung-relay-new" ]; then
+        pass
+    else
+        fail "$1: live state is '$restored_running $restored_restarts $restored_registered $restored_generation $restored_id', expected only the running prior container under the canonical name"
+    fi
+}
+
+assert_candidate_is_live() {
+    if [ ! -f "$CONTAINERS/openrung-relay" ]; then
+        fail "$1: promoted openrung-relay is missing"
+        return
+    fi
+    read -r promoted_running promoted_restarts promoted_registered promoted_generation promoted_id \
+        <"$CONTAINERS/openrung-relay"
+    if [ "$promoted_running" = true ] \
+        && [ "$promoted_restarts" = 0 ] \
+        && [ "$promoted_registered" = yes ] \
+        && [ "$promoted_generation" = candidate ] \
+        && [ "$promoted_id" = id-candidate ] \
+        && [ ! -e "$CONTAINERS/openrung-relay-old" ] \
+        && [ ! -e "$CONTAINERS/openrung-relay-new" ]; then
+        pass
+    else
+        fail "$1: live state is '$promoted_running $promoted_restarts $promoted_registered $promoted_generation $promoted_id', expected only the verified candidate under the canonical name"
+    fi
+}
+
+assert_prior_and_unowned_candidate_are_preserved() {
+    if [ ! -f "$CONTAINERS/openrung-relay" ] \
+        || [ ! -f "$CONTAINERS/openrung-relay-new" ] \
+        || [ -e "$CONTAINERS/openrung-relay-old" ]; then
+        fail "$1: expected restored canonical relay plus untouched unowned name-conflict container"
+        return
+    fi
+    read -r _ _ _ conflict_generation conflict_id \
+        <"$CONTAINERS/openrung-relay-new"
+    read -r restored_running restored_restarts restored_registered restored_generation restored_id \
+        <"$CONTAINERS/openrung-relay"
+    if [ "$restored_running" = true ] \
+        && [ "$restored_generation" = prior ] \
+        && [ "$restored_id" = id-prior ] \
+        && [ "$conflict_generation" = alien ] \
+        && [ "$conflict_id" = id-alien ]; then
+        pass
+    else
+        fail "$1: create failure claimed or disturbed a container ID it did not create"
+    fi
+}
+
+reset_simulation() {
+    rm -rf "$CONTAINERS"
+    mkdir -p "$CONTAINERS"
+    printf 'true 0 yes prior id-prior\n' >"$CONTAINERS/openrung-relay"
+    : >"$DOCKER_LOG"
+    rm -f "$LEGACY_ENV_FILE"
+}
+
+write_env() {
+    {
+        printf 'OPENRUNG_BROKER_URL=https://broker-origin.openrung.org\n'
+        printf 'OPENRUNG_PUBLIC_HOST=8.8.8.8\n'
+        printf 'OPENRUNG_IDENTITY_SEED=test-identity-seed\n'
+        while [ "$#" -gt 0 ]; do
+            printf '%s\n' "$1"
+            shift
+        done
+    } >"$ENV_FILE"
+}
+
+run_volunteer_up() {
+    run_scenario=$1
+    if PATH="$FAKE_BIN:$PATH" \
+        SIM_DIR="$SIM_DIR" \
+        DOCKER_LOG="$DOCKER_LOG" \
+        SIM_SCENARIO="$run_scenario" \
+        "$TEST_SHELL" "$RUN_SCRIPT" >"$OUTPUT" 2>&1; then
+        RUN_RC=0
+    else
+        RUN_RC=$?
+    fi
+}
+
+run_volunteer_up_with_host_foundation_token() {
+    run_scenario=$1
+    if OPENRUNG_FOUNDATION_TOKEN=host-foundation-secret \
+        PATH="$FAKE_BIN:$PATH" \
+        SIM_DIR="$SIM_DIR" \
+        DOCKER_LOG="$DOCKER_LOG" \
+        SIM_SCENARIO="$run_scenario" \
+        "$TEST_SHELL" "$RUN_SCRIPT" >"$OUTPUT" 2>&1; then
+        RUN_RC=0
+    else
+        RUN_RC=$?
+    fi
+}
+
+test_foundation_env_is_refused_before_mutation() {
+    reset_simulation
+    write_env 'OPENRUNG_FOUNDATION_TOKEN=foundation-secret'
+    run_volunteer_up ok
+    assert_nonzero "$RUN_RC" "Foundation-owned env"
+    assert_no_mutating_docker_calls "Foundation-owned env"
+    if grep -qi 'foundation' "$OUTPUT"; then
+        pass
+    else
+        fail "Foundation-owned env: refusal does not explain Foundation ownership"
+    fi
+    assert_prior_is_live "Foundation-owned env"
+}
+
+test_foundation_token_duplicates_fail_closed() {
+    # Docker --env-file gives the last duplicate to the container, but this
+    # helper cannot safely infer volunteer ownership from a blank or ambiguous
+    # Foundation assignment.  Treat every occurrence as a fail-closed
+    # Foundation ownership marker, regardless of ordering.
+    reset_simulation
+    write_env \
+        'OPENRUNG_FOUNDATION_TOKEN=' \
+        'OPENRUNG_FOUNDATION_TOKEN=last-value-is-usable'
+    run_volunteer_up create_fail
+    assert_nonzero "$RUN_RC" "last non-empty Foundation token"
+    assert_no_mutating_docker_calls "last non-empty Foundation token"
+    assert_prior_is_live "last non-empty Foundation token"
+
+    reset_simulation
+    write_env \
+        'OPENRUNG_FOUNDATION_TOKEN=shadowed-value' \
+        'OPENRUNG_FOUNDATION_TOKEN='
+    run_volunteer_up create_fail
+    assert_nonzero "$RUN_RC" "last empty Foundation token"
+    assert_no_mutating_docker_calls "last empty Foundation token"
+    assert_prior_is_live "last empty Foundation token"
+}
+
+test_bare_foundation_marker_is_refused() {
+    reset_simulation
+    write_env 'OPENRUNG_FOUNDATION_TOKEN'
+    run_volunteer_up_with_host_foundation_token create_fail
+    assert_nonzero "$RUN_RC" "bare Foundation token marker"
+    assert_no_mutating_docker_calls "bare Foundation token marker"
+    if grep -qi 'foundation' "$OUTPUT"; then
+        pass
+    else
+        fail "bare Foundation token marker: refusal does not explain Foundation ownership"
+    fi
+    assert_prior_is_live "bare Foundation token marker"
+}
+
+test_failed_candidate_create_preserves_unowned_conflict() {
+    reset_simulation
+    write_env
+    run_volunteer_up create_fail
+    assert_nonzero "$RUN_RC" "candidate create failure"
+    assert_log_has_create "candidate create failure"
+    assert_prior_and_unowned_candidate_are_preserved "candidate create failure"
+    if grep -q '^rm openrung-relay-new$' "$DOCKER_LOG"; then
+        fail "candidate create failure: removed the unowned name-conflict container"
+    else
+        pass
+    fi
+}
+
+test_failed_candidate_start_restores_prior() {
+    reset_simulation
+    write_env
+    run_volunteer_up start_fail
+    assert_nonzero "$RUN_RC" "candidate start failure"
+    assert_log_has_create "candidate start failure"
+    if grep -q '^start id-candidate$' "$DOCKER_LOG"; then
+        pass
+    else
+        fail "candidate start failure: candidate was not started by its exact create ID"
+    fi
+    assert_prior_is_live "candidate start failure"
+}
+
+test_crash_looping_candidate_restores_prior() {
+    reset_simulation
+    write_env
+    run_volunteer_up crash_loop
+    assert_nonzero "$RUN_RC" "candidate crash loop"
+    assert_log_has_create "candidate crash loop"
+    assert_prior_is_live "candidate crash loop"
+}
+
+test_unregistered_candidate_restores_prior() {
+    reset_simulation
+    write_env
+    run_volunteer_up no_register
+    assert_nonzero "$RUN_RC" "candidate registration timeout"
+    assert_log_has_create "candidate registration timeout"
+    assert_prior_is_live "candidate registration timeout"
+}
+
+test_successful_update_promotes_candidate() {
+    reset_simulation
+    write_env
+    run_volunteer_up ok
+    if [ "$RUN_RC" -eq 0 ]; then
+        pass
+    else
+        fail "successful candidate update: expected success, got exit $RUN_RC"
+    fi
+    assert_log_has_create "successful candidate update"
+    assert_candidate_is_live "successful candidate update"
+    promotion_line=$(sed -n '/^rename openrung-relay-new openrung-relay$/=' "$DOCKER_LOG" | head -1)
+    backup_rm_line=$(sed -n '/^rm openrung-relay-old$/=' "$DOCKER_LOG" | head -1)
+    if [ -n "$promotion_line" ] \
+        && [ -n "$backup_rm_line" ] \
+        && [ "$promotion_line" -lt "$backup_rm_line" ]; then
+        pass
+    else
+        fail "successful candidate update: candidate was not promoted before the old container was removed"
+    fi
+}
+
+expect_public_ipv4() {
+    # The selected child shell, not this harness, must expand its positional
+    # parameters after sourcing the helper library.
+    # shellcheck disable=SC2016
+    if "$TEST_SHELL" -c '. "$1"; is_public_ipv4 "$2"' sh "$LIB_SCRIPT" "$1" \
+        >"$OUTPUT" 2>&1; then
+        pass
+    else
+        fail "is_public_ipv4 rejected known public address $1"
+    fi
+}
+
+expect_non_public_ipv4() {
+    # shellcheck disable=SC2016
+    if "$TEST_SHELL" -c '. "$1"; is_public_ipv4 "$2"' sh "$LIB_SCRIPT" "$1" \
+        >"$OUTPUT" 2>&1; then
+        fail "is_public_ipv4 accepted non-global address $1"
+    else
+        pass
+    fi
+}
+
+test_special_ipv4_ranges() {
+    expect_public_ipv4 1.1.1.1
+    expect_public_ipv4 8.8.8.8
+
+    # RFC 5737 documentation networks (TEST-NET-1/2/3).
+    expect_non_public_ipv4 192.0.2.1
+    expect_non_public_ipv4 198.51.100.1
+    expect_non_public_ipv4 203.0.113.1
+
+    # IETF protocol-assignment and deprecated 6to4-relay anycast space.
+    expect_non_public_ipv4 192.0.0.1
+    expect_non_public_ipv4 192.88.99.1
+
+    # RFC 2544 benchmarking network (the full 198.18.0.0/15).
+    expect_non_public_ipv4 198.18.0.1
+    expect_non_public_ipv4 198.19.255.254
+}
+
+test_foundation_env_is_refused_before_mutation
+test_foundation_token_duplicates_fail_closed
+test_bare_foundation_marker_is_refused
+test_failed_candidate_create_preserves_unowned_conflict
+test_failed_candidate_start_restores_prior
+test_crash_looping_candidate_restores_prior
+test_unregistered_candidate_restores_prior
+test_successful_update_promotes_candidate
+test_special_ipv4_ranges
+
+if [ "$FAIL" -ne 0 ]; then
+    echo "volunteer-up tests: $PASS passed, $FAIL failed" >&2
+    exit 1
+fi
+
+echo "volunteer-up tests: $PASS passed"


### PR DESCRIPTION
## What

`deploy/relay/volunteer-up.sh`: volunteers with any Linux VPS bring up a **volunteer-class** relay with one line:

```sh
curl -fsSL https://raw.githubusercontent.com/openrung/openrung/main/deploy/relay/volunteer-up.sh | sudo sh
```

Setup is identical to the Foundation fleet posture minus the token: host networking, `--cap-drop ALL --cap-add NET_BIND_SERVICE`, read-only rootfs + `/tmp` tmpfs, root-owned mode-0600 `/etc/openrung/relay.env`, registration against the broker's direct TLS origin (`https://broker-origin.openrung.org` — the CDN front challenges datacenter IPs), and a stable `OPENRUNG_IDENTITY_SEED` minted once on first run (spec `openrung-relay-identity-v1`). No `OPENRUNG_FOUNDATION_TOKEN` is installed, so the broker attests `node_class=volunteer`. Re-running the same line is the update path; the env file (and identity) is preserved, and the host ends up in exactly the steady state `foundation-up.sh convert` accepts if it is ever promoted.

The README gains a matching "One-line volunteer VPS bring-up" section.

## Hardening

An adversarial multi-agent review ran against the first draft; every confirmed finding is fixed and was re-verified by experiment:

- **Truncation-safe**: whole body in `main()`, invoked on the last line. A `curl | sh` stream cut mid-download is an unterminated-function parse error that executes *nothing* — previously a cut between `docker rm -f` and `docker run` would have silently destroyed a serving relay on the update path (confirmed by byte-truncation experiments under dash/ash/bash).
- **No seed leakage**: xtrace is forced off (`{ set +x; } 2>/dev/null`, the foundation-up.sh guard), so `sudo sh -x` cannot print the Ed25519 identity seed.
- **Strict IP validation**: detected addresses must be a real dotted-quad, no leading zeros, and not loopback/RFC1918/CGNAT/link-local/multicast — a glitched detection response can no longer poison the env file/relay directory. Each detection attempt (ipify, then checkip.amazonaws.com) is captured and validated separately so a partial body cannot concatenate with a later response.
- **busybox compatibility**: busybox wget has no `-4`; the wget branch retries without it, keeping auto-detection working on Alpine-class hosts (curl-less, apt-less). Validation safely rejects a dual-stack IPv6 answer.
- **Never clobbers someone else's relay**: refuses legacy `openrung-volunteer` containers and `/etc/openrung/volunteer.env`, compose-managed `openrung-relay` containers (compose pins the same name), and any `openrung-relay` container it did not set up (present without the canonical env file).
- Diagnostics name the broker URL actually in the env file (last-occurrence-wins, matching `--env-file`), and overrides supplied on a re-run print a "edit the env file instead" note rather than being silently ignored.

## Testing

- 30-case unit suite for `is_public_ipv4` + end-to-end harness (stubbed docker/curl): first run, re-run identity preservation, truncated-stream safety, `sh -x` seed-leak check, compose-refusal — all passing under real **dash** (ubuntu:24.04), **busybox ash** (alpine:3), and **bash-as-sh**.
- busybox-wget fallback exercised against a stub that rejects `-4` exactly like busybox v1.37.
- `shellcheck -s sh` clean; `sh -n`/`bash -n` clean.
- `grep -q 'registered relay'` verified against `cmd/relay/main.go` — logged on every successful registration regardless of node class, only after xray and the listener are up.

Per our process: ready for Codex review, then user merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)