### PR TITLE
Shape relay egress with CAKE dual-dsthost for per-client fairness

### DIFF
--- a/deploy/relay/hetzner-up.sh
+++ b/deploy/relay/hetzner-up.sh
@@ -15,7 +15,7 @@
 #
 # Overridable via env: OPENRUNG_LOCATION, OPENRUNG_SERVER_TYPE, OPENRUNG_OS_IMAGE,
 # OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_SSH_KEY_NAME,
-# OPENRUNG_FIREWALL_NAME.
+# OPENRUNG_FIREWALL_NAME, OPENRUNG_SHAPE_RATE.
 #
 # This helper provisions anonymous volunteer-class relays only. It cannot safely
 # accept any registration bearer: Hetzner retains cloud-init user-data. Provision
@@ -37,6 +37,10 @@ SSH_KEY_NAME="${OPENRUNG_SSH_KEY_NAME:-openrung}"
 # This helper provisions volunteer-class nodes, and the live fleet already shares
 # this firewall resource. Keep its semantic class name to avoid orphaning it.
 FIREWALL_NAME="${OPENRUNG_FIREWALL_NAME:-openrung-volunteer}"
+# Egress CAKE shaping rate ('off' disables). CAX11 can push well past this,
+# but the rate must sit at or below true deliverable egress under real load so
+# the queue forms on the box, where CAKE manages it, not upstream.
+SHAPE_RATE="${OPENRUNG_SHAPE_RATE:-1000mbit}"
 
 if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_FOUNDATION_TOKEN+x}" = x ]; then
   echo "error: this helper provisions anonymous volunteer-class relays only; OPENRUNG_VOLUNTEER_TOKEN / OPENRUNG_FOUNDATION_TOKEN must be unset because Hetzner retains cloud-init user-data. A Foundation relay also needs a TLS broker, which this plaintext-origin helper does not use — install its credential post-boot over an authenticated channel instead." >&2
@@ -108,6 +112,38 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get -o DPkg::Lock::Timeout=300 update
 apt-get -o DPkg::Lock::Timeout=300 install -y docker.io curl
 systemctl enable --now docker
+# Per-client fairness + bufferbloat control: shape egress with CAKE in
+# dual-dsthost mode, so under contention every destination host (= client IP)
+# gets an equal share of the link, while a lone client may still use the full
+# rate (CAKE is work-conserving). besteffort collapses the DSCP tiers — tunnel
+# traffic is all one class. Installed as a boot unit so the qdisc survives
+# reboots. Best-effort: a shaping failure must never block relay bring-up.
+cat > /usr/local/sbin/openrung-shape <<'SHAPESCRIPT'
+#!/bin/sh
+set -eu
+RATE="${SHAPE_RATE}"
+case "\$RATE" in ""|off|none) exit 0 ;; esac
+DEV="\$(ip -o route get 1.1.1.1 | sed -n 's/.* dev \([^ ]*\).*/\1/p')"
+[ -n "\$DEV" ] || { echo "openrung-shape: no default-route device found" >&2; exit 1; }
+exec tc qdisc replace dev "\$DEV" root cake bandwidth "\$RATE" dual-dsthost besteffort
+SHAPESCRIPT
+chmod 0755 /usr/local/sbin/openrung-shape
+cat > /etc/systemd/system/openrung-shape.service <<'SHAPEUNIT'
+[Unit]
+Description=OpenRung egress fairness shaping (CAKE dual-dsthost)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/openrung-shape
+
+[Install]
+WantedBy=multi-user.target
+SHAPEUNIT
+systemctl daemon-reload
+systemctl enable --now openrung-shape.service || echo "warning: egress shaping unit failed; relay continues unshaped" >&2
 # Public IPv4 from the Hetzner metadata service; clients reach the relay here.
 PUBLIC_IP="\$(curl -fsS http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
 docker pull ${IMAGE}

--- a/deploy/relay/lightsail-up.sh
+++ b/deploy/relay/lightsail-up.sh
@@ -9,7 +9,7 @@
 # relay shows up in the broker dashboard under the same friendly name as the box.
 #
 # Overridable via env: OPENRUNG_REGION, OPENRUNG_AZ, OPENRUNG_BUNDLE,
-# OPENRUNG_BLUEPRINT, OPENRUNG_IMAGE, OPENRUNG_BROKER_URL.
+# OPENRUNG_BLUEPRINT, OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_SHAPE_RATE.
 #
 # This helper deliberately provisions only unauthenticated volunteer-class
 # relays. Lightsail retains user-data and the bootstrap log, so registration
