### PR TITLE
Correct mobile WSS and NAT punching documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ cleartext ClientHello, while the Cloudflare front conceals its own only as long
 as ECH survives — the ordinary-TLS fallback sends it. A configured proxy
 tunnels both fronts outside this transport and keeps sending the name.
 
-The desktop client still tries direct Reality first. When a genuine network
-failure blocks a direct-mode Foundation relay, that relay may advertise its own
-signed WSS fronts. Each CDN front terminates at the same relay's local sidecar,
-which carries opaque Reality bytes only to that relay's loopback Reality
-listener. The broker issues relay- and front-bound authorization tickets but
-remains outside the user data path. The desktop client and relay-local sidecar
-share the transport mechanics from the independently versioned
-[`wsscore`](wsscore/README.md) module; ticket authority, origin authentication,
-deployment policy, telemetry orchestration, and user interfaces remain in
-their owning applications.
+The desktop app and both mobile clients still try direct Reality first. When a
+genuine network failure blocks a direct-mode Foundation relay, that relay may
+advertise its own signed WSS fronts. Each CDN front terminates at the same
+relay's local sidecar, which carries opaque Reality bytes only to that relay's
+loopback Reality listener. The broker issues relay- and front-bound
+authorization tickets but remains outside the user data path. Those clients
+and the relay-local sidecar share the transport mechanics from the
+independently versioned [`wsscore`](wsscore/README.md) module; ticket authority,
+origin authentication, deployment policy, telemetry orchestration, and user
+interfaces remain in their owning applications.
 
 ## Highlights
 
@@ -92,9 +92,9 @@ their owning applications.
   attempt NAT hole punching first, with the relay hub as the fallback.
 - 📱 **Full-device mobile client** — the OpenRung app routes all device
   traffic in VPN mode (developed in a separate React Native repository).
-- 🛡️ **Direct-first censorship fallback** — the desktop client can carry the
-  existing end-to-end Reality connection through a relay-owned WSS/CDN front
-  when the direct route is blocked.
+- 🛡️ **Direct-first censorship fallback** — the desktop app and both mobile
+  clients can carry the existing end-to-end Reality connection through a
+  relay-owned WSS/CDN front when the direct route is blocked.
 - 🧭 **Privacy-aware control plane** — the broker matchmakes but never carries
   user traffic.
 - 🗄️ **Production-friendly broker** — optional shared PostgreSQL state for safe
@@ -285,8 +285,8 @@ go run ./cmd/client check -broker http://localhost:8080
 
 For the zero-privilege desktop proxy app and macOS full-device CLI routing, see
 [`docs/desktop-client.md`](docs/desktop-client.md).
-WSS fallback is currently desktop-only. Android and iOS are developed in
-separate repositories and do not currently ship this fallback.
+The separately maintained Android and iOS clients implement the same
+direct-first WSS/CDN fallback through pinned `brokerapi` and `wsscore` modules.
 
 ## Repository layout
 
@@ -308,15 +308,14 @@ internal/relayruntime/  Relay runtime, Xray config, and broker client helpers.
 internal/wssbridge/  Relay-side tickets, replay/origin authentication,
                      admission limits, and sidecar orchestration over wsscore.
 brokerapi/           Shared broker control-plane Go client (nested module
-                     github.com/openrung/openrung/brokerapi) for desktop and
-                     separately released mobile bindings.
+                     github.com/openrung/openrung/brokerapi) for desktop,
+                     Android, and iOS bindings.
 punchcore/           Shared NAT hole-punch protocol core (nested Go module
                      github.com/openrung/openrung/punchcore) consumed by the
-                     servers, the desktop client, and the mobile app's binding.
+                     servers and the desktop, Android, and iOS clients.
 wsscore/             Shared opaque Reality-over-WSS transport core (nested Go
                      module github.com/openrung/openrung/wsscore) consumed by
-                     the desktop client and relay-local sidecar, and available
-                     for separately released mobile clients to pin.
+                     the desktop, Android, and iOS clients and relay sidecar.
 desktop/             Desktop GUI client (Wails v2 + React; own Go module).
 desktop-volunteer/   One-click volunteer relay GUI (Wails v2 + React; own
                      Go module).
