### PR TITLE
Harden secret handling boundaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,8 +29,29 @@ build
 .cache
 .claude
 
-# Local runtime files and secrets.
+# Local runtime files and secrets. The Dockerfiles do not consume environment
+# templates, so keep examples out of the broad `COPY . .` build stages too.
 .env
+.env.*
+*.env
+*.env.*
+**/.env
+**/.env.*
+**/*.env
+**/*.env.*
+
+# Locally generated private-key material. Public .crt certificates may remain
+# available to builds, but private keys must never enter a COPY . . layer.
+*.key
+*.pem
+*.p12
+*.pfx
+*.seed
+**/*.key
+**/*.pem
+**/*.p12
+**/*.pfx
+**/*.seed
 *.local.json
 openrung-telemetry.jsonl
 openrung-xray-config.json

--- a/.github/workflows/broker-image.yml
+++ b/.github/workflows/broker-image.yml
@@ -15,6 +15,7 @@ on:
       - 'internal/wssbridge/**'
       - 'go.mod'
       - 'go.sum'
+      - '.dockerignore'
       # The root go.mod replaces nested modules with local directories, so the
       # broker's build/download layers depend on their contents too.
       - 'brokerapi/go.mod'

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -36,6 +36,9 @@ jobs:
           OPENRUNG_TEST_SHELL=/bin/dash sh deploy/relay/volunteer-up_test.sh
           OPENRUNG_TEST_SHELL=/bin/bash sh deploy/relay/volunteer-up_test.sh
           docker run --rm -v "$PWD:/src:ro" -w /src alpine:3 sh deploy/relay/volunteer-up_test.sh
+          bash -n deploy/relayhub/ec2-up.sh
+          bash -n deploy/relayhub/ec2-up_test.sh
+          bash deploy/relayhub/ec2-up_test.sh
 
   go:
     runs-on: ubuntu-latest

--- a/.github/workflows/relayhub-image.yml
+++ b/.github/workflows/relayhub-image.yml
@@ -19,6 +19,7 @@ on:
       - 'wsscore/**'
       - 'go.mod'
       - 'go.sum'
+      - '.dockerignore'
       - 'deploy/relayhub/**'
       - '.github/workflows/relayhub-image.yml'
   workflow_dispatch:

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -14,7 +14,7 @@ fronted by Cloudflare with a direct-IP origin fallback on `:8080`.
 ## Quick start
 
 ```sh
-cp .env.example .env          # edit: signing seeds, token/anonymous, dashboard, store
+install -m 0600 .env.example .env  # edit: signing seeds, token/anonymous, dashboard, store
 docker compose up -d --build
 docker compose logs -f
 ```

--- a/deploy/broker/docker-compose.yml
+++ b/deploy/broker/docker-compose.yml
@@ -1,6 +1,6 @@
 # OpenRung broker (control plane).
 #
-#   cp .env.example .env      # then edit .env (token/anonymous, dashboard, store)
+#   install -m 0600 .env.example .env  # then edit .env (token/anonymous, dashboard, store)
 #   docker compose up -d --build
 #   docker compose logs -f
 #

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -30,7 +30,7 @@ heartbeats normally, so it remains available for rollback.
 
 ```sh
 cd deploy/relay
-cp .env.example .env          # edit: set OPENRUNG_BROKER_URL and OPENRUNG_PUBLIC_HOST
+install -m 0600 .env.example .env  # edit: set OPENRUNG_BROKER_URL and OPENRUNG_PUBLIC_HOST
 docker compose up -d --build
 docker compose logs -f        # expect: registered relay … / heartbeat ok
 ```

--- a/deploy/relay/docker-compose.yml
+++ b/deploy/relay/docker-compose.yml
@@ -1,6 +1,6 @@
 # OpenRung relay runtime.
 #
-#   cp .env.example .env      # then edit .env (set OPENRUNG_BROKER_URL + OPENRUNG_PUBLIC_HOST)
+#   install -m 0600 .env.example .env  # then edit .env (set broker URL + public host)
 #   docker compose up -d --build
 #   docker compose logs -f
 #

--- a/deploy/relayhub/README.md
+++ b/deploy/relayhub/README.md
@@ -71,15 +71,70 @@ governed by the tunnel/punch protocol versions and negotiated capability flags.
 `ec2-up.sh` provisions a hub on EC2 with a secondary private IP + **two Elastic IPs**, so the punch
 reflector has two vantage points (RFC 5780 classification). It binds the on-NIC private IPs and
 advertises the EIPs (the bind/advertise split), self-signs a TLS cert covering both EIPs, installs a
-boot-time unit that keeps the secondary private IP on the interface across reboots, and runs the hub
-with punch enabled.
+boot-time unit that keeps the secondary private IP on the interface across reboots, and stages the
+hub with punch enabled. It starts immediately only after an explicit anonymous-mode opt-in.
 
 ```sh
+# Authenticated deployment: stage the host, then install the token over verified SSH.
 ./deploy/relayhub/ec2-up.sh hub-ec2-seoul
+
+# Deliberately public deployment: start an open hub immediately.
+OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true \
+  ./deploy/relayhub/ec2-up.sh hub-ec2-seoul-open
 ```
 
+This helper never accepts a bearer token. It rejects
+`OPENRUNG_VOLUNTEER_TOKEN` even when the variable is set to an empty value, and
+does so before making any AWS call. With no explicit anonymous opt-in it pulls
+the image and prepares the TLS and environment files, but leaves relayhub
+stopped. EC2 retains instance user-data and exposes it through IMDS to local
+processes; because the hub uses host networking, an IMDSv2 session token does
+not isolate user-data from the container. A bearer token must therefore never
+be passed to this bootstrap.
+
+For an authenticated hub, use this staged deployment:
+
+1. Provision the host with `OPENRUNG_VOLUNTEER_TOKEN` unset.
+2. Verify and pin the instance's SSH host key through an authenticated,
+   out-of-band source. Do not use first-contact TOFU for a credential transfer.
+   If the named EC2 key pair already exists, `OPENRUNG_KEY_FILE` must identify
+   its matching, usable local private key; the provisioning helper compares its
+   public key with the copy held by EC2 before allocating the instance's EIPs.
+3. Send exactly one token line over that verified SSH connection via stdin, not
+   argv. Wait for cloud-init before installing it, or cloud-init can overwrite
+   the environment file. For example, run the following in Bash after replacing
+   `<eip1>` and the key path and after pinning the host key:
+
+   ```bash
+   (
+     set +x
+     IFS= read -r -s -p 'Volunteer token: ' token
+     printf '\n' >&2
+     printf '%s\n' "$token"
+   ) | ssh -o StrictHostKeyChecking=yes \
+       -i ~/.ssh/id_ed25519_openrung ubuntu@<eip1> \
+       'sudo cloud-init status --wait >/dev/null &&
+        sudo /usr/local/sbin/openrung-relayhub-install-token'
+   ```
+
+   The root-only installer accepts standard HTTP bearer-token characters
+   (for example, output from `openssl rand -hex 32`), atomically writes exactly
+   one `OPENRUNG_VOLUNTEER_TOKEN` assignment to
+   `/etc/openrung/relayhub.env` as `root:root` mode `0600`, removes any
+   anonymous opt-in, and performs the first container start with the hardened
+   flags. The start helper validates that exactly one authentication mode is
+   configured and never removes an existing container before attempting a
+   replacement.
+
+If this helper was previously run with a token, assume that credential persists
+in EC2 user-data, cloud-init artifacts, and disk snapshots. Rotate the token and
+replace or retire the affected instance; changing the file mode does not remove
+those historical copies.
+
 Defaults: `ap-northeast-2`, `t4g.micro` (ARM). Override via `OPENRUNG_REGION`, `OPENRUNG_EC2_TYPE`,
-`OPENRUNG_EC2_SUBNET`, etc. Verify with `curl -k https://<eip1>:9444/api/v1/punch/config` (returns
+`OPENRUNG_EC2_SUBNET`, etc. A custom `OPENRUNG_IMAGE` must run as a non-root user and provide the
+`id` executable so the bootstrap can assign the TLS private key to the image's runtime UID. Verify
+with `curl -k https://<eip1>:9444/api/v1/punch/config` (returns
 the two advertised reflector EIPs). Note EC2 egress is metered and each in-use public IPv4 is billed
 hourly — this helper exists because two same-family public IPs are easy to get on EC2, not because
 EC2 is the right place to move bytes. Read the bandwidth warning above before using it for anything

--- a/deploy/relayhub/README.md
+++ b/deploy/relayhub/README.md
@@ -39,7 +39,7 @@ Operators who already know the relay is publicly reachable can select
 ## Quick start
 
 ```sh
-cp .env.example .env          # set OPENRUNG_HUB_PUBLIC_HOST + OPENRUNG_BROKER_URL
+install -m 0600 .env.example .env  # set OPENRUNG_HUB_PUBLIC_HOST + OPENRUNG_BROKER_URL
 mkdir -p certs                # put hub.crt + hub.key here (see TLS below)
 docker compose up -d --build
 docker compose logs -f

--- a/deploy/relayhub/docker-compose.yml
+++ b/deploy/relayhub/docker-compose.yml
@@ -1,6 +1,6 @@
 # OpenRung relay hub.
 #
-#   cp .env.example .env      # then edit .env (set OPENRUNG_HUB_PUBLIC_HOST + OPENRUNG_BROKER_URL)
+#   install -m 0600 .env.example .env  # then edit .env (set public host + broker URL)
 #   # put your TLS cert/key in ./certs (strongly recommended — see README.md)
 #   docker compose up -d --build
 #   docker compose logs -f

--- a/deploy/relayhub/ec2-up.sh
+++ b/deploy/relayhub/ec2-up.sh
@@ -112,6 +112,10 @@ trap 'rm -f "$UD"' EXIT
 cat > "$UD" <<'TMPL'
 #!/bin/bash
 set -eux
+# Secrets are written later in this bootstrap. Keep newly-created files private
+# by default, then explicitly relax only the public certificate and directories
+# that the unprivileged relayhub container must traverse.
+umask 077
 exec > /var/log/openrung-init.log 2>&1
 export DEBIAN_FRONTEND=noninteractive
 
@@ -159,11 +163,12 @@ MAC=$(imds network/interfaces/macs/ | head -1 | tr -d /)
 PRIMARY=$(imds local-ipv4)
 SECONDARY=$(imds "network/interfaces/macs/$MAC/local-ipv4s" | grep -v "^$PRIMARY$" | head -1)
 
-mkdir -p /etc/openrung/certs
+install -d -m 0755 /etc/openrung/certs
 openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
   -keyout /etc/openrung/certs/hub.key -out /etc/openrung/certs/hub.crt \
   -subj "/CN=__EIP1__" -addext "subjectAltName=IP:__EIP1__,IP:__EIP2__"
-chmod 644 /etc/openrung/certs/hub.crt /etc/openrung/certs/hub.key
+chmod 0600 /etc/openrung/certs/hub.key
+chmod 0644 /etc/openrung/certs/hub.crt
 
 cat > /etc/openrung/relayhub.env <<ENV
 OPENRUNG_HUB_PUBLIC_HOST=__EIP1__
@@ -178,8 +183,22 @@ OPENRUNG_HUB_REFLECTOR_ADVERTISE=__EIP1__:__REFLECTOR_PORT__,__EIP2__:__REFLECTO
 __TOKEN_ENV__
 __ANON_ENV__
 ENV
+chown root:root /etc/openrung/relayhub.env
+chmod 0600 /etc/openrung/relayhub.env
 
 docker pull __IMAGE__
+# The image runs as its unprivileged openrung user. Preserve mode 0600 while
+# making the key readable by that user through the read-only bind mount.
+if ! HUB_UID=$(docker run --rm --entrypoint id __IMAGE__ -u); then
+  echo "could not resolve relayhub image UID" >&2
+  exit 1
+fi
+case "$HUB_UID" in
+  ''|*[!0-9]*) echo "invalid relayhub image UID: $HUB_UID" >&2; exit 1 ;;
+  0) echo "relayhub image must run as a non-root user" >&2; exit 1 ;;
+esac
+chown "$HUB_UID" /etc/openrung/certs/hub.key
+chmod 0600 /etc/openrung/certs/hub.key
 docker rm -f openrung-relayhub 2>/dev/null || true
 docker run -d --name openrung-relayhub --restart unless-stopped \
   --network host --cap-drop ALL --read-only --tmpfs /tmp \

--- a/deploy/relayhub/ec2-up.sh
+++ b/deploy/relayhub/ec2-up.sh
@@ -15,8 +15,9 @@
 #
 # It launches an instance in the default VPC, assigns a secondary private IP,
 # allocates + associates two EIPs, self-signs a control-channel TLS cert (SANs =
-# both EIPs), and runs the hub with punch enabled. A boot-time systemd unit keeps
-# the secondary private IP configured on the interface across reboots.
+# both EIPs), and stages the hub with punch enabled. It starts immediately only
+# after an explicit anonymous-mode opt-in. A boot-time systemd unit keeps the
+# secondary private IP configured on the interface across reboots.
 #
 # Prerequisites: authenticated `aws` CLI with EC2 permissions, and the GHCR image
 # published + PUBLIC.
@@ -24,8 +25,31 @@
 # Overridable via env: OPENRUNG_REGION, OPENRUNG_EC2_SUBNET, OPENRUNG_EC2_TYPE,
 # OPENRUNG_IMAGE, OPENRUNG_BROKER_URL, OPENRUNG_HUB_CONTROL_PORT,
 # OPENRUNG_HUB_HTTP_PORT, OPENRUNG_HUB_PORT_RANGE, OPENRUNG_HUB_REFLECTOR_PORT,
-# OPENRUNG_KEY_NAME, OPENRUNG_KEY_FILE, OPENRUNG_SG_NAME, OPENRUNG_VOLUNTEER_TOKEN.
+# OPENRUNG_KEY_NAME, OPENRUNG_KEY_FILE, OPENRUNG_SG_NAME,
+# OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS.
+#
+# This helper never accepts a bearer token. EC2 retains user-data and exposes it
+# through IMDS to local processes, including containers using host networking.
+# By default it stages the host without starting the hub; explicitly set
+# OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true to launch an open hub instead.
 set -euo pipefail
+
+if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ]; then
+  echo "error: OPENRUNG_VOLUNTEER_TOKEN is not accepted because EC2 user-data persists and is readable through IMDS; provision first, then install it post-boot over authenticated SSH" >&2
+  exit 2
+fi
+
+case "${OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS:-}" in
+  ''|false) ALLOW_ANONYMOUS=false ;;
+  true) ALLOW_ANONYMOUS=true ;;
+  *)
+    echo "error: OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS must be exactly true or false" >&2
+    exit 2
+    ;;
+esac
+
+# Local temporary files can include newly-created SSH private-key material.
+umask 077
 
 REGION="${OPENRUNG_REGION:-ap-northeast-2}"          # Seoul
 ITYPE="${OPENRUNG_EC2_TYPE:-t4g.micro}"              # ARM Graviton (cheapest)
@@ -36,6 +60,24 @@ IMAGE="${OPENRUNG_IMAGE:-ghcr.io/openrung/openrung-relayhub:main}"
 # reaches it without the Cloudflare front's Managed Challenge while the
 # registrations stop crossing the public internet in cleartext.
 BROKER_URL="${OPENRUNG_BROKER_URL:-https://broker-origin.openrung.org}"
+case "$BROKER_URL" in
+  http://*|https://*) ;;
+  *) echo "error: OPENRUNG_BROKER_URL must be an http(s) base URL" >&2; exit 2 ;;
+esac
+case "$BROKER_URL" in
+  *[[:space:]]*|*'?'*|*'#'*)
+    echo "error: OPENRUNG_BROKER_URL must not contain whitespace, a query, or a fragment; user-data is persistent" >&2
+    exit 2
+    ;;
+esac
+BROKER_AUTHORITY="${BROKER_URL#*://}"
+BROKER_AUTHORITY="${BROKER_AUTHORITY%%/*}"
+case "$BROKER_AUTHORITY" in
+  ''|*@*)
+    echo "error: OPENRUNG_BROKER_URL must have a host and no userinfo; user-data is persistent" >&2
+    exit 2
+    ;;
+esac
 CONTROL_PORT="${OPENRUNG_HUB_CONTROL_PORT:-9443}"
 HTTP_PORT="${OPENRUNG_HUB_HTTP_PORT:-9444}"
 PORT_RANGE="${OPENRUNG_HUB_PORT_RANGE:-20000-20100}"
@@ -45,7 +87,6 @@ KEY_NAME="${OPENRUNG_KEY_NAME:-openrung}"
 # key pair when it does not exist yet, so hosts share the fleet-standard key.
 KEY_FILE="${OPENRUNG_KEY_FILE:-$HOME/.ssh/id_ed25519_openrung}"
 SG_NAME="${OPENRUNG_SG_NAME:-openrung-relayhub}"
-TOKEN="${OPENRUNG_VOLUNTEER_TOKEN:-}"
 
 RANGE_START="${PORT_RANGE%%-*}"
 RANGE_END="${PORT_RANGE##*-}"
@@ -84,8 +125,12 @@ echo "Security group: ${SG_ID}"
 # --- key pair (idempotent) ---
 # Prefer importing the fleet-standard public key (derived from $KEY_FILE) so every
 # host is reachable with the same key. Only generate a fresh key pair as a last
-# resort, and never overwrite an existing local private key.
-if ! aws ec2 describe-key-pairs --region "$REGION" --key-names "$KEY_NAME" >/dev/null 2>&1; then
+# resort, and never overwrite an existing local private key. An existing EC2 key
+# name must contain the public key derived from the configured private key: the
+# authenticated post-boot token handoff depends on that key actually working.
+if ! EC2_PUBLIC_KEY="$(aws ec2 describe-key-pairs --region "$REGION" \
+  --key-names "$KEY_NAME" --include-public-key \
+  --query 'KeyPairs[0].PublicKey' --output text 2>/dev/null)"; then
   if [ -f "$KEY_FILE" ] && PUBKEY="$(ssh-keygen -y -f "$KEY_FILE" 2>/dev/null)" && [ -n "$PUBKEY" ]; then
     aws ec2 import-key-pair --region "$REGION" --key-name "$KEY_NAME" \
       --public-key-material "$(printf '%s' "$PUBKEY" | base64)" >/dev/null
@@ -95,9 +140,33 @@ if ! aws ec2 describe-key-pairs --region "$REGION" --key-names "$KEY_NAME" >/dev
     exit 1
   else
     mkdir -p "$(dirname "$KEY_FILE")"
-    aws ec2 create-key-pair --region "$REGION" --key-name "$KEY_NAME" --query KeyMaterial --output text > "$KEY_FILE"
-    chmod 600 "$KEY_FILE"
+    KEY_TMP="$(mktemp "${KEY_FILE}.tmp.XXXXXX")"
+    trap '[ -z "${KEY_TMP:-}" ] || rm -f -- "$KEY_TMP"' EXIT HUP INT TERM
+    if ! aws ec2 create-key-pair --region "$REGION" --key-name "$KEY_NAME" \
+      --query KeyMaterial --output text > "$KEY_TMP"; then
+      echo "ERROR: failed to create EC2 key pair '${KEY_NAME}'; no local private key was installed" >&2
+      exit 1
+    fi
+    chmod 0600 "$KEY_TMP"
+    if ! ln "$KEY_TMP" "$KEY_FILE"; then
+      echo "ERROR: ${KEY_FILE} appeared while creating '${KEY_NAME}'; refusing to overwrite it" >&2
+      exit 1
+    fi
+    rm -f -- "$KEY_TMP"
+    KEY_TMP=""
+    trap - EXIT HUP INT TERM
     echo "Created key pair, private key at ${KEY_FILE}"
+  fi
+else
+  if [ ! -f "$KEY_FILE" ] || ! LOCAL_PUBLIC_KEY="$(ssh-keygen -y -f "$KEY_FILE" 2>/dev/null)"; then
+    echo "ERROR: EC2 key pair '${KEY_NAME}' already exists, but ${KEY_FILE} is missing or unusable; authenticated post-boot setup would be unreachable" >&2
+    exit 1
+  fi
+  read -r EC2_KEY_TYPE EC2_KEY_BLOB _ <<< "$EC2_PUBLIC_KEY"
+  read -r LOCAL_KEY_TYPE LOCAL_KEY_BLOB _ <<< "$LOCAL_PUBLIC_KEY"
+  if [ -z "${EC2_KEY_BLOB:-}" ] || [ "$LOCAL_KEY_TYPE" != "$EC2_KEY_TYPE" ] || [ "$LOCAL_KEY_BLOB" != "$EC2_KEY_BLOB" ]; then
+    echo "ERROR: ${KEY_FILE} does not match existing EC2 key pair '${KEY_NAME}'; authenticated post-boot setup would be unreachable" >&2
+    exit 1
   fi
 fi
 
@@ -106,12 +175,13 @@ read -r ALLOC1 EIP1 < <(aws ec2 allocate-address --region "$REGION" --domain vpc
 read -r ALLOC2 EIP2 < <(aws ec2 allocate-address --region "$REGION" --domain vpc --query '[AllocationId,PublicIp]' --output text)
 echo "Elastic IPs: ${EIP1} (primary) + ${EIP2} (reflector-2)"
 
-# --- cloud-init: config secondary IP, TLS cert, run hub with punch on ---
+# --- cloud-init: configure secondary IP, TLS, and a staged/anonymous hub ---
 UD="$(mktemp)"
-trap 'rm -f "$UD"' EXIT
+RENDERED_UD="$(mktemp)"
+trap 'rm -f "$UD" "$RENDERED_UD"' EXIT
 cat > "$UD" <<'TMPL'
 #!/bin/bash
-set -eux
+set -eu
 # Secrets are written later in this bootstrap. Keep newly-created files private
 # by default, then explicitly relax only the public certificate and directories
 # that the unprivileged relayhub container must traverse.
@@ -124,8 +194,8 @@ export DEBIAN_FRONTEND=noninteractive
 cat > /usr/local/bin/openrung-secondary-ips.sh <<'SCRIPT'
 #!/bin/bash
 set -eu
-TOKEN=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 600")
-imds() { curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }
+IMDS_TOKEN=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 600")
+imds() { curl -sS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }
 MAC=$(imds network/interfaces/macs/ | head -1 | tr -d /)
 PRIMARY=$(imds local-ipv4)
 CIDR=$(imds "network/interfaces/macs/$MAC/subnet-ipv4-cidr-block")
@@ -157,8 +227,8 @@ systemctl daemon-reload
 systemctl enable --now openrung-secondary-ips.service
 systemctl enable --now docker
 
-TOKEN=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 600")
-imds() { curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }
+IMDS_TOKEN=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 600")
+imds() { curl -sS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }
 MAC=$(imds network/interfaces/macs/ | head -1 | tr -d /)
 PRIMARY=$(imds local-ipv4)
 SECONDARY=$(imds "network/interfaces/macs/$MAC/local-ipv4s" | grep -v "^$PRIMARY$" | head -1)
@@ -180,7 +250,6 @@ OPENRUNG_HUB_TLS_CERT=/etc/openrung/certs/hub.crt
 OPENRUNG_HUB_TLS_KEY=/etc/openrung/certs/hub.key
 OPENRUNG_HUB_REFLECTOR_ADDRS=$PRIMARY:__REFLECTOR_PORT__,$SECONDARY:__REFLECTOR_PORT__
 OPENRUNG_HUB_REFLECTOR_ADVERTISE=__EIP1__:__REFLECTOR_PORT__,__EIP2__:__REFLECTOR_PORT__
-__TOKEN_ENV__
 __ANON_ENV__
 ENV
 chown root:root /etc/openrung/relayhub.env
@@ -199,33 +268,118 @@ case "$HUB_UID" in
 esac
 chown "$HUB_UID" /etc/openrung/certs/hub.key
 chmod 0600 /etc/openrung/certs/hub.key
-docker rm -f openrung-relayhub 2>/dev/null || true
+
+cat > /usr/local/sbin/openrung-relayhub-start <<'SCRIPT'
+#!/bin/sh
+set -eu
+unset OPENRUNG_VOLUNTEER_TOKEN OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS
+ENV_FILE=/etc/openrung/relayhub.env
+if [ "$(id -u)" -ne 0 ]; then
+  echo "openrung-relayhub-start must run as root" >&2
+  exit 1
+fi
+if [ "$(stat -c '%u:%a' "$ENV_FILE" 2>/dev/null || true)" != "0:600" ]; then
+  echo "$ENV_FILE must be owned by root with mode 0600" >&2
+  exit 1
+fi
+AUTH_LINE_COUNT=$(grep -Ec '^OPENRUNG_(VOLUNTEER_TOKEN|ALLOW_ANONYMOUS_VOLUNTEERS)=' "$ENV_FILE" || true)
+TOKEN_LINE_COUNT=$(grep -Ec '^OPENRUNG_VOLUNTEER_TOKEN=.+$' "$ENV_FILE" || true)
+ANON_LINE_COUNT=$(grep -Ec '^OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true$' "$ENV_FILE" || true)
+if [ "$AUTH_LINE_COUNT" -ne 1 ] || { [ "$TOKEN_LINE_COUNT" -ne 1 ] && [ "$ANON_LINE_COUNT" -ne 1 ]; }; then
+  echo "$ENV_FILE must contain exactly one non-empty token or explicit anonymous opt-in" >&2
+  exit 1
+fi
 docker run -d --name openrung-relayhub --restart unless-stopped \
   --network host --cap-drop ALL --read-only --tmpfs /tmp \
   -v /etc/openrung/certs:/etc/openrung/certs:ro \
   --env-file /etc/openrung/relayhub.env \
   __IMAGE__
+SCRIPT
+chmod 0700 /usr/local/sbin/openrung-relayhub-start
+
+cat > /usr/local/sbin/openrung-relayhub-install-token <<'SCRIPT'
+#!/bin/sh
+set -eu
+umask 077
+ENV_FILE=/etc/openrung/relayhub.env
+unset OPENRUNG_VOLUNTEER_TOKEN OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS VOLUNTEER_TOKEN EXTRA_INPUT
+if [ "$(id -u)" -ne 0 ]; then
+  echo "openrung-relayhub-install-token must run as root" >&2
+  exit 1
+fi
+if [ ! -f "$ENV_FILE" ]; then
+  echo "$ENV_FILE is missing; wait for cloud-init to finish" >&2
+  exit 1
+fi
+if docker container inspect openrung-relayhub >/dev/null 2>&1; then
+  echo "token installer is for a staged first start only; an openrung-relayhub container already exists" >&2
+  exit 1
+fi
+ENV_TMP="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+trap 'unset VOLUNTEER_TOKEN EXTRA_INPUT; [ -z "${ENV_TMP:-}" ] || rm -f -- "$ENV_TMP"' EXIT HUP INT TERM
+awk '!/^OPENRUNG_VOLUNTEER_TOKEN=/ && !/^OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=/' \
+  "$ENV_FILE" > "$ENV_TMP"
+chown root:root "$ENV_TMP"
+chmod 0600 "$ENV_TMP"
+if ! IFS= read -r VOLUNTEER_TOKEN || [ -z "$VOLUNTEER_TOKEN" ]; then
+  unset VOLUNTEER_TOKEN
+  echo "expected one non-empty volunteer bearer token on stdin" >&2
+  exit 2
+fi
+case "$VOLUNTEER_TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    unset VOLUNTEER_TOKEN
+    echo "volunteer token contains characters that are not valid in an HTTP bearer token" >&2
+    exit 2
+    ;;
+esac
+EXTRA_INPUT=""
+if IFS= read -r EXTRA_INPUT || [ -n "$EXTRA_INPUT" ]; then
+  unset VOLUNTEER_TOKEN EXTRA_INPUT
+  echo "expected exactly one token line on stdin" >&2
+  exit 2
+fi
+unset EXTRA_INPUT
+if ! printf 'OPENRUNG_VOLUNTEER_TOKEN=%s\n' "$VOLUNTEER_TOKEN" >> "$ENV_TMP"; then
+  unset VOLUNTEER_TOKEN
+  echo "could not write volunteer token to the private environment file" >&2
+  exit 1
+fi
+unset VOLUNTEER_TOKEN
+mv "$ENV_TMP" "$ENV_FILE"
+ENV_TMP=""
+trap - EXIT HUP INT TERM
+exec /usr/local/sbin/openrung-relayhub-start
+SCRIPT
+chmod 0700 /usr/local/sbin/openrung-relayhub-install-token
+__AUTO_START__
 TMPL
 
-# Without a token the hub fails closed, so when none is provided we explicitly
-# allow anonymous relay connections (open, unauthenticated hub) instead — set
-# OPENRUNG_VOLUNTEER_TOKEN to require auth.
-TOKEN_ENV=""
 ANON_ENV=""
-if [ -n "$TOKEN" ]; then
-  TOKEN_ENV="OPENRUNG_VOLUNTEER_TOKEN=${TOKEN}"
-else
+AUTO_START='echo "relayhub staged without authentication; install a token post-boot before starting it"'
+if [ "$ALLOW_ANONYMOUS" = true ]; then
   ANON_ENV="OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true"
+  AUTO_START=/usr/local/sbin/openrung-relayhub-start
 fi
-sed -i \
-  -e "s#__IMAGE__#${IMAGE}#g" \
-  -e "s#__BROKER_URL__#${BROKER_URL}#g" \
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed 's/[\\&#]/\\&/g'
+}
+IMAGE_REPLACEMENT="$(escape_sed_replacement "$IMAGE")"
+BROKER_URL_REPLACEMENT="$(escape_sed_replacement "$BROKER_URL")"
+ANON_ENV_REPLACEMENT="$(escape_sed_replacement "$ANON_ENV")"
+AUTO_START_REPLACEMENT="$(escape_sed_replacement "$AUTO_START")"
+
+sed \
+  -e "s#__IMAGE__#${IMAGE_REPLACEMENT}#g" \
+  -e "s#__BROKER_URL__#${BROKER_URL_REPLACEMENT}#g" \
   -e "s/__EIP1__/${EIP1}/g" -e "s/__EIP2__/${EIP2}/g" \
   -e "s/__CONTROL_PORT__/${CONTROL_PORT}/g" -e "s/__HTTP_PORT__/${HTTP_PORT}/g" \
   -e "s/__PORT_RANGE__/${PORT_RANGE}/g" -e "s/__REFLECTOR_PORT__/${REFLECTOR_PORT}/g" \
-  -e "s#__TOKEN_ENV__#${TOKEN_ENV}#g" \
-  -e "s#__ANON_ENV__#${ANON_ENV}#g" \
-  "$UD"
+  -e "s#__ANON_ENV__#${ANON_ENV_REPLACEMENT}#g" \
+  -e "s#__AUTO_START__#${AUTO_START_REPLACEMENT}#g" \
+  "$UD" > "$RENDERED_UD"
+mv "$RENDERED_UD" "$UD"
 
 # --- launch (primary private IP + one secondary; auto public IP for boot egress) ---
 IID="$(aws ec2 run-instances --region "$REGION" \
@@ -247,11 +401,20 @@ SECONDARY_IP="$(aws ec2 describe-instances --instance-ids "$IID" --region "$REGI
 aws ec2 associate-address --region "$REGION" --allocation-id "$ALLOC1" --network-interface-id "$ENI" --private-ip-address "$PRIMARY_IP" >/dev/null
 aws ec2 associate-address --region "$REGION" --allocation-id "$ALLOC2" --network-interface-id "$ENI" --private-ip-address "$SECONDARY_IP" >/dev/null
 
-echo "Done. Hub '${NAME}' (${IID}):"
+echo "Provisioned hub host '${NAME}' (${IID}):"
 echo "  control  ${EIP1}:${CONTROL_PORT} (TLS, self-signed)"
 echo "  http api ${EIP1}:${HTTP_PORT} (reachability prober + punch coordinator)"
 echo "  reflector UDP ${EIP1}:${REFLECTOR_PORT} + ${EIP2}:${REFLECTOR_PORT}"
 echo "  tunnels  ${EIP1}:${PORT_RANGE}"
-echo "It registers tunneled relays with ${BROKER_URL} after boot (~2-3 min)."
-echo "Verify: curl -k https://${EIP1}:${HTTP_PORT}/api/v1/punch/config"
+if [ "$ALLOW_ANONYMOUS" = true ]; then
+  echo "  authentication: OPEN / anonymous (explicit opt-in)"
+  echo "It registers tunneled relays with ${BROKER_URL} after boot (~2-3 min)."
+  echo "Verify: curl -k https://${EIP1}:${HTTP_PORT}/api/v1/punch/config"
+else
+  echo "  status: STAGED; relayhub is not running"
+  echo "Verify and pin the SSH host key out of band, then send exactly one token line"
+  echo "over SSH stdin after cloud-init completes:"
+  echo "  ssh -o StrictHostKeyChecking=yes -i ${KEY_FILE} ubuntu@${EIP1} \\"
+  echo "    'sudo cloud-init status --wait >/dev/null && sudo /usr/local/sbin/openrung-relayhub-install-token'"
+fi
 echo "OPENRUNG_HUB name=${NAME} eip1=${EIP1} eip2=${EIP2} instance=${IID}"

--- a/deploy/relayhub/ec2-up_test.sh
+++ b/deploy/relayhub/ec2-up_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Static regression checks for the cloud-init file-permission contract in
+# ec2-up.sh. Provisioning the script itself would require a live AWS account,
+# so keep these checks narrowly focused on ordering and explicit modes.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/ec2-up.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+line_of() {
+  local needle="$1" matches count
+  matches="$(grep -nF -- "$needle" "$SCRIPT" || true)"
+  count="$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d ' ')"
+  [ "$count" -eq 1 ] || fail "expected one '${needle}' line, found ${count}"
+  printf '%s' "${matches%%:*}"
+}
+
+TEMPLATE_LINE="$(line_of "cat > \"\$UD\" <<'TMPL'")"
+UMASK_LINE="$(line_of 'umask 077')"
+OPENSSL_LINE="$(line_of 'openssl req -x509 -newkey rsa:2048 -nodes -days 3650')"
+CERT_MODE_LINE="$(line_of 'chmod 0644 /etc/openrung/certs/hub.crt')"
+ENV_WRITE_LINE="$(line_of 'cat > /etc/openrung/relayhub.env <<ENV')"
+ENV_OWNER_LINE="$(line_of 'chown root:root /etc/openrung/relayhub.env')"
+ENV_MODE_LINE="$(line_of 'chmod 0600 /etc/openrung/relayhub.env')"
+PULL_LINE="$(line_of 'docker pull __IMAGE__')"
+UID_LINE="$(line_of 'if ! HUB_UID=$(docker run --rm --entrypoint id __IMAGE__ -u); then')"
+ROOT_UID_REJECT_LINE="$(line_of '0) echo "relayhub image must run as a non-root user" >&2; exit 1 ;;')"
+KEY_OWNER_LINE="$(line_of 'chown "$HUB_UID" /etc/openrung/certs/hub.key')"
+
+KEY_MODE_MATCHES="$(grep -nF -- 'chmod 0600 /etc/openrung/certs/hub.key' "$SCRIPT" || true)"
+KEY_MODE_COUNT="$(printf '%s\n' "$KEY_MODE_MATCHES" | sed '/^$/d' | wc -l | tr -d ' ')"
+[ "$KEY_MODE_COUNT" -eq 2 ] || fail "expected key mode to be enforced before and after chown"
+KEY_MODE_FIRST="$(printf '%s\n' "$KEY_MODE_MATCHES" | sed -n '1s/:.*//p')"
+KEY_MODE_SECOND="$(printf '%s\n' "$KEY_MODE_MATCHES" | sed -n '2s/:.*//p')"
+
+[ "$TEMPLATE_LINE" -lt "$UMASK_LINE" ] || fail "restrictive umask is outside cloud-init"
+[ "$UMASK_LINE" -lt "$OPENSSL_LINE" ] || fail "private key is created before restrictive umask"
+[ "$OPENSSL_LINE" -lt "$KEY_MODE_FIRST" ] || fail "key mode is not enforced after generation"
+[ "$KEY_MODE_FIRST" -lt "$CERT_MODE_LINE" ] || fail "unexpected key/certificate mode sequence"
+[ "$UMASK_LINE" -lt "$ENV_WRITE_LINE" ] || fail "environment file is created before restrictive umask"
+[ "$ENV_WRITE_LINE" -lt "$ENV_OWNER_LINE" ] || fail "environment owner is set before the file is written"
+[ "$ENV_OWNER_LINE" -lt "$ENV_MODE_LINE" ] || fail "environment mode is set before its owner"
+[ "$ENV_MODE_LINE" -lt "$PULL_LINE" ] || fail "environment permissions are not finalized before Docker"
+[ "$PULL_LINE" -lt "$UID_LINE" ] || fail "image UID is resolved before the image is pulled"
+[ "$UID_LINE" -lt "$ROOT_UID_REJECT_LINE" ] || fail "root image UID is not rejected after UID resolution"
+[ "$ROOT_UID_REJECT_LINE" -lt "$KEY_OWNER_LINE" ] || fail "key ownership is set before validating the image UID"
+[ "$KEY_OWNER_LINE" -lt "$KEY_MODE_SECOND" ] || fail "key mode is not re-enforced after chown"
+
+if grep -Eq 'chmod[[:space:]]+0?644[[:space:]].*hub\.key' "$SCRIPT"; then
+  fail "TLS private key must never be made world-readable"
+fi
+
+echo "PASS: relayhub bootstrap keeps generated secrets private"