@@ -25,6 +25,11 @@ BUNDLE="${OPENRUNG_BUNDLE:-micro_3_0}"          # 1GB RAM / 2 vCPU / 40GB / 2TB
 BLUEPRINT="${OPENRUNG_BLUEPRINT:-ubuntu_24_04}"
 IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
 BROKER_URL="${OPENRUNG_BROKER_URL:-http://54.238.185.205:8080}"
+# Egress CAKE shaping rate ('off' disables). Sized for the default micro
+# bundles; raise it when launching a bigger bundle. Must sit at or below the
+# instance's true deliverable egress: fairness only works when the queue forms
+# on the box, where CAKE manages it, not in the provider's switch.
+SHAPE_RATE="${OPENRUNG_SHAPE_RATE:-400mbit}"
 
 if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_FOUNDATION_TOKEN+x}" = x ] || [ "${OPENRUNG_NODE_CLASS+x}" = x ]; then
   echo "error: this helper does not accept registration tokens (including the foundation token) or node-class overrides because Lightsail user-data persists; configure them post-boot in a root-owned env file" >&2
@@ -74,6 +79,38 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get -o DPkg::Lock::Timeout=300 update
 apt-get -o DPkg::Lock::Timeout=300 install -y docker.io
 systemctl enable --now docker
+# Per-client fairness + bufferbloat control: shape egress with CAKE in
+# dual-dsthost mode, so under contention every destination host (= client IP)
+# gets an equal share of the link, while a lone client may still use the full
+# rate (CAKE is work-conserving). besteffort collapses the DSCP tiers — tunnel
+# traffic is all one class. Installed as a boot unit so the qdisc survives
+# reboots. Best-effort: a shaping failure must never block relay bring-up.
+cat > /usr/local/sbin/openrung-shape <<'SHAPESCRIPT'
+#!/bin/sh
+set -eu
+RATE="${SHAPE_RATE}"
+case "\$RATE" in ""|off|none) exit 0 ;; esac
+DEV="\$(ip -o route get 1.1.1.1 | sed -n 's/.* dev \([^ ]*\).*/\1/p')"
+[ -n "\$DEV" ] || { echo "openrung-shape: no default-route device found" >&2; exit 1; }
+exec tc qdisc replace dev "\$DEV" root cake bandwidth "\$RATE" dual-dsthost besteffort
+SHAPESCRIPT
+chmod 0755 /usr/local/sbin/openrung-shape
+cat > /etc/systemd/system/openrung-shape.service <<'SHAPEUNIT'
+[Unit]
+Description=OpenRung egress fairness shaping (CAKE dual-dsthost)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/openrung-shape
+
+[Install]
+WantedBy=multi-user.target
+SHAPEUNIT
+systemctl daemon-reload
+systemctl enable --now openrung-shape.service || echo "warning: egress shaping unit failed; relay continues unshaped" >&2
 docker pull ${IMAGE}
 docker rm -f openrung-relay 2>/dev/null || true
 # Minted once per instance: the broker derives the relay ID from this seed

--- a/deploy/relay/linode-up.sh
+++ b/deploy/relay/linode-up.sh
@@ -16,7 +16,7 @@
 #
 # Overridable via env: OPENRUNG_REGION, OPENRUNG_TYPE, OPENRUNG_OS_IMAGE,
 # OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_FIREWALL_NAME,
-# OPENRUNG_SSH_PUBKEY_FILE.
+# OPENRUNG_SSH_PUBKEY_FILE, OPENRUNG_SHAPE_RATE.
 #
 # This helper provisions anonymous volunteer-class relays only. It cannot safely
 # accept any registration bearer: Linode retains cloud-init user-data in the
@@ -36,6 +36,11 @@ IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relay:main}"
 # exactly like the Lightsail fleet (see lightsail-up.sh).
 BROKER_URL="${OPENRUNG_BROKER_URL:-http://54.238.185.205:8080}"
 FIREWALL_NAME="${OPENRUNG_FIREWALL_NAME:-openrung-relay}"
+# Egress CAKE shaping rate ('off' disables). g6-standard-1 has a 2 Gbps line,
+# but xray on its single shared vCPU tops out near 1 Gbps — the rate must sit
+# at or below true deliverable egress so the queue forms on the box, where
+# CAKE manages it, not in the provider's switch.
+SHAPE_RATE="${OPENRUNG_SHAPE_RATE:-1000mbit}"
 
 if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_FOUNDATION_TOKEN+x}" = x ]; then
   echo "error: this helper provisions anonymous volunteer-class relays only; OPENRUNG_VOLUNTEER_TOKEN / OPENRUNG_FOUNDATION_TOKEN must be unset because Linode retains cloud-init user-data. A Foundation relay also needs a TLS broker, which this plaintext-origin helper does not use — install its credential post-boot over an authenticated channel instead." >&2
@@ -115,6 +120,38 @@ systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
 apt-get -o DPkg::Lock::Timeout=300 update
 apt-get -o DPkg::Lock::Timeout=300 install -y docker.io curl jq
 systemctl enable --now docker