@@ -344,9 +343,9 @@ docs/                Architecture, API, client, and operations docs.
 - **Abuse and rate controls** — exit policies, rate limits, and abuse
   reporting ahead of a broad public rollout.
 - **NAT hole-punch coverage** — direct client↔relay paths for volunteer-run
-  relays behind CGNAT are implemented in the desktop and Android clients using
-  `github.com/openrung/openrung/punchcore`; iOS support and broader production
-  rollout are still planned.
+  relays behind CGNAT are implemented in the desktop, Android, and iOS clients
+  using `github.com/openrung/openrung/punchcore`; broader production rollout
+  and harder NAT mappings remain planned.
 - **Dual-stack relay discovery** — multiple public endpoints per relay.
 
 Have an opinion on what should come first?

--- a/brokerapi/README.md
+++ b/brokerapi/README.md
@@ -1,8 +1,8 @@
 # brokerapi
 
 `brokerapi` is OpenRung's shared Go client for end-user connection and session
-broker requests. It is a standalone module so the CLI, desktop app, and future
-gomobile bindings all use one implementation of:
+broker requests. It is a standalone module so the CLI, desktop app, and Android
+and iOS gomobile bindings all use one implementation of:
 
 - opportunistic Encrypted Client Hello for the Cloudflare broker front;
 - verified SNI-less TLS for the CloudFront broker front;
@@ -102,21 +102,19 @@ result, err := api.FirstReachable(
 application can decode those bytes into its own relay model without exposing
 server-internal relay fields through this module.
 
-For mobile, bind a small cancellation-owning wrapper into the same Go
-AAR/XCFramework as the existing tunnel library. Do not ship a second Go
-runtime in a separate Android AAR. A wrapper should return verified relay JSON
-and accept telemetry JSON through `SendTelemetryBatchJSON`; JavaScript `fetch`
-must not remain on any pre-tunnel broker path that needs ECH.
+The mobile repository binds cancellation-owning wrappers into the same Go
+AAR/XCFramework as its tunnel library, avoiding a second Go runtime. Native
+directory discovery returns verified relay JSON, telemetry passes through
+`SendTelemetryBatchJSON`, and WSS ticket operations remain inside the native
+VPN owners rather than crossing the React Native bridge.
 
-The separately maintained mobile app also fetches the signed update manifest
-from the Cloudflare broker front. That manifest has its own signing keys,
-rollback rules, and multi-origin policy and is not implemented by this initial
-module extraction. The mobile integration must move that request behind this
-transport (or stop using the Cloudflare broker URL) before claiming complete
-broker-SNI concealment. Note that even then the claim holds only where ECH
-survives: the Cloudflare front's ordinary-TLS fallback still sends its hostname,
-and only the native CloudFront and Azure fronts are unconditionally SNI-less.
-Azure has the weaker provider-bound authentication described above.
+The separately maintained mobile app also routes its exact Cloudflare and
+CloudFront update-manifest candidates through this transport. The manifest's
+signature, freshness, rollback, cache, and multi-origin selection policy remain
+in the application layer, with an exact redirecting GitHub release URL as its
+narrow JavaScript fallback. Broker-SNI concealment still holds only where ECH
+survives on Cloudflare; its ordinary-TLS fallback sends the hostname, while the
+native CloudFront front is unconditionally SNI-less.
 
 `RequestWSSTicket` owns one hardened POST and response validation and refuses
 endpoint-unbound fronts. Overall deadline, broker-front failover, and the single

--- a/desktop/config/config.go
+++ b/desktop/config/config.go
@@ -99,12 +99,13 @@ const (
 	// suspend reconnection (and leave traffic on the normal network) for long.
 	MaxRecoveryBackoff = 60 * time.Second
 
-	// Mid-session health monitor (desktop-only; mobile has no equivalent yet):
-	// one probe sweep through the tunnel every HealthProbeInterval. After
-	// HealthFailureThreshold consecutive failures AND proof the local network
-	// is alive (some known relay answers a TCP dial), the tunnel is declared
-	// dead and an automatic failover re-ladder runs. The network-alive gate is
-	// what keeps a wifi blip or laptop sleep from churning relays.
+	// Desktop mid-session health monitor; mobile clients own separate native
+	// health and recovery policies. One probe sweep through the tunnel runs every
+	// HealthProbeInterval. After HealthFailureThreshold consecutive failures AND
+	// proof the local network is alive (some known relay answers a TCP dial), the
+	// tunnel is declared dead and an automatic failover re-ladder runs. The
+	// network-alive gate is what keeps a wifi blip or laptop sleep from churning
+	// relays.
 	HealthProbeInterval    = 30 * time.Second
 	HealthFailureThreshold = 3
 )

--- a/docs/api.md
+++ b/docs/api.md
@@ -971,14 +971,15 @@ The endpoint exists only when `OPENRUNG_WSS_TICKET_SIGNING_SEED` is configured.
 `400` reports malformed or incomplete JSON, `409` asks the client to refresh a
 relay whose lease is too close to expiry, `429` includes a bounded
 `Retry-After`, and `503` reports temporary store failure. This fallback is
-implemented by the desktop client in this repository. Its opaque WebSocket and
+implemented by the desktop client in this repository and by the Android and
+iOS clients in their separate mobile repository. Its opaque WebSocket and
 multiplexing mechanics come from the shared, independently tagged
 `github.com/openrung/openrung/wsscore` module. The hardened HTTPS ticket
 exchange comes from the independently tagged
 `github.com/openrung/openrung/brokerapi` module; broker-front scheduling and
-relay-health policy remain application concerns. Android and iOS live in
-separate repositories and release independently. A shared-module tag does not
-restore, update, or make either mobile client WSS-capable.
+relay-health policy remain application concerns. Mobile releases pin reviewed
+module tags and ship independently; publishing a shared-module tag alone does
+not update an installed app.
 
 ## Mirror Relay List
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,11 +168,11 @@ discovery, punch mechanics, reflector, policies) lives in the nested
 `punchcore/` Go module
 (`github.com/openrung/openrung/punchcore`) — the single source of truth with no
 hand-mirrored copies. The servers and the desktop client consume it in-repo via