--- a/deploy/relayhub/ec2-up_test.sh
+++ b/deploy/relayhub/ec2-up_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Static regression checks for the cloud-init file-permission contract in
-# ec2-up.sh. Provisioning the script itself would require a live AWS account,
-# so keep these checks narrowly focused on ordering and explicit modes.
+# Regression checks for the cloud-init secret-handling contract in ec2-up.sh.
+# A mocked AWS CLI captures the exact rendered user-data without touching AWS.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -21,7 +20,11 @@ line_of() {
 }
 
 TEMPLATE_LINE="$(line_of "cat > \"\$UD\" <<'TMPL'")"
-UMASK_LINE="$(line_of 'umask 077')"
+STRICT_MODE_LINE="$(line_of 'set -euo pipefail')"
+TOKEN_REJECT_LINE="$(line_of 'if [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ]; then')"
+FIRST_AWS_LINE="$(line_of 'AMI="$(aws ssm get-parameter --region "$REGION" \')"
+UMASK_LINE="$(awk -v start="$TEMPLATE_LINE" 'NR > start && $0 == "umask 077" { print NR; exit }' "$SCRIPT")"
+[ -n "$UMASK_LINE" ] || fail "cloud-init does not set a restrictive umask"
 OPENSSL_LINE="$(line_of 'openssl req -x509 -newkey rsa:2048 -nodes -days 3650')"
 CERT_MODE_LINE="$(line_of 'chmod 0644 /etc/openrung/certs/hub.crt')"
 ENV_WRITE_LINE="$(line_of 'cat > /etc/openrung/relayhub.env <<ENV')"
@@ -38,6 +41,9 @@ KEY_MODE_COUNT="$(printf '%s\n' "$KEY_MODE_MATCHES" | sed '/^$/d' | wc -l | tr -
 KEY_MODE_FIRST="$(printf '%s\n' "$KEY_MODE_MATCHES" | sed -n '1s/:.*//p')"
 KEY_MODE_SECOND="$(printf '%s\n' "$KEY_MODE_MATCHES" | sed -n '2s/:.*//p')"
 
+FIRST_EXECUTABLE_AFTER_STRICT="$(awk -v start="$STRICT_MODE_LINE" 'NR > start && $0 !~ /^[[:space:]]*($|#)/ { print NR; exit }' "$SCRIPT")"
+[ "$FIRST_EXECUTABLE_AFTER_STRICT" -eq "$TOKEN_REJECT_LINE" ] || fail "a command can run before token rejection"
+[ "$TOKEN_REJECT_LINE" -lt "$FIRST_AWS_LINE" ] || fail "token input is not rejected before the first AWS call"
 [ "$TEMPLATE_LINE" -lt "$UMASK_LINE" ] || fail "restrictive umask is outside cloud-init"
 [ "$UMASK_LINE" -lt "$OPENSSL_LINE" ] || fail "private key is created before restrictive umask"
 [ "$OPENSSL_LINE" -lt "$KEY_MODE_FIRST" ] || fail "key mode is not enforced after generation"
@@ -55,4 +61,436 @@ if grep -Eq 'chmod[[:space:]]+0?644[[:space:]].*hub\.key' "$SCRIPT"; then
   fail "TLS private key must never be made world-readable"
 fi
 
-echo "PASS: relayhub bootstrap keeps generated secrets private"
+for forbidden in '__TOKEN_ENV__' 'TOKEN_ENV=' 'TOKEN="${OPENRUNG_VOLUNTEER_TOKEN:-}"'; do
+  if grep -Fq -- "$forbidden" "$SCRIPT"; then
+    fail "relayhub bootstrap still contains obsolete token interpolation: $forbidden"
+  fi
+done
+
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+FAKE_BIN="$TEST_TMP/bin"
+AWS_LOG="$TEST_TMP/aws.log"
+AWS_CAPTURE="$TEST_TMP/user-data"
+AWS_ALLOC_COUNTER="$TEST_TMP/allocate-count"
+mkdir -p "$FAKE_BIN" "$TEST_TMP/home/.ssh"
+: > "$TEST_TMP/home/.ssh/id_ed25519_openrung"
+
+cat > "$FAKE_BIN/ssh-keygen" <<'FAKE_SSH_KEYGEN'
+#!/bin/sh
+printf '%s\n' "${OPENRUNG_TEST_LOCAL_PUBLIC_KEY:-ssh-ed25519 AAAAopenrungtestkey}"
+exit 0
+FAKE_SSH_KEYGEN
+chmod 0700 "$FAKE_BIN/ssh-keygen"
+
+cat > "$FAKE_BIN/docker" <<'FAKE_DOCKER'
+#!/bin/sh
+if [ -n "${OPENRUNG_TEST_CHILD_ENV_LOG:-}" ] && \
+  { [ "${VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ]; }; then
+  printf 'docker inherited a volunteer token\n' >> "$OPENRUNG_TEST_CHILD_ENV_LOG"
+fi
+if [ "${1:-}" = container ] && [ "${2:-}" = inspect ]; then
+  [ "${OPENRUNG_TEST_CONTAINER_EXISTS:-false}" = true ]
+  exit
+fi
+echo "unexpected fake docker call: $*" >&2
+exit 96
+FAKE_DOCKER
+chmod 0700 "$FAKE_BIN/docker"
+
+cat > "$FAKE_BIN/mktemp" <<'FAKE_MKTEMP'
+#!/bin/sh
+if [ -n "${OPENRUNG_TEST_CHILD_ENV_LOG:-}" ] && \
+  { [ "${VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ]; }; then
+  printf 'mktemp inherited a volunteer token\n' >> "$OPENRUNG_TEST_CHILD_ENV_LOG"
+fi
+exec /usr/bin/mktemp "$@"
+FAKE_MKTEMP
+chmod 0700 "$FAKE_BIN/mktemp"
+
+cat > "$FAKE_BIN/aws" <<'FAKE_AWS'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$OPENRUNG_TEST_AWS_LOG"
+service="${1:-}"
+operation="${2:-}"
+shift 2 || true
+
+case "$service $operation" in
+  'ssm get-parameter')
+    printf 'ami-test\n'
+    ;;
+  'ec2 describe-vpcs')
+    printf 'vpc-test\n'
+    ;;
+  'ec2 describe-subnets')
+    printf 'subnet-test\n'
+    ;;
+  'ec2 describe-security-groups')
+    printf 'sg-test\n'
+    ;;
+  'ec2 describe-key-pairs')
+    if [ "${OPENRUNG_TEST_KEY_EXISTS:-true}" != true ]; then
+      exit 255
+    fi
+    case " $* " in
+      *' --include-public-key '*)
+        printf '%s\n' "${OPENRUNG_TEST_EC2_PUBLIC_KEY:-ssh-ed25519 AAAAopenrungtestkey}"
+        ;;
+    esac
+    ;;
+  'ec2 import-key-pair')
+    ;;
+  'ec2 create-key-pair')
+    printf '%s\n' 'fake-private-key-material'
+    if [ "${OPENRUNG_TEST_CREATE_KEY_FAIL:-false}" = true ]; then
+      exit 95
+    fi
+    ;;
+  'ec2 allocate-address')
+    count=0
+    if [ -f "$OPENRUNG_TEST_ALLOC_COUNTER" ]; then
+      count="$(cat "$OPENRUNG_TEST_ALLOC_COUNTER")"
+    fi
+    count=$((count + 1))
+    printf '%s' "$count" > "$OPENRUNG_TEST_ALLOC_COUNTER"
+    case "$count" in
+      1) printf 'alloc-1\t203.0.113.10\n' ;;
+      2) printf 'alloc-2\t203.0.113.11\n' ;;
+      *) exit 91 ;;
+    esac
+    ;;
+  'ec2 run-instances')
+    user_data=''
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = '--user-data' ]; then
+        shift
+        user_data="${1:-}"
+        break
+      fi
+      shift
+    done
+    case "$user_data" in
+      file://*) cp "${user_data#file://}" "$OPENRUNG_TEST_AWS_CAPTURE" ;;
+      *) exit 92 ;;
+    esac
+    printf 'i-test\n'
+    ;;
+  'ec2 wait')
+    ;;
+  'ec2 describe-instances')
+    case "$*" in
+      *NetworkInterfaceId*) printf 'eni-test\n' ;;
+      *'Primary==`true`'*) printf '10.0.0.10\n' ;;
+      *'Primary==`false`'*) printf '10.0.0.11\n' ;;
+      *) exit 93 ;;
+    esac
+    ;;
+  'ec2 associate-address')
+    ;;
+  *)
+    printf 'unexpected fake aws call: %s %s %s\n' "$service" "$operation" "$*" >&2
+    exit 94
+    ;;
+esac
+FAKE_AWS
+chmod 0700 "$FAKE_BIN/aws"
+
+test_token_rejection() {
+  local value="$1" output status
+  : > "$AWS_LOG"
+  set +e
+  output="$(env -i \
+    PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    HOME="$TEST_TMP/home" \
+    OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+    OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+    OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+    OPENRUNG_VOLUNTEER_TOKEN="$value" \
+    bash "$SCRIPT" rejected-hub 2>&1)"
+  status=$?
+  set -e
+
+  [ "$status" -eq 2 ] || fail "set token exited $status, want 2"
+  [ ! -s "$AWS_LOG" ] || fail "set token reached AWS before rejection"
+  case "$output" in
+    *user-data*IMDS*post-boot*) ;;
+    *) fail "token rejection does not explain persistent user-data and post-boot setup" ;;
+  esac
+  if [ -n "$value" ] && printf '%s' "$output" | grep -Fq -- "$value"; then
+    fail "token rejection echoed the supplied credential"
+  fi
+}
+
+test_token_rejection 'sentinel-volunteer-token-do-not-print'
+test_token_rejection ''
+
+reset_mock_aws() {
+  : > "$AWS_LOG"
+  rm -f "$AWS_CAPTURE" "$AWS_ALLOC_COUNTER"
+}
+
+assert_common_user_data_contract() {
+  [ -f "$AWS_CAPTURE" ] || fail "mocked provisioning did not capture rendered user-data"
+  if grep -Eq '^OPENRUNG_VOLUNTEER_TOKEN=' "$AWS_CAPTURE"; then
+    fail "rendered EC2 user-data contains a volunteer-token assignment"
+  fi
+  if grep -Eq '__[A-Z0-9_]+__' "$AWS_CAPTURE"; then
+    fail "rendered user-data contains an unresolved template placeholder"
+  fi
+  if grep -Eq '(^|[;[:space:]])set[[:space:]]+(-[^;[:space:]]*x|-o[[:space:]]+xtrace)([;[:space:]]|$)' "$AWS_CAPTURE"; then
+    fail "cloud-init enables xtrace and can log metadata credentials"
+  fi
+}
+
+reset_mock_aws
+staged_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$TEST_TMP/home" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  bash "$SCRIPT" staged-hub 2>&1)"
+assert_common_user_data_contract
+STAGED_ANON_COUNT="$(grep -Ec '^OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true$' "$AWS_CAPTURE" || true)"
+[ "$STAGED_ANON_COUNT" -eq 0 ] || fail "default staged user-data enables anonymous access"
+grep -Fq "cat > /usr/local/sbin/openrung-relayhub-start <<'SCRIPT'" "$AWS_CAPTURE" \
+  || fail "staged host does not install the root-only start helper"
+grep -Fq 'chmod 0700 /usr/local/sbin/openrung-relayhub-start' "$AWS_CAPTURE" \
+  || fail "relayhub start helper is not root-only"
+grep -Fq 'chmod 0700 /usr/local/sbin/openrung-relayhub-install-token' "$AWS_CAPTURE" \
+  || fail "relayhub token installer is not root-only"
+if grep -Fq 'docker rm -f openrung-relayhub' "$AWS_CAPTURE"; then
+  fail "start helper can remove a live relayhub before its replacement succeeds"
+fi
+STAGED_BOOT_ACTION="$(awk '$0 == "chmod 0700 /usr/local/sbin/openrung-relayhub-install-token" { getline; print; exit }' "$AWS_CAPTURE")"
+[ "$STAGED_BOOT_ACTION" = 'echo "relayhub staged without authentication; install a token post-boot before starting it"' ] \
+  || fail "default staged user-data has an unexpected post-bootstrap action"
+case "$staged_output" in
+  *'status: STAGED; relayhub is not running'*'StrictHostKeyChecking=yes'*'cloud-init status --wait'*'openrung-relayhub-install-token'*) ;;
+  *) fail "staged provisioning output does not describe the authenticated post-boot path" ;;
+esac
+
+reset_mock_aws
+anonymous_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$TEST_TMP/home" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true \
+  bash "$SCRIPT" anonymous-hub 2>&1)"
+assert_common_user_data_contract
+ANON_COUNT="$(grep -Ec '^OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true$' "$AWS_CAPTURE" || true)"
+[ "$ANON_COUNT" -eq 1 ] || fail "explicit anonymous user-data must contain one active opt-in"
+ANON_BOOT_ACTION="$(awk '$0 == "chmod 0700 /usr/local/sbin/openrung-relayhub-install-token" { getline; print; exit }' "$AWS_CAPTURE")"
+[ "$ANON_BOOT_ACTION" = '/usr/local/sbin/openrung-relayhub-start' ] \
+  || fail "explicit anonymous user-data does not have exactly the intended start action"
+case "$anonymous_output" in
+  *'authentication: OPEN / anonymous (explicit opt-in)'*) ;;
+  *) fail "anonymous provisioning output does not disclose open access" ;;
+esac
+
+reset_mock_aws
+set +e
+invalid_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$TEST_TMP/home" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=1 \
+  bash "$SCRIPT" invalid-anonymous-hub 2>&1)"
+invalid_status=$?
+set -e
+[ "$invalid_status" -eq 2 ] || fail "invalid anonymous opt-in exited $invalid_status, want 2"
+[ ! -s "$AWS_LOG" ] || fail "invalid anonymous opt-in reached AWS"
+case "$invalid_output" in
+  *'must be exactly true or false'*) ;;
+  *) fail "invalid anonymous opt-in error is not actionable" ;;
+esac
+
+reset_mock_aws
+set +e
+broker_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$TEST_TMP/home" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  OPENRUNG_BROKER_URL='https://user:sentinel-password@broker.example' \
+  bash "$SCRIPT" credential-url-hub 2>&1)"
+broker_status=$?
+set -e
+[ "$broker_status" -eq 2 ] || fail "credential-bearing broker URL exited $broker_status, want 2"
+[ ! -s "$AWS_LOG" ] || fail "credential-bearing broker URL reached AWS"
+if printf '%s' "$broker_output" | grep -Fq 'sentinel-password'; then
+  fail "broker URL rejection echoed embedded credentials"
+fi
+
+reset_mock_aws
+set +e
+mismatch_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$TEST_TMP/home" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  OPENRUNG_TEST_LOCAL_PUBLIC_KEY='ssh-ed25519 AAAAlocalkey' \
+  OPENRUNG_TEST_EC2_PUBLIC_KEY='ssh-ed25519 AAAAremotekey' \
+  bash "$SCRIPT" mismatched-key-hub 2>&1)"
+mismatch_status=$?
+set -e
+[ "$mismatch_status" -eq 1 ] || fail "mismatched EC2 key exited $mismatch_status, want 1"
+case "$mismatch_output" in
+  *'does not match existing EC2 key pair'*'post-boot setup would be unreachable'*) ;;
+  *) fail "mismatched EC2 key error is not actionable" ;;
+esac
+if grep -Eq '^ec2 (allocate-address|run-instances)' "$AWS_LOG"; then
+  fail "mismatched EC2 key was detected only after allocating or launching resources"
+fi
+
+CREATE_FAIL_HOME="$TEST_TMP/create-fail-home"
+mkdir -p "$CREATE_FAIL_HOME"
+reset_mock_aws
+set +e
+create_fail_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$CREATE_FAIL_HOME" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  OPENRUNG_TEST_KEY_EXISTS=false \
+  OPENRUNG_TEST_CREATE_KEY_FAIL=true \
+  bash "$SCRIPT" failed-key-create-hub 2>&1)"
+create_fail_status=$?
+set -e
+[ "$create_fail_status" -eq 1 ] || fail "failed key creation exited $create_fail_status, want 1"
+[ ! -e "$CREATE_FAIL_HOME/.ssh/id_ed25519_openrung" ] \
+  || fail "failed EC2 key creation left a private-key target behind"
+if find "$CREATE_FAIL_HOME" -name 'id_ed25519_openrung.tmp.*' -print -quit | grep -q .; then
+  fail "failed EC2 key creation left private-key temporary material behind"
+fi
+case "$create_fail_output" in
+  *'no local private key was installed'*) ;;
+  *) fail "failed EC2 key creation error is not actionable" ;;
+esac
+
+reset_mock_aws
+ampersand_output="$(env -i \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  HOME="$TEST_TMP/home" \
+  OPENRUNG_TEST_AWS_LOG="$AWS_LOG" \
+  OPENRUNG_TEST_AWS_CAPTURE="$AWS_CAPTURE" \
+  OPENRUNG_TEST_ALLOC_COUNTER="$AWS_ALLOC_COUNTER" \
+  OPENRUNG_BROKER_URL='https://broker.example/path&segment' \
+  bash "$SCRIPT" ampersand-url-hub 2>&1)"
+assert_common_user_data_contract
+grep -Fqx 'OPENRUNG_BROKER_URL=https://broker.example/path&segment' "$AWS_CAPTURE" \
+  || fail "valid broker URL replacement metacharacters corrupt rendered user-data"
+case "$ampersand_output" in
+  *'status: STAGED; relayhub is not running'*) ;;
+  *) fail "valid broker URL did not complete staged provisioning" ;;
+esac
+
+# Execute the rendered stdin installer against an isolated env file. Replace
+# only its absolute paths and root check; all parsing and atomic-update logic is
+# the same script that cloud-init installs.
+INSTALLER_RAW="$TEST_TMP/install-token-raw.sh"
+INSTALLER_SCRIPT="$TEST_TMP/install-token.sh"
+INSTALL_ENV="$TEST_TMP/relayhub.env"
+INSTALL_START="$TEST_TMP/start-relayhub"
+INSTALL_START_LOG="$TEST_TMP/start.log"
+INSTALL_CHILD_ENV_LOG="$TEST_TMP/child-env.log"
+awk '
+  $0 == "cat > /usr/local/sbin/openrung-relayhub-install-token <<\047SCRIPT\047" { copying=1; next }
+  copying && $0 == "SCRIPT" { exit }
+  copying { print }
+' "$AWS_CAPTURE" > "$INSTALLER_RAW"
+awk -v env_file="$INSTALL_ENV" -v start_helper="$INSTALL_START" '
+  $0 == "ENV_FILE=/etc/openrung/relayhub.env" { print "ENV_FILE=" env_file; next }
+  $0 == "if [ \"$(id -u)\" -ne 0 ]; then" { print "if false; then"; next }
+  $0 == "chown root:root \"$ENV_TMP\"" { print ":"; next }
+  $0 == "exec /usr/local/sbin/openrung-relayhub-start" { print "exec " start_helper; next }
+  { print }
+' "$INSTALLER_RAW" > "$INSTALLER_SCRIPT"
+chmod 0700 "$INSTALLER_SCRIPT"
+cat > "$INSTALL_START" <<'FAKE_START'
+#!/bin/sh
+if [ -n "${OPENRUNG_TEST_CHILD_ENV_LOG:-}" ] && \
+  { [ "${VOLUNTEER_TOKEN+x}" = x ] || [ "${OPENRUNG_VOLUNTEER_TOKEN+x}" = x ]; }; then
+  printf 'start helper inherited a volunteer token\n' >> "$OPENRUNG_TEST_CHILD_ENV_LOG"
+fi
+printf 'started\n' >> "$OPENRUNG_TEST_START_LOG"
+FAKE_START
+chmod 0700 "$INSTALL_START"
+
+reset_install_fixture() {
+  printf '%s\n' \
+    'OPENRUNG_HUB_PUBLIC_HOST=203.0.113.10' \
+    'OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true' > "$INSTALL_ENV"
+  : > "$INSTALL_START_LOG"
+  : > "$INSTALL_CHILD_ENV_LOG"
+}
+
+run_installer() {
+  env \
+    PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    OPENRUNG_TEST_START_LOG="$INSTALL_START_LOG" \
+    OPENRUNG_TEST_CHILD_ENV_LOG="$INSTALL_CHILD_ENV_LOG" \
+    OPENRUNG_VOLUNTEER_TOKEN=inherited-openrung-sentinel \
+    VOLUNTEER_TOKEN=inherited-sentinel \
+    "$INSTALLER_SCRIPT"
+}
+
+reset_install_fixture
+printf 'valid-token_123=\n' | run_installer
+grep -Fqx 'OPENRUNG_VOLUNTEER_TOKEN=valid-token_123=' "$INSTALL_ENV" \
+  || fail "stdin installer did not write the valid token"
+if grep -Fq 'OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=' "$INSTALL_ENV"; then
+  fail "stdin installer retained the anonymous opt-in"
+fi
+[ "$(grep -c '^started$' "$INSTALL_START_LOG")" -eq 1 ] \
+  || fail "stdin installer did not perform exactly one first start"
+[ ! -s "$INSTALL_CHILD_ENV_LOG" ] \
+  || fail "stdin installer exposed the bearer through a child-process environment"
+
+assert_installer_rejects() {
+  local label="$1" input_kind="$2" status before
+  reset_install_fixture
+  before="$(cat "$INSTALL_ENV")"
+  set +e
+  case "$input_kind" in
+    blank) printf '\n' | run_installer >/dev/null 2>&1 ;;
+    invalid) printf 'invalid:token\n' | run_installer >/dev/null 2>&1 ;;
+    extra_terminated) printf 'valid-token\nextra\n' | run_installer >/dev/null 2>&1 ;;
+    extra_unterminated) printf 'valid-token\nextra' | run_installer >/dev/null 2>&1 ;;
+    *) fail "unknown installer test input: $input_kind" ;;
+  esac
+  status=$?
+  set -e
+  [ "$status" -eq 2 ] || fail "$label installer input exited $status, want 2"
+  [ "$(cat "$INSTALL_ENV")" = "$before" ] || fail "$label installer input changed the env file"
+  [ ! -s "$INSTALL_START_LOG" ] || fail "$label installer input started relayhub"
+  [ ! -s "$INSTALL_CHILD_ENV_LOG" ] || fail "$label installer input leaked through a child environment"
+}
+
+assert_installer_rejects "blank" blank
+assert_installer_rejects "invalid-character" invalid
+assert_installer_rejects "newline-terminated extra-line" extra_terminated
+assert_installer_rejects "unterminated extra-line" extra_unterminated
+
+reset_install_fixture
+before_existing="$(cat "$INSTALL_ENV")"
+set +e
+printf 'valid-token\n' | OPENRUNG_TEST_CONTAINER_EXISTS=true run_installer >/dev/null 2>&1
+existing_status=$?
+set -e
+[ "$existing_status" -eq 1 ] || fail "existing-container install exited $existing_status, want 1"
+[ "$(cat "$INSTALL_ENV")" = "$before_existing" ] \
+  || fail "existing-container refusal changed the env file"
+[ ! -s "$INSTALL_START_LOG" ] || fail "existing-container refusal started relayhub"
+[ ! -s "$INSTALL_CHILD_ENV_LOG" ] \
+  || fail "existing-container refusal leaked through a child environment"
+
+echo "PASS: relayhub bootstrap keeps volunteer bearers out of persistent EC2 user-data"