+# Per-client fairness + bufferbloat control: shape egress with CAKE in
+# dual-dsthost mode, so under contention every destination host (= client IP)
+# gets an equal share of the link, while a lone client may still use the full
+# rate (CAKE is work-conserving). besteffort collapses the DSCP tiers — tunnel
+# traffic is all one class. Installed as a boot unit so the qdisc survives
+# reboots. Best-effort: a shaping failure must never block relay bring-up.
+cat > /usr/local/sbin/openrung-shape <<'SHAPESCRIPT'
+#!/bin/sh
+set -eu
+RATE="${SHAPE_RATE}"
+case "\$RATE" in ""|off|none) exit 0 ;; esac
+DEV="\$(ip -o route get 1.1.1.1 | sed -n 's/.* dev \([^ ]*\).*/\1/p')"
+[ -n "\$DEV" ] || { echo "openrung-shape: no default-route device found" >&2; exit 1; }
+exec tc qdisc replace dev "\$DEV" root cake bandwidth "\$RATE" dual-dsthost besteffort
+SHAPESCRIPT
+chmod 0755 /usr/local/sbin/openrung-shape
+cat > /etc/systemd/system/openrung-shape.service <<'SHAPEUNIT'
+[Unit]
+Description=OpenRung egress fairness shaping (CAKE dual-dsthost)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/openrung-shape
+
+[Install]
+WantedBy=multi-user.target
+SHAPEUNIT
+systemctl daemon-reload
+systemctl enable --now openrung-shape.service || echo "warning: egress shaping unit failed; relay continues unshaped" >&2
 # Public IPv4 from the Linode Metadata service; clients reach the relay here.
 MDTOKEN="\$(curl -fsS -X PUT -H 'Metadata-Token-Expiry-Seconds: 300' http://169.254.169.254/v1/token || true)"
 PUBLIC_IP=""


### PR DESCRIPTION
## Why

The July bandwidth audit (Obsidian: *Bandwidth & Quota Audit*) found no abuse — but it did find that a single heavy client pulled 7.3% of all fleet traffic (245 GB in two days, sustained 29–81 Mbps bursts during peak hours), and that nothing on a relay arbitrates between clients when the link saturates: the default `mq`/`fq_codel` qdisc gives per-flow fairness only, so one bulk downloader with parallel connections crowds out interactive users and bufferbloats the box.

Per-client *quotas* were explicitly rejected (client_id is self-issued, relays only see source IPs, and hard caps would punish CGNAT'd users hardest). This is the no-identity alternative: instantaneous fairness at the packet scheduler.

## What

Each cloud bring-up helper (`lightsail-up.sh`, `linode-up.sh`, `hetzner-up.sh`) now installs, via user-data:

- `/usr/local/sbin/openrung-shape` — applies `tc qdisc replace dev <default-route-iface> root cake bandwidth <rate> dual-dsthost besteffort`
- `openrung-shape.service` — systemd oneshot (`network-online.target`), so the qdisc survives reboots

Behavior: under contention every destination host (= client IP) gets an equal share of egress, then fair per-flow within each host; a lone client may still use the full rate (CAKE is work-conserving). `besteffort` collapses DSCP tiers — tunnel traffic is all one class. CoDel AQM inside each flow queue keeps latency low for light users even at 100% utilization.

Defaults, overridable with `OPENRUNG_SHAPE_RATE` (`off` disables):

| helper | default | rationale |
|---|---|---|
| Lightsail | `400mbit` | micro bundles; raise for bigger bundles |
| Linode | `1000mbit` | 2 Gbps line but ~1 Gbps realistic xray ceiling on 1 shared vCPU |
| Hetzner | `1000mbit` | CAX11 same ballpark |

The rate must sit at or below true deliverable egress so the queue forms on the box where CAKE manages it, not in the provider's switch.

## Safety

- `systemctl enable --now` is guarded — a shaping failure warns and never blocks relay bring-up.
- `sch_cake` verified present on the current fleet's kernels (Ubuntu 6.17-aws, 6.8-generic).
- Rollback on a live box: `tc qdisc del dev <iface> root` (reverts to kernel default).
- Verified: dry-ran `lightsail-up.sh` against an AWS shim; generated user-data passes `sh -n` (dash/POSIX — Lightsail requirement), the boot-time-written script is byte-exact and valid.

## Not in this PR

- The currently *running* 7 boxes get the same qdisc via a prepared one-time SSH block (session handoff); this PR covers newly provisioned boxes.
- `volunteer-up.sh` (third-party hardware — shaping someone else's NIC should be opt-in; follow-up if wanted), `foundation-up.sh` convert path, and the relayhub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)