-`internal/punch` (the quic-go session/transport/bridge layer); the Android app's
-gomobile binding (`android/punchbridge` in `openrung-mobile-app`) consumes the
-punchcore module at a pinned, tagged version. iOS remains a follow-up: it embeds
-stock sing-box without an app-layer punch client, so it ignores `punch_capable`
-and uses the hub relay with no regression.
+`internal/punch` (the quic-go session/transport/bridge layer). The Android and
+iOS native bindings in `openrung-mobile-app` consume the same punchcore module
+at a pinned, tagged version. Both mobile platforms try the direct punched path
+for an eligible signed descriptor and retain the Relay Hub as the same-relay
+fallback when punching is unavailable, fails, or becomes unstable.
 
 #### punchcore pin/upgrade procedure (wire changes)
 
@@ -186,14 +186,17 @@ and uses the hub relay with no regression.
    through the Go proxy); no manual tagging.
 4. Dependabot in the mobile repo (scoped to punchcore) opens the
    `android/punchbridge/go.mod` (+`go.sum`) bump PR when it sees the new tag,
-   which automatically busts the AAR CI caches (their hash keys include
-   go.mod/go.sum). Manual fallback: `go get` the new version directly.
-5. Rebuild the AAR via `android/build-libbox-release.sh` and ship.
+   which automatically busts the Android AAR and iOS XCFramework CI caches
+   (their hash keys include go.mod/go.sum). Manual fallback: `go get` the new
+   version directly.
+5. Rebuild the AAR via `android/build-libbox-release.sh` and the XCFramework via
+   `ios/build-libbox-release.sh`, run both platform VPN suites, and ship the
+   corresponding app releases.
 
 Local cross-repo development uses
-`PUNCHCORE_SRC=/path/to/openrung/punchcore android/build-libbox-release.sh`
-and/or an uncommitted `go.work` — never in releases (GPL §6 pins the module
-version).
+`PUNCHCORE_SRC=/path/to/openrung/punchcore` with either mobile platform's
+`build-libbox-release.sh` and/or an uncommitted `go.work` — never in releases
+(GPL §6 pins the module version).
 
 ```mermaid
 sequenceDiagram
@@ -233,33 +236,33 @@ sequenceDiagram
     V->>V: Xray exits to destination
 ```
 
