### PR TITLE
Add authenticated relay inventory endpoint

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -84,6 +84,10 @@ func run() error {
 	if foundationToken != "" && foundationToken == registrationToken {
 		return errors.New("OPENRUNG_FOUNDATION_TOKEN must differ from OPENRUNG_VOLUNTEER_TOKEN: a shared value would let any holder of the volunteer token register a foundation relay")
 	}
+	inventoryToken := os.Getenv("OPENRUNG_RELAY_INVENTORY_TOKEN")
+	if err := validateInventoryToken(inventoryToken, registrationToken, foundationToken, os.Getenv("OPENRUNG_DASHBOARD_TOKEN")); err != nil {
+		return err
+	}
 
 	// Fail closed on the signing key too: a missing or malformed seed must
 	// crash-loop (an ordinary, visible outage) rather than serve unsigned relay
@@ -121,6 +125,7 @@ func run() error {
 		RelayLeaseTTL:     *leaseTTL,
 		TelemetrySink:     telemetrySink,
 		DashboardToken:    os.Getenv("OPENRUNG_DASHBOARD_TOKEN"),
+		InventoryToken:    inventoryToken,
 		// Cloudflare's published ranges are trusted by default; add more (e.g. an upstream LB) here.
 		TrustedProxyCIDRs:          splitAndTrim(os.Getenv("OPENRUNG_TRUSTED_PROXY_CIDRS")),
 		MaxNewRelayIDsPerIPPerDay:  maxNewRelayIDs,
@@ -181,6 +186,22 @@ func run() error {
 		err = closeErr
 	}
 	return err
+}
+
+func validateInventoryToken(inventory, registration, foundation, dashboard string) error {
+	if inventory == "" {
+		return nil
+	}
+	for name, token := range map[string]string{
+		"OPENRUNG_VOLUNTEER_TOKEN":  registration,
+		"OPENRUNG_FOUNDATION_TOKEN": foundation,
+		"OPENRUNG_DASHBOARD_TOKEN":  dashboard,
+	} {
+		if token != "" && inventory == token {
+			return fmt.Errorf("OPENRUNG_RELAY_INVENTORY_TOKEN must differ from %s", name)
+		}
+	}
+	return nil
 }
 
 func versionInfo() string {

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -50,7 +50,8 @@ func run() error {
 		fmt.Println(versionInfo())
 		return nil
 	}
-	wssTicketSeed, err := parseOptionalWSSTicketSeed(os.Getenv("OPENRUNG_WSS_TICKET_SIGNING_SEED"))
+	wssTicketSigningSeed := os.Getenv("OPENRUNG_WSS_TICKET_SIGNING_SEED")
+	wssTicketSeed, err := parseOptionalWSSTicketSeed(wssTicketSigningSeed)
 	if err != nil {
 		return err
 	}
@@ -85,7 +86,8 @@ func run() error {
 		return errors.New("OPENRUNG_FOUNDATION_TOKEN must differ from OPENRUNG_VOLUNTEER_TOKEN: a shared value would let any holder of the volunteer token register a foundation relay")
 	}
 	inventoryToken := os.Getenv("OPENRUNG_RELAY_INVENTORY_TOKEN")
-	if err := validateInventoryToken(inventoryToken, registrationToken, foundationToken, os.Getenv("OPENRUNG_DASHBOARD_TOKEN")); err != nil {
+	relaySigningKey := os.Getenv("OPENRUNG_RELAY_SIGNING_KEY")
+	if err := validateInventoryToken(inventoryToken, registrationToken, foundationToken, os.Getenv("OPENRUNG_DASHBOARD_TOKEN"), relaySigningKey, wssTicketSigningSeed); err != nil {
 		return err
 	}
 
@@ -93,7 +95,7 @@ func run() error {
 	// crash-loop (an ordinary, visible outage) rather than serve unsigned relay
 	// lists, which healthz and old clients would never notice while every
 	// verifying client silently lost discovery.
-	signingSeed, err := broker.ParseSigningSeed(os.Getenv("OPENRUNG_RELAY_SIGNING_KEY"))
+	signingSeed, err := broker.ParseSigningSeed(relaySigningKey)
 	if err != nil {
 		return err
 	}
@@ -188,17 +190,22 @@ func run() error {
 	return err
 }
 
-func validateInventoryToken(inventory, registration, foundation, dashboard string) error {
+func validateInventoryToken(inventory, registration, foundation, dashboard, relaySigningKey, wssTicketSigningSeed string) error {
 	if inventory == "" {
 		return nil
 	}
-	for name, token := range map[string]string{
-		"OPENRUNG_VOLUNTEER_TOKEN":  registration,
-		"OPENRUNG_FOUNDATION_TOKEN": foundation,
-		"OPENRUNG_DASHBOARD_TOKEN":  dashboard,
+	for _, credential := range []struct {
+		name  string
+		value string
+	}{
+		{"OPENRUNG_VOLUNTEER_TOKEN", registration},
+		{"OPENRUNG_FOUNDATION_TOKEN", foundation},
+		{"OPENRUNG_DASHBOARD_TOKEN", dashboard},
+		{"OPENRUNG_RELAY_SIGNING_KEY", relaySigningKey},
+		{"OPENRUNG_WSS_TICKET_SIGNING_SEED", wssTicketSigningSeed},
 	} {
-		if token != "" && inventory == token {
-			return fmt.Errorf("OPENRUNG_RELAY_INVENTORY_TOKEN must differ from %s", name)
+		if credential.value != "" && inventory == credential.value {
+			return fmt.Errorf("OPENRUNG_RELAY_INVENTORY_TOKEN must differ from %s", credential.name)
 		}
 	}
 	return nil

--- a/cmd/broker/main_test.go
+++ b/cmd/broker/main_test.go
@@ -32,23 +32,30 @@ func TestParseOptionalWSSTicketSeed(t *testing.T) {
 }
 
 func TestValidateInventoryToken(t *testing.T) {
-	if err := validateInventoryToken("", "volunteer", "foundation", "dashboard"); err != nil {
+	if err := validateInventoryToken("", "volunteer", "foundation", "dashboard", "relay-seed", "wss-seed"); err != nil {
 		t.Fatalf("empty inventory token: %v", err)
 	}
 	for name, values := range map[string]struct {
-		inventory, registration, foundation, dashboard string
+		inventory, registration, foundation, dashboard, relaySigningKey, wssTicketSigningSeed string
 	}{
-		"volunteer":  {"same", "same", "foundation", "dashboard"},
-		"foundation": {"same", "volunteer", "same", "dashboard"},
-		"dashboard":  {"same", "volunteer", "foundation", "same"},
+		"volunteer":               {"same", "same", "foundation", "dashboard", "relay-seed", "wss-seed"},
+		"foundation":              {"same", "volunteer", "same", "dashboard", "relay-seed", "wss-seed"},
+		"dashboard":               {"same", "volunteer", "foundation", "same", "relay-seed", "wss-seed"},
+		"relay signing seed":      {"same", "volunteer", "foundation", "dashboard", "same", "wss-seed"},
+		"WSS ticket signing seed": {"same", "volunteer", "foundation", "dashboard", "relay-seed", "same"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := validateInventoryToken(values.inventory, values.registration, values.foundation, values.dashboard); err == nil {
+			if err := validateInventoryToken(values.inventory, values.registration, values.foundation, values.dashboard, values.relaySigningKey, values.wssTicketSigningSeed); err == nil {
 				t.Fatal("accepted equal credentials")
 			}
 		})
 	}
-	if err := validateInventoryToken("inventory", "volunteer", "foundation", "dashboard"); err != nil {
+	if err := validateInventoryToken("inventory", "volunteer", "foundation", "dashboard", "relay-seed", "wss-seed"); err != nil {
 		t.Fatalf("distinct credentials rejected: %v", err)
+	}
+	// The first configured conflict must always win so startup errors are stable.
+	err := validateInventoryToken("same", "same", "foundation", "dashboard", "same", "same")
+	if err == nil || !strings.Contains(err.Error(), "OPENRUNG_VOLUNTEER_TOKEN") {
+		t.Fatalf("conflict error = %v, want volunteer token", err)
 	}
 }

--- a/cmd/broker/main_test.go
+++ b/cmd/broker/main_test.go
@@ -30,3 +30,25 @@ func TestParseOptionalWSSTicketSeed(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateInventoryToken(t *testing.T) {
+	if err := validateInventoryToken("", "volunteer", "foundation", "dashboard"); err != nil {
+		t.Fatalf("empty inventory token: %v", err)
+	}
+	for name, values := range map[string]struct {
+		inventory, registration, foundation, dashboard string
+	}{
+		"volunteer":  {"same", "same", "foundation", "dashboard"},
+		"foundation": {"same", "volunteer", "same", "dashboard"},
+		"dashboard":  {"same", "volunteer", "foundation", "same"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateInventoryToken(values.inventory, values.registration, values.foundation, values.dashboard); err == nil {
+				t.Fatal("accepted equal credentials")
+			}
+		})
+	}
+	if err := validateInventoryToken("inventory", "volunteer", "foundation", "dashboard"); err != nil {
+		t.Fatalf("distinct credentials rejected: %v", err)
+	}
+}

--- a/deploy/broker/.env.example
+++ b/deploy/broker/.env.example
@@ -80,10 +80,11 @@ OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true
 # Dedicated bearer for GET /admin/api/relays/inventory. Unset keeps the route
 # absent (404). This is only for operator tooling such as bunny-wss-front.sh
 # inventory, never a dashboard, relay, client, or signing credential. It must
-# differ from the volunteer, Foundation, and dashboard tokens. Generate it
-# independently, keep the populated env file root-owned mode 0600 (or source a
-# secret manager), and rotate by recreating the container. Callers should read
-# a mode-0600 header file or use a secret-manager command, not put it in argv.
+# differ from every bearer token and signing seed. Generate it independently;
+# do not reuse the relay-list/WSS signing seeds or an external manifest-signing
+# seed. Keep the populated env file root-owned mode 0600 (or source a secret
+# manager), and rotate by recreating the container. Callers should read a
+# mode-0600 header file or use a secret-manager command, not put it in argv.
 #OPENRUNG_RELAY_INVENTORY_TOKEN=
 
 # ---------------------------------------------------------------------------

--- a/deploy/broker/.env.example
+++ b/deploy/broker/.env.example
@@ -77,6 +77,15 @@ OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true
 # HTTPS (e.g. behind Cloudflare) so the admin session cookie is protected.
 #OPENRUNG_DASHBOARD_TOKEN=
 
+# Dedicated bearer for GET /admin/api/relays/inventory. Unset keeps the route
+# absent (404). This is only for operator tooling such as bunny-wss-front.sh
+# inventory, never a dashboard, relay, client, or signing credential. It must
+# differ from the volunteer, Foundation, and dashboard tokens. Generate it
+# independently, keep the populated env file root-owned mode 0600 (or source a
+# secret manager), and rotate by recreating the container. Callers should read
+# a mode-0600 header file or use a secret-manager command, not put it in argv.
+#OPENRUNG_RELAY_INVENTORY_TOKEN=
+
 # ---------------------------------------------------------------------------
 # Listen address (optional)
 # ---------------------------------------------------------------------------

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -120,8 +120,10 @@ for operator tooling such as `bunny-wss-front.sh inventory`. It returns every
 currently active public relay descriptor, sorted by stable relay ID; it is not
 the ranked/truncated client directory page. Set a distinct
 `OPENRUNG_RELAY_INVENTORY_TOKEN` to enable it. When unset, the route is not
-registered and returns `404`. The broker refuses to start if this token equals
-the volunteer-registration, Foundation, or dashboard token.
+registered and returns `404`. Generate it independently: the broker refuses to
+start if it equals the volunteer-registration, Foundation, or dashboard token,
+or either broker-local relay-list/WSS signing seed. The broker cannot inspect
+an external manifest-signing seed, so keep that seed separate operationally too.
 
 Send exactly `Authorization: Bearer <token>` over HTTPS. Responses, including
 errors, are `Cache-Control: no-store`; successful JSON is signed with the

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -379,7 +379,7 @@ docker inspect openrung-broker \
 | `OPENRUNG_RELAY_SIGNING_KEY`         | yes      | —                                   | Std-base64 32-byte Ed25519 seed; signs every relay-list response |
 | `OPENRUNG_WSS_TICKET_SIGNING_SEED`   | no       | —                                   | Dedicated std-base64 32-byte Ed25519 seed; enables relay/front-bound WSS tickets |
 | `OPENRUNG_DASHBOARD_TOKEN`           | no       | —                                   | Enables the protected `/admin/telemetry` dashboard             |
-| `OPENRUNG_RELAY_INVENTORY_TOKEN`     | no       | —                                   | Enables full signed `/admin/api/relays/inventory`; must differ from volunteer, Foundation, and dashboard tokens |
+| `OPENRUNG_RELAY_INVENTORY_TOKEN`     | no       | —                                   | Enables full signed `/admin/api/relays/inventory`; must differ from all bearer tokens and signing seeds |
 | `OPENRUNG_ADDR`                      | no       | `:8080`                             | HTTP listen address                                            |
 | `OPENRUNG_TRUSTED_PROXY_CIDRS`       | no       | Cloudflare ranges                   | Extra trusted proxy CIDRs for forwarded client IPs             |
 | `OPENRUNG_RELAY_STORE`               | no       | `memory`                            | Relay state backend: `memory` or `postgres`                    |

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -113,6 +113,36 @@ file, then **recreate** the container with `--env-file` (a Docker restart does
 not reload a changed env file). `lightsail-up.sh` intentionally rejects
 `OPENRUNG_FOUNDATION_TOKEN` for this reason.
 
+### Relay inventory for operator tooling
+
+`GET /admin/api/relays/inventory` is an optional machine-to-machine snapshot
+for operator tooling such as `bunny-wss-front.sh inventory`. It returns every
+currently active public relay descriptor, sorted by stable relay ID; it is not
+the ranked/truncated client directory page. Set a distinct
+`OPENRUNG_RELAY_INVENTORY_TOKEN` to enable it. When unset, the route is not
+registered and returns `404`. The broker refuses to start if this token equals
+the volunteer-registration, Foundation, or dashboard token.
+
+Send exactly `Authorization: Bearer <token>` over HTTPS. Responses, including
+errors, are `Cache-Control: no-store`; successful JSON is signed with the
+ordinary broker relay-list key but carries the inventory-specific signed
+`channel: "relay-inventory-v1"` contract. The signing seed remains broker-local.
+Generate and rotate the token independently. Put it in a root-owned mode-0600
+env/header file or retrieve it through a secret-manager command. For example,
+avoid putting the token in a command argument:
+
+```sh
+hdr=$(mktemp)
+chmod 600 "$hdr"
+secret-manager-command-for-inventory-token | sed 's/^/Authorization: Bearer /' > "$hdr"
+curl --fail --header @"$hdr" https://broker.example/admin/api/relays/inventory
+rm -f "$hdr"
+```
+
+Recreate the container after rotating the broker env file; a restart does not
+reload its environment. Do not give this token to relays, clients, dashboards,
+or general users.
+
 > **Rolling back past `node_class`:** a broker image that predates the
 > `node_class` column does not guard registrations or heartbeats, so it can
 > overwrite a foundation relay's `host:port` row — replacing its id, keys, and
@@ -347,6 +377,7 @@ docker inspect openrung-broker \
 | `OPENRUNG_RELAY_SIGNING_KEY`         | yes      | —                                   | Std-base64 32-byte Ed25519 seed; signs every relay-list response |
 | `OPENRUNG_WSS_TICKET_SIGNING_SEED`   | no       | —                                   | Dedicated std-base64 32-byte Ed25519 seed; enables relay/front-bound WSS tickets |
 | `OPENRUNG_DASHBOARD_TOKEN`           | no       | —                                   | Enables the protected `/admin/telemetry` dashboard             |
+| `OPENRUNG_RELAY_INVENTORY_TOKEN`     | no       | —                                   | Enables full signed `/admin/api/relays/inventory`; must differ from volunteer, Foundation, and dashboard tokens |
 | `OPENRUNG_ADDR`                      | no       | `:8080`                             | HTTP listen address                                            |
 | `OPENRUNG_TRUSTED_PROXY_CIDRS`       | no       | Cloudflare ranges                   | Extra trusted proxy CIDRs for forwarded client IPs             |
 | `OPENRUNG_RELAY_STORE`               | no       | `memory`                            | Relay state backend: `memory` or `postgres`                    |

--- a/docs/api.md
+++ b/docs/api.md
@@ -373,6 +373,32 @@ When the broker uses PostgreSQL relay state, `/healthz` also verifies database
 connectivity. If relay state is unavailable, it returns `503` with an error
 payload so a load balancer can stop routing to that broker instance.
 
+## Relay inventory (operator-only)
+
+```http
+GET /admin/api/relays/inventory
+Authorization: Bearer <inventory-token>
+```
+
+This optional operational endpoint is intended solely for operator automation
+(for example, `bunny-wss-front.sh inventory`). Set the dedicated
+`OPENRUNG_RELAY_INVENTORY_TOKEN` to register it; otherwise it returns `404`.
+It accepts only an exact bearer value and is separately rate limited. The token
+must differ from the dashboard, volunteer-registration, and Foundation tokens;
+the broker rejects an unsafe configuration at startup.
+
+The successful response contains `count`, `server_time`, `not_after`, `key_id`,
+`channel: "relay-inventory-v1"`, and all currently active public relay
+descriptors, ordered by relay ID. It is signed with the existing relay-list
+signature header; this inventory channel is not a client candidate page or a
+mirror artifact. No lease token, registration credential, private identity
+material, telemetry, observed tunnel exit, or private signing material appears
+in the response. Every outcome has `Cache-Control: no-store`.
+
+Store and rotate the bearer independently in a mode-0600 token/header file or
+retrieve it with a secret-manager command. Do not place it in argv, shell
+history, relay configuration, dashboard sessions, or client code.
+
 ## Register Relay
 
 ```http

--- a/docs/api.md
+++ b/docs/api.md
@@ -384,8 +384,10 @@ This optional operational endpoint is intended solely for operator automation
 (for example, `bunny-wss-front.sh inventory`). Set the dedicated
 `OPENRUNG_RELAY_INVENTORY_TOKEN` to register it; otherwise it returns `404`.
 It accepts only an exact bearer value and is separately rate limited. The token
-must differ from the dashboard, volunteer-registration, and Foundation tokens;
-the broker rejects an unsafe configuration at startup.
+must be independently generated and differ from every bearer token and signing
+seed. The broker rejects reuse of dashboard, volunteer-registration, Foundation,
+relay-list-signing, or WSS-ticket-signing values at startup. It cannot inspect
+an external manifest-signing seed, so operators must keep that seed separate.
 
 The successful response contains `count`, `server_time`, `not_after`, `key_id`,
 `channel: "relay-inventory-v1"`, and all currently active public relay

--- a/internal/broker/inventory_test.go
+++ b/internal/broker/inventory_test.go
@@ -1,0 +1,169 @@
+package broker
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+const inventoryPath = "/admin/api/relays/inventory"
+
+func TestRelayInventoryDisabledIsNotRegistered(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed()})
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, inventoryPath, nil))
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("disabled inventory status = %d, want 404", recorder.Code)
+	}
+}
+
+func TestRelayInventoryAuthenticationAndCacheControl(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed(), InventoryToken: "inventory-secret"})
+	for _, authorization := range []string{"", "inventory-secret", "Bearer  inventory-secret", "bearer inventory-secret", "Bearer wrong"} {
+		t.Run(authorization, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, inventoryPath, nil)
+			if authorization != "" {
+				req.Header.Set("Authorization", authorization)
+			}
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401: %s", recorder.Code, recorder.Body.String())
+			}
+			if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+		})
+	}
+}
+
+func TestRelayInventoryReturnsCompleteSortedPublicSignedSet(t *testing.T) {
+	store := NewStore()
+	now := time.Now().UTC()
+	for i := 0; i < 21; i++ {
+		req := validRegisterRequest()
+		req.PublicHost = "inventory-" + string(rune('a'+i)) + ".example"
+		req.Label = "relay"
+		if _, err := store.Register(req, now, time.Minute); err != nil {
+			t.Fatalf("register relay %d: %v", i, err)
+		}
+	}
+	server := NewServer(store, Config{SigningSeed: testSigningSeed(), InventoryToken: "inventory-secret"})
+	req := httptest.NewRequest(http.MethodGet, inventoryPath, nil)
+	req.Header.Set("Authorization", "Bearer inventory-secret")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store, no-transform" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if recorder.Header().Get(signatureHeader) == "" {
+		t.Fatal("successful inventory response was not signed")
+	}
+	var response inventoryResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode inventory: %v", err)
+	}
+	if response.Count != 21 || len(response.Relays) != 21 {
+		t.Fatalf("count/relays = %d/%d, want 21/21", response.Count, len(response.Relays))
+	}
+	if response.Channel != "relay-inventory-v1" || response.ServerTime.IsZero() {
+		t.Fatalf("unexpected inventory contract: %+v", response)
+	}
+	ids := make([]string, len(response.Relays))
+	for i, desc := range response.Relays {
+		ids[i] = desc.ID
+	}
+	if !sort.StringsAreSorted(ids) {
+		t.Fatalf("relay IDs are not sorted: %v", ids)
+	}
+	for _, forbidden := range []string{"lease_token", "identity_public_key", "exit_host", "identity_proof", "wss_capability_proof"} {
+		if strings.Contains(recorder.Body.String(), "\""+forbidden+"\"") {
+			t.Fatalf("inventory leaked private field %q: %s", forbidden, recorder.Body.String())
+		}
+	}
+}
+
+type failingInventoryStore struct{ RelayStore }
+
+func (failingInventoryStore) List(time.Time, int) ([]relay.Descriptor, error) {
+	return nil, errors.New("storage unavailable")
+}
+
+func TestRelayInventoryStorageFailureIsNeverCacheable(t *testing.T) {
+	server := NewServer(failingInventoryStore{NewStore()}, Config{SigningSeed: testSigningSeed(), InventoryToken: "inventory-secret"})
+	req := httptest.NewRequest(http.MethodGet, inventoryPath, nil)
+	req.Header.Set("Authorization", "Bearer inventory-secret")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", recorder.Code)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestRelayInventoryRateLimited(t *testing.T) {
+	server := NewServer(NewStore(), Config{SigningSeed: testSigningSeed(), InventoryToken: "inventory-secret"})
+	for i := 0; i < relayInventoryBurst; i++ {
+		req := httptest.NewRequest(http.MethodGet, inventoryPath, nil)
+		req.Header.Set("Authorization", "Bearer inventory-secret")
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200", i+1, recorder.Code)
+		}
+	}
+	req := httptest.NewRequest(http.MethodGet, inventoryPath, nil)
+	req.Header.Set("Authorization", "Bearer inventory-secret")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-budget status = %d, want 429", recorder.Code)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+type privateInventoryStore struct{ RelayStore }
+
+func (privateInventoryStore) List(now time.Time, limit int) ([]relay.Descriptor, error) {
+	return []relay.Descriptor{{
+		ID:                "relay-private-test",
+		PublicHost:        "relay.example",
+		PublicPort:        443,
+		LeaseToken:        "must-not-leak",
+		IdentityPublicKey: "must-not-leak",
+		ExitHost:          "203.0.113.99",
+		RegisteredAt:      now,
+		LastHeartbeatAt:   now,
+		ExpiresAt:         now.Add(time.Minute),
+	}}, nil
+}
+
+func TestRelayInventoryDoesNotSerializePrivateDescriptorFields(t *testing.T) {
+	server := NewServer(privateInventoryStore{NewStore()}, Config{SigningSeed: testSigningSeed(), InventoryToken: "inventory-secret"})
+	req := httptest.NewRequest(http.MethodGet, inventoryPath, nil)
+	req.Header.Set("Authorization", "Bearer inventory-secret")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	for _, private := range []string{"must-not-leak", "203.0.113.99"} {
+		if strings.Contains(recorder.Body.String(), private) {
+			t.Fatalf("inventory leaked private descriptor value %q: %s", private, recorder.Body.String())
+		}
+	}
+}

--- a/internal/broker/ratelimit.go
+++ b/internal/broker/ratelimit.go
@@ -17,8 +17,12 @@ import (
 const (
 	relayListRatePerSecond = 2.0
 	relayListBurst         = 30
-	wssTicketRatePerSecond = 2.0
-	wssTicketBurst         = 30
+	// Inventory is an authenticated operator endpoint but can return the full
+	// fleet, so keep its per-source budget intentionally smaller than clients'.
+	relayInventoryRatePerSecond = 1.0 / 30
+	relayInventoryBurst         = 5
+	wssTicketRatePerSecond      = 2.0
+	wssTicketBurst              = 30
 
 	telemetryRatePerSecond = 1.0
 	telemetryBurst         = 20

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/netip"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,11 @@ type Config struct {
 	TelemetryReader  TelemetryReader
 	TelemetryQuerier TelemetryQuerier
 	DashboardToken   string
+	// InventoryToken authorizes the operational relay inventory endpoint. Empty
+	// leaves that endpoint unregistered so it does not advertise its existence.
+	// It is intentionally separate from every relay, dashboard, and signing
+	// credential.
+	InventoryToken string
 	// TrustedProxyCIDRs are additional CIDRs (beyond Cloudflare's published ranges) whose forwarded
 	// CF-Connecting-IP / X-Forwarded-For headers the broker will trust for the real client IP.
 	TrustedProxyCIDRs []string
@@ -87,6 +93,7 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	speedTestLimiter := newIPRateLimiter(speedTestRatePerSecond, speedTestBurst, rateLimiterMaxTrackedIPs)
 	relayRegistrationLimiter := newIPRateLimiter(relayRegistrationRatePerSecond, relayRegistrationBurst, rateLimiterMaxTrackedIPs)
 	wssTicketLimiter := newIPRateLimiter(wssTicketRatePerSecond, wssTicketBurst, rateLimiterMaxTrackedIPs)
+	inventoryLimiter := newIPRateLimiter(relayInventoryRatePerSecond, relayInventoryBurst, rateLimiterMaxTrackedIPs)
 	relayLedger := newRelayIDLedger(relayLedgerTTL, relayLedgerMaxEntries)
 	seedRelayLedger(relayLedger, store)
 	newIDCap := newNewRelayCap(cfg.MaxNewRelayIDsPerIPPerDay, newRelayCapWindow, cfg.RegistrationCapExemptCIDRs)
@@ -112,6 +119,9 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	mux.HandleFunc("POST /api/v1/relays/", heartbeatRelay)
 	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen, relaySigner)))
 	mux.HandleFunc("GET /api/v1/relays.mirror", rateLimited(relayListLimiter, clientIP, 10, listRelaysMirrorHandler(store, relaySigner)))
+	if cfg.InventoryToken != "" {
+		mux.HandleFunc("GET /admin/api/relays/inventory", rateLimited(inventoryLimiter, clientIP, 30, relayInventoryHandler(store, cfg.InventoryToken, relaySigner)))
+	}
 	if wssIssuer != nil {
 		mux.HandleFunc("POST /api/v1/wss/tickets", rateLimitedBy(wssTicketLimiter, wssTicketRateKey(clientIP), 10, wssTicketHandler(store, wssIssuer)))
 	}
@@ -129,6 +139,49 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	}
 
 	return mux
+}
+
+// inventoryResponse is a signed operational snapshot, deliberately distinct
+// from client directory pages. Channel binds the signature to this endpoint so
+// a successful inventory response cannot be mistaken for an API relay list.
+type inventoryResponse struct {
+	Count      int                `json:"count"`
+	ServerTime time.Time          `json:"server_time"`
+	NotAfter   time.Time          `json:"not_after"`
+	KeyID      string             `json:"key_id"`
+	Channel    string             `json:"channel"`
+	Relays     []relay.Descriptor `json:"relays"`
+}
+
+func relayInventoryHandler(store RelayStore, token string, s signer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// This endpoint is credentialed operational data. Never allow an edge or
+		// browser cache to retain either a successful snapshot or an error.
+		w.Header().Set("Cache-Control", "no-store")
+		if !bearerMatches(r, token) {
+			writeError(w, http.StatusUnauthorized, "missing or invalid relay inventory token")
+			return
+		}
+		now := time.Now().UTC()
+		relays, err := store.List(now, 0) // unbounded active set, never a client page
+		if err != nil {
+			slog.Error("could not list relay inventory", "error", err)
+			writeError(w, http.StatusServiceUnavailable, "could not list relays")
+			return
+		}
+		// Stores are free to return a ranking-ordered slice. Copy before sorting
+		// so inventory presentation cannot mutate a store-owned slice.
+		relays = append([]relay.Descriptor(nil), relays...)
+		sort.Slice(relays, func(i, j int) bool { return relays[i].ID < relays[j].ID })
+		s.writeSignedInventory(w, inventoryResponse{
+			Count:      len(relays),
+			ServerTime: now,
+			NotAfter:   now.Add(apiNotAfterWindow),
+			KeyID:      s.keyID,
+			Channel:    "relay-inventory-v1",
+			Relays:     relays,
+		})
+	}
 }
 
 func registerHandler(store RelayStore, cfg Config, clientIP *clientIPResolver, ledger *relayIDLedger, newIDCap *newRelayCap) http.HandlerFunc {

--- a/internal/broker/signing.go
+++ b/internal/broker/signing.go
@@ -111,6 +111,27 @@ func (s signer) writeSigned(w http.ResponseWriter, resp relay.ListResponse) {
 	_, _ = w.Write(body) // identical buffer — sign-what-you-send
 }
 
+// writeSignedInventory applies the ordinary relay-list signing key to the
+// inventory-specific wire contract. It must not call writeSigned: inventory is
+// not a client directory page and carries its own signed channel marker.
+func (s signer) writeSignedInventory(w http.ResponseWriter, resp inventoryResponse) {
+	resp.ServerTime = resp.ServerTime.UTC().Truncate(time.Second)
+	resp.NotAfter = resp.NotAfter.UTC().Truncate(time.Second)
+	resp.Relays = normalizePublicRelayDescriptors(resp.Relays)
+	body, err := json.Marshal(resp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not encode relay inventory")
+		return
+	}
+	sig := ed25519.Sign(s.key, body)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store, no-transform")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.Header().Set(signatureHeader, "ed25519;"+s.keyID+";"+base64.StdEncoding.EncodeToString(sig))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
 // normalizeSignedRelayListTimes narrows the public directory wire format to
 // UTC RFC 3339 at whole-second precision, which every supported client can
 // decode. It clones the descriptor slice before changing timestamps so the
@@ -119,14 +140,18 @@ func normalizeSignedRelayListTimes(resp relay.ListResponse) relay.ListResponse {
 	resp.ServerTime = resp.ServerTime.UTC().Truncate(time.Second)
 	resp.NotAfter = resp.NotAfter.UTC().Truncate(time.Second)
 	if resp.Relays != nil {
-		relays := make([]relay.Descriptor, len(resp.Relays))
-		copy(relays, resp.Relays)
-		for i := range relays {
-			relays[i].RegisteredAt = relays[i].RegisteredAt.UTC().Truncate(time.Second)
-			relays[i].LastHeartbeatAt = relays[i].LastHeartbeatAt.UTC().Truncate(time.Second)
-			relays[i].ExpiresAt = relays[i].ExpiresAt.UTC().Truncate(time.Second)
-		}
-		resp.Relays = relays
+		resp.Relays = normalizePublicRelayDescriptors(resp.Relays)
 	}
 	return resp
+}
+
+func normalizePublicRelayDescriptors(relays []relay.Descriptor) []relay.Descriptor {
+	cloned := make([]relay.Descriptor, len(relays))
+	copy(cloned, relays)
+	for i := range cloned {
+		cloned[i].RegisteredAt = cloned[i].RegisteredAt.UTC().Truncate(time.Second)
+		cloned[i].LastHeartbeatAt = cloned[i].LastHeartbeatAt.UTC().Truncate(time.Second)
+		cloned[i].ExpiresAt = cloned[i].ExpiresAt.UTC().Truncate(time.Second)
+	}
+	return cloned
 }


### PR DESCRIPTION
## Summary
- add disabled-by-default, exact-bearer authenticated operational relay inventory endpoint
- return full active public descriptor set in stable relay-ID order with inventory-scoped signed contract and rate limiting
- validate credential separation and document secure deployment and caller handling

## Tests
- go test ./internal/broker ./cmd/broker
- go test ./...