--- a/internal/buildinfo/injection_test.go
+++ b/internal/buildinfo/injection_test.go
@@ -77,3 +77,75 @@ func TestInjectionSitesUseProvenSymbols(t *testing.T) {
 		t.Fatal("found no -X injection sites at all; the scan pattern is broken")
 	}
 }
+
+// Every server Dockerfile uses COPY . . during its build stage. Keep local
+// credentials, private-key material, and documentation-only env templates out
+// of that context so they cannot be retained in an image layer or remote cache.
+func TestDockerBuildContextExcludesSecretFiles(t *testing.T) {
+	path := filepath.Join("..", "..", ".dockerignore")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	ruleLines := make(map[string]int)
+	lastNegationLine := 0
+	for lineNumber, line := range strings.Split(string(data), "\n") {
+		rule := strings.TrimSpace(line)
+		if rule == "" || strings.HasPrefix(rule, "#") {
+			continue
+		}
+		ruleLines[rule] = lineNumber + 1
+		if strings.HasPrefix(rule, "!") {
+			lastNegationLine = lineNumber + 1
+		}
+	}
+
+	for _, required := range []string{
+		".env",
+		".env.*",
+		"*.env",
+		"*.env.*",
+		"**/.env",
+		"**/.env.*",
+		"**/*.env",
+		"**/*.env.*",
+		"*.key",
+		"*.pem",
+		"*.p12",
+		"*.pfx",
+		"*.seed",
+		"**/*.key",
+		"**/*.pem",
+		"**/*.p12",
+		"**/*.pfx",
+		"**/*.seed",
+	} {
+		lineNumber, ok := ruleLines[required]
+		if !ok {
+			t.Errorf("%s does not exclude secret files matching %q", path, required)
+		} else if lineNumber < lastNegationLine {
+			// Docker evaluates matching rules in order. Requiring every secret
+			// rule after the final exception prevents a later broad negation,
+			// such as !deploy/**, from restoring sensitive files to the context.
+			t.Errorf("%s:%d secret rule %q precedes a later negation on line %d", path, lineNumber, required, lastNegationLine)
+		}
+	}
+
+	dockerfiles, err := filepath.Glob(filepath.Join("..", "..", "deploy", "*", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("glob deploy Dockerfiles: %v", err)
+	}
+	if len(dockerfiles) == 0 {
+		t.Fatal("no deploy Dockerfiles found; env-template build-input check is not running")
+	}
+	for _, dockerfile := range dockerfiles {
+		contents, err := os.ReadFile(dockerfile)
+		if err != nil {
+			t.Fatalf("read %s: %v", dockerfile, err)
+		}
+		if strings.Contains(string(contents), ".env.example") {
+			t.Errorf("%s consumes an env template; review whether it needs a narrow .dockerignore exception", dockerfile)
+		}
+	}
+}

--- a/internal/relayruntime/config.go
+++ b/internal/relayruntime/config.go
@@ -17,8 +17,10 @@ import (
 const (
 	// IdentitySeedEnvironmentVariable carries the relay's long-lived Ed25519
 	// identity seed. Xray never needs it, so every Xray subprocess is launched
-	// with this variable removed from its environment.
+	// without the relay's OPENRUNG_* environment namespace.
 	IdentitySeedEnvironmentVariable = "OPENRUNG_IDENTITY_SEED"
+
+	openRungEnvironmentVariablePrefix = "OPENRUNG_"
 
 	// DefaultMaxSessions and DefaultMaxMbps are advertised capacity hints. The
 	// relay does not enforce them directly; the broker uses them when ranking
@@ -149,24 +151,33 @@ func GenerateRealityKeyPair(xrayPath string) (RealityKeyPair, error) {
 	return ParseRealityKeyPair(out)
 }
 
-// NewXrayCommand constructs an Xray subprocess without passing the relay's
-// stable-identity seed to it. This shared boundary covers both one-shot key
+// NewXrayCommand constructs an Xray subprocess without passing relay-owned
+// environment variables to it. This shared boundary covers both one-shot key
 // generation and the long-running relay process.
 func NewXrayCommand(ctx context.Context, path string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, path, args...)
-	cmd.Env = environmentWithoutIdentitySeed(os.Environ())
+	cmd.Env = environmentForXray(os.Environ())
 	return cmd
 }
 
-func environmentWithoutIdentitySeed(environ []string) []string {
+func environmentForXray(environ []string) []string {
+	// Keep the ordinary process environment because Xray may need PATH, proxy or
+	// certificate settings, and XRAY_* runtime configuration. Xray receives all
+	// relay configuration through its config file and never needs OPENRUNG_*.
+	// Filtering the whole application namespace is safer than maintaining a list
+	// of today's secrets: future relay credentials are excluded by default too.
 	filtered := make([]string, 0, len(environ))
 	for _, entry := range environ {
 		name, _, _ := strings.Cut(entry, "=")
-		if !strings.EqualFold(name, IdentitySeedEnvironmentVariable) {
+		if !hasCaseInsensitivePrefix(name, openRungEnvironmentVariablePrefix) {
 			filtered = append(filtered, entry)
 		}
 	}
 	return filtered
+}
+
+func hasCaseInsensitivePrefix(value, prefix string) bool {
+	return len(value) >= len(prefix) && strings.EqualFold(value[:len(prefix)], prefix)
 }
 
 func ParseRealityKeyPair(out []byte) (RealityKeyPair, error) {

--- a/internal/relayruntime/config_test.go
+++ b/internal/relayruntime/config_test.go
@@ -7,49 +7,65 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 )
 
-func TestNewXrayCommandExcludesIdentitySeedFromEnvironment(t *testing.T) {
-	t.Setenv(IdentitySeedEnvironmentVariable, "long-lived-secret")
-	t.Setenv("OPENRUNG_TEST_CHILD_ENV", "preserved")
+func TestNewXrayCommandSanitizesOpenRungEnvironment(t *testing.T) {
+	secretVariables := []string{
+		"OPENRUNG_VOLUNTEER_TOKEN",
+		"openrung_foundation_token",
+		"OpenRung_Relay_Signing_Key",
+		"OPENRUNG_DASHBOARD_TOKEN",
+		"openrung_api_token",
+		"OpenRung_Identity_Seed",
+		"OPENRUNG_REALITY_private_KEY",
+	}
+	for _, name := range secretVariables {
+		t.Setenv(name, "must-not-reach-xray")
+	}
+	t.Setenv("XRAY_LOCATION_ASSET", "/xray-assets")
 
 	cmd := NewXrayCommand(context.Background(), "xray", "run")
-	if slices.Contains(cmd.Env, IdentitySeedEnvironmentVariable+"=long-lived-secret") {
-		t.Fatal("Xray command inherited OPENRUNG_IDENTITY_SEED")
+	for _, name := range secretVariables {
+		if environmentContainsVariable(cmd.Env, name) {
+			t.Fatalf("Xray command inherited %s", name)
+		}
 	}
-	if !slices.Contains(cmd.Env, "OPENRUNG_TEST_CHILD_ENV=preserved") {
+	if !slices.Contains(cmd.Env, "XRAY_LOCATION_ASSET=/xray-assets") {
 		t.Fatal("Xray command dropped unrelated environment variables")
-	}
-
-	// Windows treats environment names case-insensitively. Exercise the filter
-	// directly so a differently-cased spelling cannot survive into a child.
-	filtered := environmentWithoutIdentitySeed([]string{
-		"OpenRung_Identity_Seed=also-secret",
-		"OPENRUNG_TEST_CHILD_ENV=preserved",
-	})
-	if len(filtered) != 1 || filtered[0] != "OPENRUNG_TEST_CHILD_ENV=preserved" {
-		t.Fatalf("case-insensitive identity seed filtering = %q", filtered)
 	}
 }
 
-func TestGenerateRealityKeyPairExcludesIdentitySeedFromEnvironment(t *testing.T) {
+func TestGenerateRealityKeyPairSanitizesOpenRungEnvironment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake Xray executable requires a POSIX shell")
 	}
 
 	fakeXray := filepath.Join(t.TempDir(), "xray")
 	script := `#!/bin/sh
-if [ -n "${OPENRUNG_IDENTITY_SEED:-}" ]; then
-  echo "identity seed leaked to xray" >&2
+if env | grep -Eiq '^openrung_'; then
+  echo "OpenRung environment leaked to xray" >&2
   exit 97
+fi
+if [ "${XRAY_LOCATION_ASSET:-}" != "/xray-assets" ]; then
+  echo "Xray runtime environment was dropped" >&2
+  exit 98
 fi
 printf 'Private key: private_key\nPublic key: public-key\n'
 `
 	if err := os.WriteFile(fakeXray, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake Xray: %v", err)
 	}
-	t.Setenv(IdentitySeedEnvironmentVariable, "long-lived-secret")
+	for _, name := range []string{
+		"OpenRung_Volunteer_Token",
+		"OPENRUNG_FOUNDATION_TOKEN",
+		"openrung_identity_seed",
+		"OPENRUNG_Reality_Private_Key",
+	} {
+		t.Setenv(name, "must-not-reach-xray")
+	}
+	t.Setenv("XRAY_LOCATION_ASSET", "/xray-assets")
 
 	keys, err := GenerateRealityKeyPair(fakeXray)
 	if err != nil {
@@ -58,6 +74,16 @@ printf 'Private key: private_key\nPublic key: public-key\n'
 	if keys.PrivateKey != "private_key" || keys.PublicKey != "public-key" {
 		t.Fatalf("unexpected keys: %+v", keys)
 	}
+}
+
+func environmentContainsVariable(environ []string, want string) bool {
+	for _, entry := range environ {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(name, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildXrayConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Create deployment environment files with mode `0600` and keep relayhub TLS private keys private while preserving access for the official non-root image.
- Exclude environment files, private keys, signing seeds, and related secret material from Docker build contexts.
- Strip the complete case-insensitive `OPENRUNG_*` namespace from Xray subprocess environments while preserving ordinary variables and `XRAY_*`.
- Remove volunteer bearer values from the EC2 user-data path. `ec2-up.sh` rejects `OPENRUNG_VOLUNTEER_TOKEN` (including an explicitly empty value) before any AWS call.
- Stage authenticated EC2 hubs without starting relayhub. Only `OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true` starts an open hub during cloud-init.
- Install authenticated EC2 tokens post-boot through a root-only stdin helper after verified SSH and `cloud-init status --wait`; the helper atomically writes the `0600` env file and never passes the bearer in argv or a child-process environment.
- Disable cloud-init xtrace, verify that the configured local SSH key matches EC2's stored public key, and publish newly created private-key files atomically with no-overwrite semantics.
- Add rendered-user-data and installer regression coverage, and ensure all server image workflows react to `.dockerignore` changes.

## EC2 migration and remediation

- This intentionally changes the authenticated `deploy/relayhub/ec2-up.sh` procedure: exporting `OPENRUNG_VOLUNTEER_TOKEN` now exits with status 2 before AWS is contacted. Provision first with the token unset, verify and pin the SSH host key, then pipe one token line to the documented root-only installer.
- A tokenless invocation now stages the host and leaves relayhub stopped instead of silently starting an anonymous hub. Explicit open deployments must opt in with `OPENRUNG_ALLOW_ANONYMOUS_VOLUNTEERS=true`.
- Any instance previously provisioned with a volunteer token must be treated as retaining that credential in EC2 user-data, cloud-init artifacts, and possibly snapshots. Rotate the token and replace or retire the affected instance; changing `relayhub.env` permissions is not sufficient remediation.

## Other compatibility notes

- Stock broker, relay, relayhub Compose, and Xray deployment paths remain compatible.
- Custom relayhub images selected with `OPENRUNG_IMAGE` must run non-root and provide `id` so cloud-init can assign the TLS key to the runtime UID.
- Custom Xray wrappers must not depend on inherited `OPENRUNG_*` variables.
- Docker builds that intentionally copied env/key/seed files from the build context must move those inputs to a runtime secret mechanism or add a narrowly reviewed exception.
- Credential-bearing, query-bearing, or fragment-bearing `OPENRUNG_BROKER_URL` values are rejected before AWS because that URL is persisted in user-data.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `bash -n deploy/relayhub/ec2-up.sh`
- `bash -n deploy/relayhub/ec2-up_test.sh`
- `bash deploy/relayhub/ec2-up_test.sh`
- `git diff --check`

All eight GitHub checks pass for the latest push, including the broker, relay, and relayhub image builds.