-### Relay-local WSS fallback (desktop client ↔ Foundation relay)
+### Relay-local WSS fallback (client ↔ Foundation relay)
 
 Eligible direct-mode Foundation relays can expose a CDN-fronted WebSocket
 fallback when a client network blocks the relay's raw IP. This is not the Relay
 Hub and does not introduce a gateway fleet: every advertised front has that
 same relay as its CDN origin, and the relay-local sidecar can dial only its
-fixed loopback Reality listener. Direct Reality remains the desktop client's
-first choice, and Reality still authenticates and encrypts the complete inner
+fixed loopback Reality listener. Every WSS-capable client tries direct Reality
+first, and Reality still authenticates and encrypts the complete inner
 connection end to end. See [`wss-fallback.md`](wss-fallback.md) for the full
 protocol, failure-classification, and rollout contract.
 
 The nested `wsscore/` Go module
 (`github.com/openrung/openrung/wsscore`) is the single reusable implementation
-of the WSS data-plane mechanics. Both the desktop client and the relay-local
-sidecar consume it. It owns the protocol constants, strict advertised-front URL
-validation, binary-only WebSocket byte-stream adapter, shared bounded yamux
-configuration, opaque bidirectional copying, lifecycle limits, and the optional
-socket-control hook a future Android integration can connect to
-`VpnService.protect`.
+of the WSS data-plane mechanics. The desktop client, Android and iOS native
+bindings, and relay-local sidecar consume it. It owns the protocol constants,
+strict advertised-front URL validation, binary-only WebSocket byte-stream
+adapter, shared bounded yamux configuration, opaque bidirectional copying,
+lifecycle limits, Android's `VpnService.protect` socket-control hook, and the
+Apple constructor for PacketTunnel-owned sockets.
 
 The module deliberately does not own system policy or authority. Broker ticket
 issuance, relay-local ticket verification and replay persistence, CDN origin
 authentication, per-source admission policy, relay capability signing,
-CloudFront/deployment configuration, desktop direct-first and health/telemetry
-orchestration, and every platform UI remain in this repository's surrounding
-packages and applications. A ticket is only an opaque bearer value to the
-shared transport; `wsscore` never selects a relay or destination.
+CloudFront/deployment configuration, platform direct-first and health/telemetry
+orchestration, and every platform UI remain in their surrounding packages and
+applications. A ticket is only an opaque bearer value to the shared transport;
+`wsscore` never selects a relay or destination.
 
 #### wsscore pin/upgrade procedure
 
@@ -273,10 +276,10 @@ shared transport; `wsscore` never selects a relay or destination.
    making that nested-module version fetchable without copying its code into a
    consumer repository. Golden and live interoperability tests guard its public
    protocol and transport behavior.
-4. External clients explicitly update their pinned module version, integrate
-   their platform socket-routing and fallback policy, run their own tests, and
-   publish their own application release. Updating or tagging `wsscore` does
-   not release a mobile app.
+4. External clients explicitly update their pinned module version, verify their
+   platform socket-routing and fallback-policy integration, run their own tests,
+   and publish their own application release. Updating or tagging `wsscore`
+   does not release a mobile app.
 
 Local cross-repository development may use an uncommitted `go.work` or local
 module replacement. Released consumers pin a `wsscore/vX.Y.Z` tag.
@@ -286,10 +289,10 @@ module replacement. Released consumers pin a `wsscore/vX.Y.Z` tag.
 The nested `brokerapi/` Go module
 (`github.com/openrung/openrung/brokerapi`) is the client-side source of truth
 for end-user connection and session broker exchanges implemented by the
-module. The desktop CLI and GUI consume the in-tree module, and mobile
-repositories can expose the same implementation through a small gomobile
-binding instead of maintaining parallel request code. The broker server and
-its authorization policy remain in
+module. The desktop CLI and GUI consume the in-tree module, and the mobile
+repository exposes the same implementation through its Android and iOS
+gomobile bindings instead of maintaining parallel request code. The broker
+server and its authorization policy remain in
 `internal/broker`; extracting the client does not move the broker or add it to
 the relay data path.
 
@@ -407,11 +410,16 @@ VPN integration, tests, version pins, and release processes:
 - Android uses `VpnService` plus the embedded tunnel engine.
 - iOS uses a `NetworkExtension` packet tunnel provider.
 
-Mobile broker requests should consume a pinned `brokerapi` release through the
+Both platforms implement NAT-punch-first access for eligible Relay Hub relays
+through their pinned `punchcore` binding, with the hub path as the same-relay
+fallback. They also implement direct-first WSS/CDN fallback for eligible
+Foundation relays through pinned `brokerapi` and `wsscore` bindings.
+
+Mobile broker requests consume a pinned `brokerapi` release through the
 platform's native binding. This removes the TypeScript TLS limitation and gives
 mobile the same opportunistic ECH, signature verification, identity headers,
-cache policy, and URL hardening as desktop. Publishing this module does not by
-itself update either separately released app.
+cache policy, and URL hardening as desktop. Publishing a new module tag does
+not by itself update either separately released app.
 
 Native mobile discovery delegates candidate construction and racing to
 `BrokerCandidates` and `FirstReachable`, so platform `AppConfig` must not
@@ -422,22 +430,20 @@ inherits the hard pre-HTTP refusal for endpoint-unbound fronts. The platform
 ticket-front builders should filter such a winning front too as defense in
 depth and to avoid a request that is guaranteed to fail locally.
 
-The mobile app's update-manifest checker is a separate signed-content client
-with its own keys, rollback protection, and GitHub fallback. Its current
-Cloudflare-broker candidate must also move behind the Go broker transport—or be
-removed—during mobile integration. Until then, that request still exposes the
-broker SNI unconditionally, so integrating relay discovery and telemetry alone
-is not complete mobile broker-SNI concealment. Moving it is necessary but not
-sufficient: only the CloudFront front is unconditionally SNI-less, while the
-Cloudflare front's ordinary-TLS fallback still sends its hostname wherever ECH
-is blocked.
+The mobile app's update-manifest checker remains a separate signed-content
+client with its own keys, freshness and rollback rules, and GitHub fallback.
+Its exact Cloudflare and CloudFront candidates run through the native
+`brokerapi` transport; signature verification and candidate selection remain in
+the application layer, and the exact redirecting GitHub release asset is the
+narrow JavaScript-fetch exception. Cloudflare's ordinary-TLS fallback still
+sends its hostname wherever ECH is blocked, while the native CloudFront front
+is unconditionally SNI-less.
 
-The reusable `wsscore` module makes a future transport integration possible but
-does not restore or ship WSS fallback on either platform. Android must still
-wire socket protection and the ticket/direct-first policy in its repository;
-iOS must perform its corresponding platform integration. Each mobile release
-must advertise support only after that repository independently implements and
-tests the complete contract.
+Android wires WSS socket protection to `VpnService.protect` before connect;
+iOS uses the Apple constructor for PacketTunnel-owned sockets. Swift and Kotlin
+own the corresponding direct-first classification, ticket ordering, lifecycle,
+recovery, and telemetry policy, while the pinned shared modules own their
+common transport and broker mechanics.
 
 ### Future Dedicated Exit Mode
 

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -22,8 +22,9 @@ ticket HTTP exchange, telemetry posting, URL hardening, and the shared broker
 TLS transport. Direct-first selection, multi-front scheduling, relay-health
 and telemetry lifecycle decisions, sing-box configuration, recovery, and UI
 state remain desktop application responsibilities. Android and iOS are
-maintained and released outside this repository; publishing either shared
-module does not restore or enable their WSS fallback.
+maintained and released outside this repository and implement the same
+direct-first contract through their own platform orchestration over pinned
+`brokerapi` and `wsscore` releases.
 
 ## Desktop App: Local Proxy
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -24,7 +24,7 @@ Shared Go modules are versioned separately from deployable applications:
 | --- | --- | --- | --- |
 | `github.com/openrung/openrung/brokerapi` | `brokerapi/VERSION` | `brokerapi/vX.Y.Z` | Root and desktop clients in this repository; pinned mobile broker bindings |
 | `github.com/openrung/openrung/punchcore` | `punchcore/VERSION` | `punchcore/vX.Y.Z` | Relay/hub and desktop code in this repository; pinned mobile punch bindings |
-| `github.com/openrung/openrung/wsscore` | `wsscore/VERSION` | `wsscore/vX.Y.Z` | Desktop client and relay sidecar in this repository; separately released mobile clients when they adopt WSS |
+| `github.com/openrung/openrung/wsscore` | `wsscore/VERSION` | `wsscore/vX.Y.Z` | Desktop client and relay sidecar in this repository; pinned Android and iOS WSS bindings |
 
 These nested-module versions identify reusable code, not a running service or
 an application release. In-repository Go modules use local replacements so

--- a/docs/wss-fallback.md
+++ b/docs/wss-fallback.md
@@ -9,7 +9,7 @@ Foundation relays that explicitly advertise it in their signed descriptor.
 There is no standalone WSS intermediary and no cross-relay router:
 
 ```text
-desktop client
+OpenRung client (desktop / Android / iOS)
   ├─ first choice ── Reality/TCP ─────────────────────► selected relay :443
   └─ fallback ────── WSS front ─► relay origin TLS :8443
                                       └─ loopback-only relay-local sidecar
@@ -66,13 +66,14 @@ Reality handshake succeeding.
 ## Shared transport implementation
 
 The nested Go module `github.com/openrung/openrung/wsscore` is the single
-reusable implementation of these data-plane mechanics. The desktop client and
-relay-local sidecar both consume it; neither maintains a second WebSocket,
-yamux, or opaque-copy implementation. The module owns the public protocol
-constants, strict production front-URL validation, binary-only WebSocket stream
-adaptation, the shared bounded yamux profile, opaque bidirectional copying,
-session/stream lifecycle controls, and an optional socket-control hook for a
-future Android caller to connect to `VpnService.protect`.
+reusable implementation of these data-plane mechanics. The desktop client,
+Android and iOS native bindings, and relay-local sidecar consume it; none
+maintains a second WebSocket, yamux, or opaque-copy implementation. The module
+owns the public protocol constants, strict production front-URL validation,
+binary-only WebSocket stream adaptation, the shared bounded yamux profile,
+opaque bidirectional copying, session/stream lifecycle controls, Android's
+`VpnService.protect` socket-control hook, and the corresponding Apple
+constructor for PacketTunnel-owned sockets.
 
 `wsscore` is intentionally authority-free. Its client is given one exact URL
 and an opaque bearer ticket by its caller, and its server-side transport is
@@ -176,7 +177,7 @@ not widen them without a new reviewed protocol version.
 ## Obtaining a ticket
 
 Ticket acquisition is control-plane HTTPS, not part of relay health probing.
-The desktop client:
+The client:
 
 1. Selects a relay using the normal signed directory and health ranking.
 2. Attempts direct Reality first.
@@ -334,26 +335,20 @@ unanalyzable after the first rotation.
 
 ## Client repository scope
 
-This repository's desktop client is the only client restored by this change.
-It consumes `wsscore` for the shared transport and `brokerapi` for the broker
-HTTP exchanges while retaining direct-first selection, local-failure
-classification, broker-front scheduling, bounded retry handling, telemetry
-lifecycle, and independent fallback health in the desktop application layer as
-described above.
+This repository owns the desktop orchestration, shared `wsscore` and
+`brokerapi` modules, broker ticket authority, and relay-local sidecar. Android
+and iOS are maintained in the separate mobile repository and implement the
+same signed-front, direct-first, ticket, lifecycle, recovery, and telemetry
+contract in their native VPN owners. Android wires `wsscore` socket protection
+to `VpnService.protect`; iOS uses the Apple constructor for PacketTunnel-owned
+sockets. Both platforms route individual ticket and broker operations through
+their pinned `brokerapi` binding.
 
-Android and iOS are developed in separate repositories. They are not updated,
-restored, or made WSS-capable by this repository change. Mobile release notes
-must continue to describe WSS fallback as unavailable until each mobile
-repository independently implements and tests the same protocol and security
-contract. The reusable module and its Android socket-control hook are adoption
-building blocks only: Android still has to wire the hook to
-`VpnService.protect`, and both platforms must add their own ticket,
-direct-first, lifecycle, and UI integration before publishing a separate
-mobile release. The reusable `brokerapi` module lets those repositories adopt
-the same SNI-concealing broker client — ECH for the Cloudflare front, SNI-less
-TLS for the CloudFront front — without reimplementing it, but its tag is also
-only an adoption building block until a mobile binding is integrated and
-released.
+The mobile repository pins reviewed module tags, rebuilds its AAR and
+XCFramework, runs platform VPN tests, and publishes its own application
+releases. A new shared-module tag therefore does not update a released mobile
+app by itself; current mobile support comes from the independently integrated
+and tested application code.
 
 ## Rollout and rollback contract
 

--- a/punchcore/README.md
+++ b/punchcore/README.md
@@ -8,8 +8,9 @@ format and mechanics, consumed by:
 - the relay hub and relay runtimes (this repository, via `internal/punch`
   and `internal/tunnel`),
 - the desktop CLI and GUI clients (this repository),
-- the Android app's gomobile binding (`android/punchbridge` in
-  `openrung-mobile-app`), which pins a tagged version of this module.
+- the Android and iOS native bindings (`android/punchbridge` plus the mobile
+  build grafts in `openrung-mobile-app`), which pin a tagged version of this
+  module.
 
 ## What belongs here
 
@@ -23,14 +24,14 @@ format and mechanics, consumed by:
 - **The hub HTTP client** (`HubClient`) and `HardenedHTTPClient`.
 - **The `Policy` presets**: `DesktopPolicy()` (historical
   `internal/punch` behavior; also what the hub and relay runtimes run) and
-  `MobilePolicy()` (the hardened Android profile). Zero-value `Policy` is not
+  `MobilePolicy()` (the hardened Android/iOS profile). Zero-value `Policy` is not
   valid; always start from a preset.
 
 ## What never belongs here
 
 - QUIC transports, sessions, or bridges — the QUIC stack differs per consumer
-  (mainline quic-go on desktop/servers, the sagernet fork on Android), so each
-  consumer keeps its own session layer on top of this module.
+  (mainline quic-go on desktop/servers and the mobile libbox integration), so
+  each consumer keeps its own session layer on top of this module.
 - Hub secret storage or rotation policy.
 - The hub's HTTP coordination *server* (`internal/tunnel`).
 - Any UI.
@@ -54,15 +55,17 @@ protocol change and must be treated as one (see `ProtoVersion`).
    the Go proxy). No manual tagging.
 4. Dependabot in the mobile repo (scoped to this module) opens the
    `android/punchbridge/go.mod` (+`go.sum`) bump PR when it sees the new tag;
-   the bump automatically busts the AAR CI caches. Manual fallback:
+   the shared pin automatically busts the Android AAR and iOS XCFramework CI
+   caches. Manual fallback:
    `go get github.com/openrung/openrung/punchcore@vX.Y.Z` in
    `android/punchbridge`.
-5. Rebuild the AAR via `android/build-libbox-release.sh` and ship.
+5. Rebuild the AAR via `android/build-libbox-release.sh` and the XCFramework via
+   `ios/build-libbox-release.sh`, run both platform VPN suites, and ship the
+   corresponding app releases.
 
-Local cross-repo development: use
-`PUNCHCORE_SRC=/path/to/openrung/punchcore android/build-libbox-release.sh`
-and/or an uncommitted `go.work`; never in releases (GPL §6 pins the module
-version).
+Local cross-repo development: use `PUNCHCORE_SRC=/path/to/openrung/punchcore`
+with either mobile platform's `build-libbox-release.sh` and/or an uncommitted
+`go.work`; never in releases (GPL §6 pins the module version).
 
 ## License
 

--- a/punchcore/policy.go
+++ b/punchcore/policy.go
@@ -5,8 +5,8 @@ import "net"
 // Policy selects between the trust profiles of the two first-party consumers.
 // DesktopPolicy preserves the historical openrung/internal/punch behavior and is
 // also what the hub and volunteers run; MobilePolicy preserves the hardened
-// behavior of the Android punchbridge. Zero values are NOT a valid policy; always
-// start from a preset.
+// behavior of the Android/iOS native bindings. Zero values are NOT a valid policy;
+// always start from a preset.
 type Policy struct {
 	// MaxPeersPerKind caps how many candidates of each kind (host, srflx) a peer
 	// may advertise before SanitizePeers stops accepting them. Desktop 8, mobile 4.
@@ -35,7 +35,7 @@ type Policy struct {
 // hub coordinator, the CLI/desktop clients, and volunteers.
 func DesktopPolicy() Policy { return Policy{MaxPeersPerKind: 8} }
 
-// MobilePolicy is the hardened Android punchbridge profile.
+// MobilePolicy is the hardened Android/iOS native-client profile.
 func MobilePolicy() Policy {
 	return Policy{MaxPeersPerKind: 4, RequireGlobalSrflx: true, SingleSrflxIP: true,
 		StrictReflectorAddrs: true, FailGatherOnCancel: true}

--- a/wsscore/README.md
+++ b/wsscore/README.md
@@ -2,10 +2,10 @@
 
 `github.com/openrung/openrung/wsscore` is OpenRung's reusable opaque
 Reality-over-WebSocket transport. It is a nested Go module and the **single
-source of truth** used by the desktop client and the relay-local sidecar in
-this repository. Android and iOS live in separate repositories and must pin,
-integrate, test, and release this module independently; adding it here does not
-restore either mobile client by itself.
+source of truth** used by the desktop client and relay-local sidecar in this
+repository and by the Android and iOS native bindings in the separate mobile
+repository. Mobile releases pin, test, and ship reviewed module versions; a
+new tag here does not update an installed app by itself.
 
 The CDN terminates the outer TLS/WebSocket connection at the destination
 relay's own sidecar. The existing Reality connection remains end to end inside
@@ -20,12 +20,14 @@ Reality key material or interprets payload bytes.
   `Client.Close`).
 - Binary-only WebSocket-to-`net.Conn` adaptation, the shared yamux profile,
   opaque bidirectional copying, and reusable idle/lifetime controls.
-- The gomobile-friendly `SocketProtector` hook. Android implementations must
-  delegate `Protect(fd int32) bool` to `VpnService.protect(fd)` so the outer CDN
-  socket does not recurse into the VPN tunnel. Protection fails closed and is
-  installed before `connect(2)`. Mobile repositories should expose their own
-  small gomobile binding wrapper around the client API; `wsscore` also exports
-  Go-native relay/test primitives and is not itself a direct gobind surface.
+- The gomobile-friendly `SocketProtector` hook. Android delegates
+  `Protect(fd int32) bool` to `VpnService.protect(fd)` so the outer CDN socket
+  does not recurse into the VPN tunnel. Protection fails closed and is
+  installed before `connect(2)`. The mobile repository exposes small Android
+  and iOS binding wrappers around the client API; iOS uses the dedicated
+  nil-protector constructor for PacketTunnel-owned sockets. `wsscore` also
+  exports Go-native relay/test primitives and is not itself a direct gobind
+  surface.
 
 ## What never belongs here
 
@@ -80,8 +82,9 @@ CNAMEs and every other CDN URL retain ordinary SNI derived from the signed
 front URL. Encrypted ClientHello configuration is rejected on the native-front
 no-SNI path so it cannot silently add a different public SNI. The deprecated
 `CloudFrontNoSNI` field remains an alias for pinned consumers. The in-repository
-desktop client enables the new option; external module consumers must opt in
-deliberately when they upgrade.
+desktop client enables `NativeFrontNoSNI`; the current Android and iOS bindings
+enable the compatibility alias and retain CloudFront no-SNI behavior until
+their next reviewed pin upgrade.
 
 `brokerapi/cloudfront_tls.go` applies the same technique to the control plane
 in a separate copy — `brokerapi` carries no dependencies, so it cannot import


### PR DESCRIPTION
## Summary
- replace stale desktop-only WSS claims with the current Android and iOS implementation
- document iOS NAT punching and shared mobile punch/WSS bindings
- update brokerapi, punchcore, wsscore, API, architecture, and versioning guidance
- preserve the distinction between shared-module tags and independently shipped mobile releases

## Validation
- `go test ./config` in `desktop`
- `go test ./...` in `punchcore`
- `git diff --check`
- repository-wide audit for the removed stale claims