### PR TITLE
C1: engine absorbs the cmd/relay-only features

### DIFF
--- a/internal/relayruntime/broker.go
+++ b/internal/relayruntime/broker.go
@@ -59,7 +59,7 @@ func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out 
 
 	requestURL := strings.TrimRight(b.BaseURL, "/") + path
 	if b.RequireSecureTransport {
-		if err := requireSecureBrokerURL(requestURL); err != nil {
+		if err := ValidateSecureBrokerURL(requestURL); err != nil {
 			return err
 		}
 	}
@@ -118,7 +118,12 @@ func (b *BrokerClient) postJSON(ctx context.Context, path string, body any, out 
 	return nil
 }
 
-func requireSecureBrokerURL(rawURL string) error {
+// ValidateSecureBrokerURL enforces the secure-transport broker policy on a
+// URL: https anywhere, plaintext http only on loopback. BrokerClient applies
+// it per request when RequireSecureTransport is set; config validators call
+// it directly so the misconfiguration fails at startup instead of on the
+// first request.
+func ValidateSecureBrokerURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("parse broker URL %q: %w", rawURL, err)

--- a/internal/relayruntime/engine/connlog_test.go
+++ b/internal/relayruntime/engine/connlog_test.go
@@ -1,0 +1,106 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe io.Writer for capturing engine/observer output.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// runConnLogSession runs a direct session with the given connection-log
+// writer, opens one client connection against the observer, and returns once
+// the engine has counted it.
+func runConnLogSession(t *testing.T, output *syncBuffer, engineLog *syncBuffer) {
+	t.Helper()
+	broker := &fakeBroker{}
+	ts := httptest.NewServer(broker.handler())
+	defer ts.Close()
+
+	cfg := Config{
+		BrokerURL:   ts.URL,
+		Mode:        ModeDirect,
+		ListenPort:  freePort(t),
+		Identity:    testIdentity,
+		DisableXray: true,
+		ConfigDir:   t.TempDir(),
+	}
+	if output != nil {
+		cfg.ConnectionLogOutput = output
+	}
+	eng := New(cfg, Events{Log: engineLog})
+	brokerClient := eng.cfg.brokerClient()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = eng.runDirectSession(ctx, brokerClient, eng.cfg, "log-relay", testIdentity, "127.0.0.1", directOnlyListenHost)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	eventually(t, 5*time.Second, "session online", func() bool {
+		return eng.Status().Phase == PhaseOnline
+	})
+
+	// One observed connection; xray is disabled, so the forward target refuses
+	// and the observer immediately reports the disconnect too.
+	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(eng.cfg.ListenPort)))
+	if err != nil {
+		t.Fatalf("dial observer: %v", err)
+	}
+	defer conn.Close()
+	eventually(t, 5*time.Second, "connection counted", func() bool {
+		return eng.Status().TotalConnections >= 1
+	})
+}
+
+func TestConnectionLogOutputReceivesObserverLines(t *testing.T) {
+	output := &syncBuffer{}
+	engineLog := &syncBuffer{}
+	runConnLogSession(t, output, engineLog)
+
+	eventually(t, 5*time.Second, "connection log lines", func() bool {
+		s := output.String()
+		return strings.Contains(s, "client connected") && strings.Contains(s, "client disconnected")
+	})
+	// The console lines are opt-in only: they carry client addresses and must
+	// not leak into the engine's UI log stream.
+	if s := engineLog.String(); strings.Contains(s, "client connected") {
+		t.Fatalf("engine log contains per-connection lines: %q", s)
+	}
+}
+
+func TestConnectionLinesStayOutOfLogsByDefault(t *testing.T) {
+	engineLog := &syncBuffer{}
+	runConnLogSession(t, nil, engineLog)
+
+	if s := engineLog.String(); strings.Contains(s, "client connected") || strings.Contains(s, "client disconnected") {
+		t.Fatalf("per-connection lines reached the engine log without opt-in: %q", s)
+	}
+}

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -100,6 +100,14 @@ type Config struct {
 	NodeClass string
 	// Label is the public relay name; generated (adjective-noun) when empty.
 	Label string
+	// PublicHost is the public hostname or IP clients can reach (cmd/relay's
+	// -public-host). Direct mode uses it verbatim; when empty, the host's
+	// first global IPv6 address is auto-detected and periodically re-checked
+	// for rotation (an explicit host is pinned, so no recheck runs). Auto
+	// mode prefers the probe-observed address, and tunnel mode's endpoint
+	// comes from the hub. A WSS relay binds xray to the IPv4 wildcard, so it
+	// should set this to the IPv4 address the directory must advertise.
+	PublicHost string
 	// XrayPath locates the xray binary. Defaults to "xray" via PATH.
 	XrayPath string
 	// ListenPort is the direct-only public/listen port and the sole automatic
@@ -147,6 +155,8 @@ type Config struct {
 	// per-connection connect/disconnect lines — which include client IPs — as
 	// cmd/relay prints to stdout. Nil (the default, and the GUI posture) keeps
 	// them out of every log; aggregate counters remain in Status either way.
+	// The engine serializes writes (one line per Write call), so the writer
+	// itself does not need to be goroutine-safe.
 	ConnectionLogOutput io.Writer
 	// Identity seeds the relay identity; missing parts are generated.
 	Identity Identity
@@ -302,19 +312,21 @@ func (c Config) effectiveConfig() (Config, error) {
 
 // brokerClient builds the broker client for this config. A foundation token is
 // the bearer and, on its own, requires secure transport (https + redirect
-// refusal), so that guarantee holds even for a config that skipped posture
-// normalization. All broker requests use only the canonical registration and
-// heartbeat routes and refuse every redirect (see relayruntime.BrokerClient).
+// refusal); the node-class check is case/space-insensitive so the guarantee
+// also holds for a config that skipped posture normalization. All broker
+// requests use only the canonical registration and heartbeat routes and
+// refuse every redirect (see relayruntime.BrokerClient).
 func (c Config) brokerClient() *relayruntime.BrokerClient {
 	token := c.Token
 	if c.FoundationToken != "" {
 		token = c.FoundationToken
 	}
+	nodeClass := strings.ToLower(strings.TrimSpace(c.NodeClass))
 	return &relayruntime.BrokerClient{
 		BaseURL:                c.BrokerURL,
 		Token:                  token,
 		HTTPClient:             c.HTTPClient,
-		RequireSecureTransport: c.FoundationToken != "" || c.NodeClass == relay.NodeClassFoundation,
+		RequireSecureTransport: c.FoundationToken != "" || nodeClass == relay.NodeClassFoundation,
 	}
 }
 
@@ -334,6 +346,15 @@ func (c Config) validate() error {
 	}
 	if c.Mode != ModeTunnel && c.BrokerURL == "" {
 		return fmt.Errorf("broker URL is required")
+	}
+	// A foundation posture refuses plaintext non-loopback brokers on every
+	// request (BrokerClient.RequireSecureTransport), so a bad URL can never
+	// succeed; rejecting it here surfaces the misconfiguration at Start
+	// instead of as an endless register-retry loop.
+	if c.Mode != ModeTunnel && (c.FoundationToken != "" || c.NodeClass == relay.NodeClassFoundation) {
+		if err := relayruntime.ValidateSecureBrokerURL(c.BrokerURL); err != nil {
+			return err
+		}
 	}
 	if c.ListenPort < 1 || c.ListenPort > 65535 {
 		return fmt.Errorf("listen port must be between 1 and 65535")
@@ -928,6 +949,13 @@ func (e *Engine) startXray(ctx context.Context, cfg Config, identity Identity, l
 // Tunnel mode renders a freshly reserved loopback binding for the same reason
 // cmd/relay does.
 func (e *Engine) RenderXrayConfig() ([]byte, error) {
+	// Refuse while running: prepareIdentity's generate-and-report flow must
+	// not race a live session's — both could mint identities for the same
+	// missing fields and the last writeback would win, splitting the persisted
+	// seed from the one the session registered with.
+	if e.Running() {
+		return nil, errors.New("cannot render the xray config while the relay is running")
+	}
 	cfg, err := e.currentConfig().effectiveConfig()
 	if err != nil {
 		return nil, err
@@ -963,6 +991,14 @@ func (e *Engine) RenderXrayConfig() ([]byte, error) {
 }
 
 func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.BrokerClient, cfg Config, label string, identity Identity, publicHost, listenHost string) error {
+	// A probe-observed address (auto mode) wins; otherwise an explicitly
+	// configured public host is used verbatim, and only as a last resort is
+	// the host's global IPv6 auto-detected.
+	usedConfiguredHost := false
+	if publicHost == "" && cfg.PublicHost != "" {
+		publicHost = cfg.PublicHost
+		usedConfiguredHost = true
+	}
 	if publicHost == "" {
 		detected, err := detectPublicIPv6()
 		if err != nil {
@@ -1000,10 +1036,12 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 	if !wss {
 		// Per-connection lines include client IPs; unless the caller opted into
 		// console connection logging (ConnectionLogOutput) they go nowhere, and
-		// the engine surfaces aggregate counters instead.
+		// the engine surfaces aggregate counters instead. The observer writes
+		// from one goroutine per connection, so the caller's writer is wrapped
+		// in a lock to honour the field's no-concurrency-requirement contract.
 		output := io.Writer(io.Discard)
 		if cfg.ConnectionLogOutput != nil {
-			output = cfg.ConnectionLogOutput
+			output = &lockedWriter{w: cfg.ConnectionLogOutput}
 		}
 		observer := &relayruntime.ConnectionObserver{
 			ListenHost: listenHost,
@@ -1117,7 +1155,13 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 	// we baseline against the same source the recheck uses, and only when it
 	// yields an address at all (no global IPv6 ⇒ nothing to watch here).
 	const ipRecheckInterval = 5 * time.Minute
-	ipBaseline, _ := detectPublicIPv6()
+	// An explicitly configured public host is pinned — rotation of the host's
+	// auto-detected IPv6 addresses is irrelevant to it — so the recheck only
+	// arms when the registered address actually came from detection.
+	ipBaseline := ""
+	if !usedConfiguredHost {
+		ipBaseline, _ = detectPublicIPv6()
+	}
 	ipRecheck := time.NewTicker(ipRecheckInterval)
 	defer ipRecheck.Stop()
 
@@ -1161,8 +1205,12 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 					continue
 				}
 				if verifyErr := verifyRegisteredDescriptor(reSigned, updated, identityKey); verifyErr != nil {
-					e.logf("re-register after expired lease failed: %v", verifyErr)
-					continue
+					// Fail closed like the initial registration: the broker-side
+					// lease now exists in a state this relay refuses to serve in
+					// (unattested class, tampered fronts), so end the session and
+					// surface the error instead of staying online mislabeled and
+					// re-registering at heartbeat cadence forever.
+					return fmt.Errorf("re-register after expired lease: %w", verifyErr)
 				}
 				desc = updated
 				e.logf("re-registered with the broker as %q (%s)", desc.Label, desc.ID)
@@ -1414,6 +1462,21 @@ func pinnedLeafVerifier(want string) func([][]byte, [][]*x509.Certificate) error
 		}
 		return nil
 	}
+}
+
+// lockedWriter serializes writes from the observer's per-connection
+// goroutines onto the caller-supplied ConnectionLogOutput, so the caller's
+// writer does not need to be goroutine-safe. Each observer line arrives as a
+// single Write call, so lines never interleave.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }
 
 // stopProcess interrupts the xray child and escalates to Kill; nil cmd (xray

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -2,7 +2,10 @@
 // Start/Stop lifecycle, status/identity callbacks, and live traffic counters
 // instead of the one-shot, signal-driven flow in cmd/relay. GUI apps (the
 // OpenRung Volunteer desktop app) bind it to their bridge layer; the orchestration
-// mirrors cmd/relay/main.go run/runTunnelMode.
+// mirrors cmd/relay/main.go run/runTunnelMode and also carries the operator
+// features that historically lived only there: foundation node-class posture,
+// per-relay WSS front registration, per-connection console logging, and
+// config-only rendering (RenderXrayConfig).
 package engine
 
 import (
@@ -22,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,6 +85,19 @@ type Config struct {
 	BrokerURL string
 	// Token optionally authenticates registration and hub attachment.
 	Token string
+	// FoundationToken is the foundation registration token. Presenting it runs
+	// this as a foundation relay: it forces foundation class and direct mode,
+	// becomes the broker bearer (over Token), and requires secure broker
+	// transport (https + redirect refusal). It is never sent to a relay hub —
+	// direct mode is the only mode that has no hub path. An explicit
+	// non-foundation NodeClass conflicts with it and fails validation.
+	FoundationToken string
+	// NodeClass declares the relay operator class: relay.NodeClassVolunteer or
+	// relay.NodeClassFoundation. Empty means unstated (the broker treats it as
+	// volunteer). Foundation requires direct mode: auto and tunnel send the
+	// registration token to the relay hub. Prefer FoundationToken, which sets
+	// this automatically.
+	NodeClass string
 	// Label is the public relay name; generated (adjective-noun) when empty.
 	Label string
 	// XrayPath locates the xray binary. Defaults to "xray" via PATH.
@@ -119,6 +136,18 @@ type Config struct {
 	MaxMbps     int
 	// HeartbeatInterval is the direct-mode broker heartbeat cadence (min 5s).
 	HeartbeatInterval time.Duration
+	// WSSFronts are per-relay CDN front descriptors advertised at registration
+	// (see relay.WSSFrontDescriptor). Foundation direct mode on port 443 with
+	// an explicit stable identity seed only; a non-foundation config with
+	// fronts fails validation rather than registering. A WSS relay's xray owns
+	// the public listener directly — no per-connection observer runs, so
+	// relay-local WSS streams produce no address or byte-count records.
+	WSSFronts []relay.WSSFrontDescriptor
+	// ConnectionLogOutput, when non-nil, receives the observer's colored
+	// per-connection connect/disconnect lines — which include client IPs — as
+	// cmd/relay prints to stdout. Nil (the default, and the GUI posture) keeps
+	// them out of every log; aggregate counters remain in Status either way.
+	ConnectionLogOutput io.Writer
 	// Identity seeds the relay identity; missing parts are generated.
 	Identity Identity
 	// ConfigDir is where the generated xray config (which contains the Reality
@@ -137,6 +166,9 @@ type Config struct {
 func (c Config) withDefaults() Config {
 	if c.AutomaticPortCandidates != nil {
 		c.AutomaticPortCandidates = append([]int(nil), c.AutomaticPortCandidates...)
+	}
+	if c.WSSFronts != nil {
+		c.WSSFronts = append([]relay.WSSFrontDescriptor(nil), c.WSSFronts...)
 	}
 	if c.Mode == "" {
 		c.Mode = ModeAuto
@@ -171,7 +203,127 @@ func (c Config) withDefaults() Config {
 	return c
 }
 
+// applyFoundationTokenPosture makes a foundation token a self-contained relay
+// posture, mirroring cmd/relay: presenting it forces foundation class and
+// direct mode (the bearer choice and secure-transport requirement follow from
+// the token in brokerClient). An explicit non-foundation node class is a
+// contradiction and rejected; a non-direct mode is overridden to direct, the
+// only mode that never routes anything through a hub.
+func applyFoundationTokenPosture(c *Config) error {
+	if c.FoundationToken == "" {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(c.NodeClass)) {
+	case "", relay.NodeClassFoundation:
+	default:
+		return fmt.Errorf("node class %q conflicts with a foundation token, which already forces foundation class", c.NodeClass)
+	}
+	c.NodeClass = relay.NodeClassFoundation
+	c.Mode = ModeDirect
+	return nil
+}
+
+// resolvesToDirect reports whether cfg can only ever serve directly. Auto mode
+// without a hub never probes and always degrades to direct in runSession, so
+// it counts; auto with a hub does not, because the probe path exists.
+func (c Config) resolvesToDirect() bool {
+	return c.Mode == ModeDirect || (c.Mode == ModeAuto && c.HubAddr == "")
+}
+
+// requireDirectModeForFoundation prevents a foundation-class relay from ever
+// entering the hub-based auto/tunnel paths. Auto probing sends the
+// registration token to the hub before it chooses a mode, so even an
+// eventually-direct result is not safe for a foundation posture.
+func requireDirectModeForFoundation(c Config) error {
+	if c.NodeClass == relay.NodeClassFoundation && !c.resolvesToDirect() {
+		return errors.New("node class foundation requires direct mode: auto and tunnel send the registration token to the relay hub; use direct mode against a TLS broker, or set FoundationToken, which forces direct mode")
+	}
+	return nil
+}
+
+// validateWSSFronts enforces the WSS registration posture on a config whose
+// fronts and node class are already normalized. It mirrors cmd/relay's
+// validateWSSRelayConfig, minus the listen-host cases: the engine owns its
+// listen host and pins a WSS relay's xray to the IPv4 wildcard itself.
+func (c Config) validateWSSFronts() error {
+	if len(c.WSSFronts) == 0 {
+		return nil
+	}
+	if c.NodeClass != relay.NodeClassFoundation {
+		return errors.New("WSS fronts require node class foundation")
+	}
+	if !c.resolvesToDirect() {
+		return errors.New("WSS fronts require direct mode")
+	}
+	if c.ListenPort != 443 {
+		return errors.New("WSS fronts require listen port 443 so the sidecar can reach only its local Reality listener")
+	}
+	if c.ConnectionLogOutput != nil {
+		return errors.New("WSS fronts require connection logging disabled so relay-local WSS streams produce no per-connection address or byte-count records")
+	}
+	if strings.TrimSpace(c.Identity.IdentitySeed) == "" {
+		return errors.New("WSS fronts require an explicit stable identity seed")
+	}
+	if _, err := relay.ParseIdentitySeed(c.Identity.IdentitySeed); err != nil {
+		return errors.New("WSS fronts require a valid base64 32-byte stable identity seed")
+	}
+	return nil
+}
+
+// effectiveConfig applies the foundation-token posture and normalizes the node
+// class and WSS fronts. validate and every session start from its result, so
+// the posture and the foundation/WSS guards hold on the runtime path too, not
+// just at Start. An empty node class deliberately stays empty (unstated) so
+// the registration wire request is unchanged for existing callers.
+func (c Config) effectiveConfig() (Config, error) {
+	if err := applyFoundationTokenPosture(&c); err != nil {
+		return Config{}, err
+	}
+	if strings.TrimSpace(c.NodeClass) != "" {
+		nodeClass, err := relay.NormalizeNodeClass(c.NodeClass)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid node class: %w", err)
+		}
+		c.NodeClass = nodeClass
+	}
+	fronts, err := relay.NormalizeWSSFronts(c.WSSFronts)
+	if err != nil {
+		return Config{}, fmt.Errorf("invalid WSS fronts: %w", err)
+	}
+	c.WSSFronts = fronts
+	if err := requireDirectModeForFoundation(c); err != nil {
+		return Config{}, err
+	}
+	if err := c.validateWSSFronts(); err != nil {
+		return Config{}, err
+	}
+	return c, nil
+}
+
+// brokerClient builds the broker client for this config. A foundation token is
+// the bearer and, on its own, requires secure transport (https + redirect
+// refusal), so that guarantee holds even for a config that skipped posture
+// normalization. All broker requests use only the canonical registration and
+// heartbeat routes and refuse every redirect (see relayruntime.BrokerClient).
+func (c Config) brokerClient() *relayruntime.BrokerClient {
+	token := c.Token
+	if c.FoundationToken != "" {
+		token = c.FoundationToken
+	}
+	return &relayruntime.BrokerClient{
+		BaseURL:                c.BrokerURL,
+		Token:                  token,
+		HTTPClient:             c.HTTPClient,
+		RequireSecureTransport: c.FoundationToken != "" || c.NodeClass == relay.NodeClassFoundation,
+	}
+}
+
 func (c Config) validate() error {
+	effective, err := c.effectiveConfig()
+	if err != nil {
+		return err
+	}
+	c = effective
 	switch c.Mode {
 	case ModeAuto, ModeDirect, ModeTunnel:
 	default:
@@ -404,11 +556,13 @@ func (e *Engine) run(ctx context.Context, done chan struct{}) {
 
 	const backoffMin, backoffMax = 2 * time.Second, time.Minute
 	brokerConfig := e.currentConfig()
-	broker := &relayruntime.BrokerClient{
-		BaseURL:    brokerConfig.BrokerURL,
-		Token:      brokerConfig.Token,
-		HTTPClient: brokerConfig.HTTPClient,
+	if effective, err := brokerConfig.effectiveConfig(); err == nil {
+		// Start already validated this exact config, so the error path is
+		// unreachable; falling back to the raw config would still keep the
+		// foundation bearer/transport guarantees (they key off FoundationToken).
+		brokerConfig = effective
 	}
+	broker := brokerConfig.brokerClient()
 	backoff := backoffMin
 	for {
 		sessionStart := time.Now()
@@ -485,6 +639,11 @@ const (
 	// Direct-only mode did not run a nonce probe. Preserve its historical
 	// explicit dual-family listener semantics.
 	directOnlyListenHost = "::"
+	// wssDirectListenHost pins a WSS relay's xray listener to the IPv4
+	// wildcard: the colocated sidecar reaches only 127.0.0.1:443, and because
+	// WSS bypasses the per-connection observer, xray must own the public
+	// listener itself (mirrors cmd/relay's applyWSSFronts default).
+	wssDirectListenHost = "0.0.0.0"
 )
 
 // automaticPortCandidates returns auto mode's effective ordered list. An empty
@@ -577,7 +736,14 @@ func (e *Engine) watchForModeChange(ctx context.Context, cfg Config, current str
 }
 
 func (e *Engine) runSession(ctx context.Context, broker *relayruntime.BrokerClient) error {
-	cfg := e.currentConfig()
+	// Re-derive the effective config here as well as in Start's validation:
+	// the guard that keeps a foundation posture out of the hub paths (and WSS
+	// fronts away from non-foundation registrations) must hold on the runtime
+	// path, before autoResolve can transmit anything to a hub.
+	cfg, err := e.currentConfig().effectiveConfig()
+	if err != nil {
+		return err
+	}
 
 	e.setStatus(func() {
 		e.phase = PhaseStarting
@@ -752,6 +918,50 @@ func (e *Engine) startXray(ctx context.Context, cfg Config, identity Identity, l
 	return cmd, waitCh, nil
 }
 
+// RenderXrayConfig builds and returns the xray config JSON without starting
+// anything — the engine form of cmd/relay's -print-config-only. Missing
+// identity parts are generated (and reported through OnIdentity) exactly as a
+// real session would, so the rendered config matches a subsequent Start. Like
+// cmd/relay, it renders the canonical direct-form binding: a live direct
+// session actually rebinds xray to a reserved loopback port behind the
+// observer, which is resolved at runtime and not knowable at render time.
+// Tunnel mode renders a freshly reserved loopback binding for the same reason
+// cmd/relay does.
+func (e *Engine) RenderXrayConfig() ([]byte, error) {
+	cfg, err := e.currentConfig().effectiveConfig()
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	identity, err := e.prepareIdentity(cfg)
+	if err != nil {
+		return nil, err
+	}
+	listenHost, listenPort := directOnlyListenHost, cfg.ListenPort
+	switch {
+	case cfg.Mode == ModeTunnel:
+		host, port, err := relayruntime.ReserveLoopbackTCPPort()
+		if err != nil {
+			return nil, err
+		}
+		listenHost, listenPort = host, port
+	case len(cfg.WSSFronts) > 0:
+		listenHost = wssDirectListenHost
+	}
+	return relayruntime.BuildXrayConfig(relayruntime.XrayConfigInput{
+		ListenHost:        listenHost,
+		ListenPort:        listenPort,
+		ClientID:          identity.ClientID,
+		Flow:              relay.FlowVision,
+		Dest:              cfg.RealityDest,
+		ServerName:        cfg.ServerName,
+		RealityPrivateKey: identity.RealityPrivateKey,
+		ShortID:           identity.ShortID,
+	})
+}
+
 func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.BrokerClient, cfg Config, label string, identity Identity, publicHost, listenHost string) error {
 	if publicHost == "" {
 		detected, err := detectPublicIPv6()
@@ -761,52 +971,81 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 		publicHost = detected
 	}
 
-	// The observer owns the public port and forwards to xray on loopback; it is
-	// also the traffic-counter source.
-	targetHost, targetPort, err := relayruntime.ReserveLoopbackTCPPort()
-	if err != nil {
-		return err
+	wss := len(cfg.WSSFronts) > 0
+	var xrayListenHost string
+	var xrayListenPort int
+	if wss {
+		// WSS relays bypass the per-connection observer entirely (mirroring
+		// cmd/relay): opaque fallback streams must never create address or
+		// byte-count records, so xray owns the public listener directly and the
+		// engine's per-connection counters stay at zero.
+		xrayListenHost, xrayListenPort = wssDirectListenHost, cfg.ListenPort
+	} else {
+		// The observer owns the public port and forwards to xray on loopback; it
+		// is also the traffic-counter source.
+		targetHost, targetPort, err := relayruntime.ReserveLoopbackTCPPort()
+		if err != nil {
+			return err
+		}
+		xrayListenHost, xrayListenPort = targetHost, targetPort
 	}
 
-	xrayCmd, xrayErr, err := e.startXray(ctx, cfg, identity, targetHost, targetPort)
+	xrayCmd, xrayErr, err := e.startXray(ctx, cfg, identity, xrayListenHost, xrayListenPort)
 	if err != nil {
 		return err
 	}
 	defer stopProcess(xrayCmd, xrayErr)
 
-	observer := &relayruntime.ConnectionObserver{
-		ListenHost: listenHost,
-		ListenPort: cfg.ListenPort,
-		TargetHost: targetHost,
-		TargetPort: targetPort,
-		// Per-connection lines include client IPs; the engine keeps them out of
-		// the UI log and surfaces aggregate counters instead.
-		Output: io.Discard,
-		Events: &relayruntime.ConnectionEvents{
-			Opened: func(uint64, string) {
-				e.active.Add(1)
-				e.total.Add(1)
+	var observerErr <-chan error
+	if !wss {
+		// Per-connection lines include client IPs; unless the caller opted into
+		// console connection logging (ConnectionLogOutput) they go nowhere, and
+		// the engine surfaces aggregate counters instead.
+		output := io.Writer(io.Discard)
+		if cfg.ConnectionLogOutput != nil {
+			output = cfg.ConnectionLogOutput
+		}
+		observer := &relayruntime.ConnectionObserver{
+			ListenHost: listenHost,
+			ListenPort: cfg.ListenPort,
+			TargetHost: xrayListenHost,
+			TargetPort: xrayListenPort,
+			Output:     output,
+			Events: &relayruntime.ConnectionEvents{
+				Opened: func(uint64, string) {
+					e.active.Add(1)
+					e.total.Add(1)
+				},
+				Closed: func(_ uint64, _ string, _ time.Duration, fromClient, toClient int64) {
+					e.active.Add(-1)
+					e.bytesFrom.Add(uint64(fromClient))
+					e.bytesTo.Add(uint64(toClient))
+				},
 			},
-			Closed: func(_ uint64, _ string, _ time.Duration, fromClient, toClient int64) {
-				e.active.Add(-1)
-				e.bytesFrom.Add(uint64(fromClient))
-				e.bytesTo.Add(uint64(toClient))
-			},
-		},
+		}
+		observerCtx, cancelObserver := context.WithCancel(ctx)
+		defer cancelObserver()
+		observerErr, err = observer.Start(observerCtx)
+		if err != nil {
+			return fmt.Errorf("listen on port %d: %w", cfg.ListenPort, err)
+		}
+		e.logf("listening for direct connections on TCP %d", cfg.ListenPort)
 	}
-	observerCtx, cancelObserver := context.WithCancel(ctx)
-	defer cancelObserver()
-	observerErr, err := observer.Start(observerCtx)
-	if err != nil {
-		return fmt.Errorf("listen on port %d: %w", cfg.ListenPort, err)
-	}
-	e.logf("listening for direct connections on TCP %d", cfg.ListenPort)
 
 	e.setStatus(func() { e.phase = PhaseRegistering })
 
 	identityKey, err := identity.identityKey()
 	if err != nil {
 		return err
+	}
+	if wss {
+		// The broker derives the relay ID the colocated sidecar is pinned to
+		// from the identity seed, so a WSS registration must use exactly the
+		// explicit stable seed — never a healed or regenerated identity.
+		configured, seedErr := relay.ParseIdentitySeed(cfg.Identity.IdentitySeed)
+		if seedErr != nil || !configured.Equal(identityKey) {
+			return errors.New("prepared WSS relay identity does not match the explicit stable identity seed")
+		}
 	}
 	req := relay.RegisterRequest{
 		PublicHost:       publicHost,
@@ -822,18 +1061,37 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 		MaxMbps:          cfg.MaxMbps,
 		RelayVersion:     cfg.Version,
 		Label:            label,
+		NodeClass:        cfg.NodeClass,
+		WSSFronts:        slices.Clone(cfg.WSSFronts),
 	}
 	// Every register call — initial and after an expired lease — signs a fresh
 	// proof over the final request fields, so the proof never ages out within
-	// a session.
-	signedReq := func() relay.RegisterRequest {
+	// a session. A WSS registration additionally signs the capability proof
+	// with the same expiry, binding the exact front list to this identity.
+	signedReq := func() (relay.RegisterRequest, error) {
 		signed := req
+		expiresAt := time.Now().Add(relay.IdentityProofTTLDirect)
 		signed.IdentityPublicKey, signed.IdentityProof, signed.IdentityExpiresAt =
-			relay.SignIdentity(identityKey, signed, time.Now().Add(relay.IdentityProofTTLDirect))
-		return signed
+			relay.SignIdentity(identityKey, signed, expiresAt)
+		if len(signed.WSSFronts) > 0 {
+			var signErr error
+			signed.WSSCapabilityProof, signed.WSSCapabilityExpiresAt, signErr =
+				relay.SignWSSCapability(identityKey, signed, expiresAt)
+			if signErr != nil {
+				return relay.RegisterRequest{}, fmt.Errorf("sign WSS capability: %w", signErr)
+			}
+		}
+		return signed, nil
 	}
-	desc, err := registerWithRetry(ctx, broker, signedReq())
+	signed, err := signedReq()
 	if err != nil {
+		return err
+	}
+	desc, err := registerWithRetry(ctx, broker, signed)
+	if err != nil {
+		return err
+	}
+	if err := verifyRegisteredDescriptor(signed, desc, identityKey); err != nil {
 		return err
 	}
 	e.logf("registered with the broker as %q (%s) at %s", desc.Label, desc.ID,
@@ -892,9 +1150,18 @@ func (e *Engine) runDirectSession(ctx context.Context, broker *relayruntime.Brok
 					e.logf("heartbeat failed: %v", err)
 					continue
 				}
-				updated, regErr := broker.Register(ctx, signedReq())
+				reSigned, signErr := signedReq()
+				if signErr != nil {
+					e.logf("re-register after expired lease failed: %v", signErr)
+					continue
+				}
+				updated, regErr := broker.Register(ctx, reSigned)
 				if regErr != nil {
 					e.logf("re-register after expired lease failed: %v", regErr)
+					continue
+				}
+				if verifyErr := verifyRegisteredDescriptor(reSigned, updated, identityKey); verifyErr != nil {
+					e.logf("re-register after expired lease failed: %v", verifyErr)
 					continue
 				}
 				desc = updated
@@ -935,6 +1202,28 @@ func registerWithRetry(ctx context.Context, broker *relayruntime.BrokerClient, r
 		backoff *= 2
 	}
 	return relay.Descriptor{}, fmt.Errorf("register with broker: %w", lastErr)
+}
+
+// verifyRegisteredDescriptor applies cmd/relay's fail-closed checks to a
+// successful registration response, for the initial registration and every
+// re-registration after an expired lease alike.
+func verifyRegisteredDescriptor(req relay.RegisterRequest, desc relay.Descriptor, identityKey ed25519.PrivateKey) error {
+	// A broker that predates node_class drops the field and answers 201 with
+	// no class attested; without this check the relay would silently serve
+	// mislabeled as a volunteer-class relay.
+	if req.NodeClass == relay.NodeClassFoundation && desc.NodeClass != relay.NodeClassFoundation {
+		return fmt.Errorf("broker attested node_class %q instead of %q: the broker likely predates node_class support; upgrade it, or drop the foundation class to serve as a volunteer-class relay", desc.NodeClass, relay.NodeClassFoundation)
+	}
+	if !slices.Equal(desc.WSSFronts, req.WSSFronts) {
+		return errors.New("broker did not echo the exact signed per-relay WSS fronts; refusing to start WSS advertisement")
+	}
+	if len(req.WSSFronts) > 0 {
+		expectedRelayID := relay.DeriveRelayID(identityKey.Public().(ed25519.PublicKey))
+		if desc.ID != expectedRelayID {
+			return errors.New("broker returned a relay ID that does not match the stable WSS relay identity")
+		}
+	}
+	return nil
 }
 
 func (e *Engine) runTunnelSession(ctx context.Context, cfg Config, label string, identity Identity) error {

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -419,6 +419,13 @@ type Engine struct {
 	cfg    Config
 	events Events
 
+	// identityMu serializes prepareIdentity end-to-end. Generation cannot run
+	// under mu (Reality keys shell out to xray, and OnIdentity is a caller
+	// callback), so without this lock two concurrent callers — renders, or a
+	// render racing a starting session — could each generate a different
+	// identity for the same missing fields and the last writeback would win.
+	identityMu sync.Mutex
+
 	cancel context.CancelFunc
 	done   chan struct{}
 
@@ -826,9 +833,18 @@ func (e *Engine) currentConfig() Config {
 
 // prepareIdentity fills any missing identity parts (generating Reality keys via
 // `xray x25519`), reports the result once, and caches it back into the config
-// so later sessions reuse it even if the caller does not persist it.
+// so later sessions reuse it even if the caller does not persist it. The whole
+// flow is serialized (identityMu) and always starts from the freshest stored
+// identity rather than the caller's config snapshot, so concurrent callers
+// converge on one identity: the first to arrive generates, everyone after
+// reads what it cached. cfg contributes only XrayPath.
 func (e *Engine) prepareIdentity(cfg Config) (Identity, error) {
-	id := cfg.Identity
+	e.identityMu.Lock()
+	defer e.identityMu.Unlock()
+
+	e.mu.Lock()
+	id := e.cfg.Identity
+	e.mu.Unlock()
 	generated := false
 
 	if id.ClientID == "" {
@@ -949,10 +965,11 @@ func (e *Engine) startXray(ctx context.Context, cfg Config, identity Identity, l
 // Tunnel mode renders a freshly reserved loopback binding for the same reason
 // cmd/relay does.
 func (e *Engine) RenderXrayConfig() ([]byte, error) {
-	// Refuse while running: prepareIdentity's generate-and-report flow must
-	// not race a live session's — both could mint identities for the same
-	// missing fields and the last writeback would win, splitting the persisted
-	// seed from the one the session registered with.
+	// Refuse while running. Identity forking is prevented structurally by
+	// prepareIdentity's serialization, but a live direct session binds xray to
+	// a runtime-reserved loopback port, so a mid-session render would describe
+	// a binding the running relay does not use; refusing keeps the method's
+	// "matches a subsequent Start" promise unambiguous.
 	if e.Running() {
 		return nil, errors.New("cannot render the xray config while the relay is running")
 	}

--- a/internal/relayruntime/engine/engine.go
+++ b/internal/relayruntime/engine/engine.go
@@ -419,11 +419,15 @@ type Engine struct {
 	cfg    Config
 	events Events
 
-	// identityMu serializes prepareIdentity end-to-end. Generation cannot run
-	// under mu (Reality keys shell out to xray, and OnIdentity is a caller
-	// callback), so without this lock two concurrent callers — renders, or a
-	// render racing a starting session — could each generate a different
-	// identity for the same missing fields and the last writeback would win.
+	// identityMu serializes prepareIdentity end-to-end, and UpdateConfig with
+	// it. Generation cannot run under mu (Reality keys shell out to xray, and
+	// OnIdentity is a caller callback), so without this lock two concurrent
+	// callers — renders, or a render racing a starting session — could each
+	// generate a different identity for the same missing fields, and a
+	// preparation in flight across an UpdateConfig would write its stale
+	// result over the just-installed configuration. Lock order: identityMu
+	// before mu; Events callbacks run with identityMu held and so must not
+	// call UpdateConfig.
 	identityMu sync.Mutex
 
 	cancel context.CancelFunc
@@ -506,8 +510,14 @@ func (e *Engine) Running() bool {
 }
 
 // UpdateConfig replaces the engine configuration. It only applies while
-// stopped; calling it on a running engine returns an error.
+// stopped; calling it on a running engine returns an error. It waits for any
+// in-flight identity preparation (a concurrent RenderXrayConfig generating
+// keys) to finish first, so the installed configuration always wins: without
+// that, the preparation's writeback would overwrite the new identity with one
+// generated from the replaced config.
 func (e *Engine) UpdateConfig(cfg Config) error {
+	e.identityMu.Lock()
+	defer e.identityMu.Unlock()
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.cancel != nil {

--- a/internal/relayruntime/engine/engine_test.go
+++ b/internal/relayruntime/engine/engine_test.go
@@ -178,6 +178,40 @@ func TestDirectSessionRegistersAndRecovers(t *testing.T) {
 	}
 }
 
+// An explicitly configured public host is registered verbatim, with no
+// dependency on (or rotation recheck of) the host's auto-detected IPv6.
+func TestDirectSessionUsesConfiguredPublicHost(t *testing.T) {
+	stubIPv6(t, "", fmt.Errorf("no global IPv6 on this host"))
+
+	broker := &fakeBroker{}
+	ts := httptest.NewServer(broker.handler())
+	defer ts.Close()
+
+	eng := New(Config{
+		BrokerURL:   ts.URL,
+		Mode:        ModeDirect,
+		PublicHost:  "203.0.113.7",
+		Label:       "pinned-host-relay",
+		ListenPort:  freePort(t),
+		Identity:    testIdentity,
+		DisableXray: true,
+		ConfigDir:   t.TempDir(),
+	}, Events{})
+	if err := eng.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer eng.Stop()
+
+	eventually(t, 5*time.Second, "pinned-host relay online", func() bool {
+		s := eng.Status()
+		return s.Phase == PhaseOnline && s.PublicHost == "203.0.113.7"
+	})
+	_, _, last := broker.stats()
+	if last.PublicHost != "203.0.113.7" {
+		t.Fatalf("registered public host = %q, want the configured 203.0.113.7", last.PublicHost)
+	}
+}
+
 func TestEngineLifecycleStartStop(t *testing.T) {
 	broker := &fakeBroker{}
 	ts := httptest.NewServer(broker.handler())

--- a/internal/relayruntime/engine/engine_test.go
+++ b/internal/relayruntime/engine/engine_test.go
@@ -365,11 +365,13 @@ func TestPrepareIdentityBackfillsSeed(t *testing.T) {
 
 	// A corrupt persisted seed regenerates (a GUI volunteer cannot hand-reset
 	// identity.json) and reports the fresh identity for persistence, rather
-	// than bricking the app.
+	// than bricking the app. prepareIdentity reads the stored identity, so
+	// corrupt the engine's copy, as loading a mangled identity.json would.
 	persisted = nil
-	corrupt := eng.cfg
-	corrupt.Identity.IdentitySeed = "!!!not-base64!!!"
-	healed, err := eng.prepareIdentity(corrupt)
+	eng.mu.Lock()
+	eng.cfg.Identity.IdentitySeed = "!!!not-base64!!!"
+	eng.mu.Unlock()
+	healed, err := eng.prepareIdentity(eng.currentConfig())
 	if err != nil {
 		t.Fatalf("corrupt seed must regenerate, not fail: %v", err)
 	}

--- a/internal/relayruntime/engine/foundation_test.go
+++ b/internal/relayruntime/engine/foundation_test.go
@@ -1,0 +1,313 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// A foundation token is a self-contained posture: it forces foundation class
+// and direct mode even when a configured hub would otherwise resolve to auto,
+// so the credential can never enter a hub path.
+func TestFoundationTokenPostureForcesFoundationDirect(t *testing.T) {
+	cfg := Config{
+		FoundationToken: "fnd-secret",
+		BrokerURL:       "https://broker.test",
+		Mode:            ModeAuto,
+		HubAddr:         "hub.example:9443",
+	}.withDefaults()
+	effective, err := cfg.effectiveConfig()
+	if err != nil {
+		t.Fatalf("effectiveConfig: %v", err)
+	}
+	if effective.NodeClass != relay.NodeClassFoundation || effective.Mode != ModeDirect {
+		t.Fatalf("posture = %q/%q, want foundation/direct", effective.NodeClass, effective.Mode)
+	}
+
+	// An unnormalized foundation spelling is accepted and normalized.
+	spelled := cfg
+	spelled.NodeClass = " Foundation "
+	effective, err = spelled.effectiveConfig()
+	if err != nil {
+		t.Fatalf("effectiveConfig with spelled class: %v", err)
+	}
+	if effective.NodeClass != relay.NodeClassFoundation {
+		t.Fatalf("node class = %q, want normalized foundation", effective.NodeClass)
+	}
+
+	// An explicit non-foundation class is a contradiction, not an override.
+	conflicted := cfg
+	conflicted.NodeClass = relay.NodeClassVolunteer
+	if _, err := conflicted.effectiveConfig(); err == nil {
+		t.Fatal("effectiveConfig() error = nil, want a node-class conflict error")
+	}
+}
+
+func TestValidateFoundationRequiresDirectMode(t *testing.T) {
+	base := Config{
+		BrokerURL: "https://broker.openrung.org",
+		NodeClass: relay.NodeClassFoundation,
+		HubAddr:   "hub.example:9443",
+	}
+
+	for _, mode := range []string{ModeAuto, ModeTunnel} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := base
+			cfg.Mode = mode
+			err := cfg.withDefaults().validate()
+			if err == nil {
+				t.Fatalf("validate() error = nil, want foundation %s rejection", mode)
+			}
+			if !strings.Contains(err.Error(), "requires direct mode") {
+				t.Fatalf("validate() error = %v, want direct-mode explanation", err)
+			}
+		})
+	}
+
+	direct := base
+	direct.Mode = ModeDirect
+	if err := direct.withDefaults().validate(); err != nil {
+		t.Fatalf("validate() rejected foundation direct mode: %v", err)
+	}
+
+	// Auto without a hub never probes and always degrades to direct, so it is
+	// safe for a foundation posture (mirrors cmd/relay's hubless direct default).
+	hubless := base
+	hubless.Mode = ModeAuto
+	hubless.HubAddr = ""
+	if err := hubless.withDefaults().validate(); err != nil {
+		t.Fatalf("validate() rejected foundation auto-without-hub: %v", err)
+	}
+}
+
+func TestFoundationTokenIsBearerAndForcesSecureTransport(t *testing.T) {
+	cfg := Config{FoundationToken: "fnd-secret", Token: "vol-token", BrokerURL: "https://broker.test"}
+	bc := cfg.brokerClient()
+	if bc.Token != "fnd-secret" {
+		t.Fatalf("bearer = %q, want the foundation token (not the volunteer token)", bc.Token)
+	}
+	if !bc.RequireSecureTransport {
+		t.Fatal("RequireSecureTransport = false, want true for a foundation token")
+	}
+
+	classOnly := Config{NodeClass: relay.NodeClassFoundation, Token: "vol-token", BrokerURL: "https://broker.test"}
+	if bc := classOnly.brokerClient(); !bc.RequireSecureTransport || bc.Token != "vol-token" {
+		t.Fatalf("class-only client = token %q secure %t, want vol-token/true", bc.Token, bc.RequireSecureTransport)
+	}
+
+	volunteer := Config{Token: "vol-token", BrokerURL: "http://broker.test"}
+	if bc := volunteer.brokerClient(); bc.RequireSecureTransport {
+		t.Fatal("RequireSecureTransport = true for a volunteer config, want false")
+	}
+}
+
+// The foundation bearer must never travel over cleartext to a non-loopback
+// broker: both registration and heartbeat are refused before any request is
+// sent.
+func TestFoundationRefusesPlaintextBroker(t *testing.T) {
+	var sent atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sent.Add(1)
+		return jsonResponse(http.StatusCreated, `{"id":"relay_x","node_class":"foundation"}`), nil
+	})}
+	cfg := Config{FoundationToken: "fnd-secret", BrokerURL: "http://broker.test", HTTPClient: client}
+	broker := cfg.brokerClient()
+	if _, err := broker.Register(context.Background(), relay.RegisterRequest{}); err == nil {
+		t.Fatal("Register() error = nil, want a cleartext-broker refusal")
+	}
+	if err := broker.Heartbeat(context.Background(), "relay_x", ""); err == nil {
+		t.Fatal("Heartbeat() error = nil, want a cleartext-broker refusal")
+	}
+	if sent.Load() != 0 {
+		t.Fatalf("broker requests sent = %d, want 0 (must refuse before sending the token)", sent.Load())
+	}
+}
+
+// The broker client the engine builds must use only the canonical
+// registration/heartbeat routes and refuse every redirect, so the bearer can
+// never be forwarded to another location.
+func TestEngineBrokerUsesCanonicalRoutesAndRefusesRedirects(t *testing.T) {
+	var redirected atomic.Int32
+	var mu sync.Mutex
+	var paths []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path == "/redirect-target" {
+			redirected.Add(1)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/redirect-target", http.StatusTemporaryRedirect)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cfg := Config{BrokerURL: ts.URL, Token: "tok"}
+	broker := cfg.brokerClient()
+	if _, err := broker.Register(context.Background(), relay.RegisterRequest{}); err == nil || !strings.Contains(err.Error(), "refused redirect") {
+		t.Fatalf("Register() error = %v, want a refused-redirect error", err)
+	}
+	if err := broker.Heartbeat(context.Background(), "relay_1", "lease"); err == nil || !strings.Contains(err.Error(), "refused redirect") {
+		t.Fatalf("Heartbeat() error = %v, want a refused-redirect error", err)
+	}
+	if redirected.Load() != 0 {
+		t.Fatalf("redirect target hits = %d, want 0", redirected.Load())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"/api/v1/relays/register", "/api/v1/relays/relay_1/heartbeat"}
+	if len(paths) != len(want) || paths[0] != want[0] || paths[1] != want[1] {
+		t.Fatalf("request paths = %v, want exactly the canonical routes %v", paths, want)
+	}
+}
+
+// The full-session invariant: a foundation-token engine configured with a hub
+// and auto mode must register directly, present the foundation bearer, claim
+// foundation class, and never send a single request to the hub.
+func TestFoundationTokenSessionRegistersDirectWithoutTouchingHub(t *testing.T) {
+	stubIPv6(t, "2001:db8::1", nil)
+
+	var hubRequests atomic.Int32
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hubRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hub.Close()
+
+	var gotAuth atomic.Value
+	var gotClass atomic.Value
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/relays/register" {
+			_, _ = w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		gotAuth.Store(r.Header.Get("Authorization"))
+		var req relay.RegisterRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotClass.Store(req.NodeClass)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(relay.RegisterResponse{Descriptor: relay.Descriptor{
+			ID:         "relay_fnd",
+			NodeClass:  relay.NodeClassFoundation,
+			PublicHost: req.PublicHost,
+			PublicPort: req.PublicPort,
+		}})
+	}))
+	defer broker.Close()
+
+	eng := New(Config{
+		BrokerURL:       broker.URL, // loopback http is allowed under the secure-transport policy
+		FoundationToken: "fnd-secret",
+		Mode:            ModeAuto,
+		HubAddr:         "hub.example:9443",
+		HubHTTPURL:      hub.URL,
+		Label:           "fnd-relay",
+		ListenPort:      freePort(t),
+		Identity:        testIdentity,
+		DisableXray:     true,
+		ConfigDir:       t.TempDir(),
+	}, Events{})
+	if err := eng.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer eng.Stop()
+
+	eventually(t, 5*time.Second, "foundation relay online", func() bool {
+		s := eng.Status()
+		return s.Phase == PhaseOnline && s.Transport == relay.TransportDirect && s.RelayID == "relay_fnd"
+	})
+	if got := hubRequests.Load(); got != 0 {
+		t.Fatalf("hub requests = %d, want 0 (foundation posture must never touch the hub)", got)
+	}
+	if auth, _ := gotAuth.Load().(string); auth != "Bearer fnd-secret" {
+		t.Fatalf("Authorization = %q, want the foundation token as bearer", auth)
+	}
+	if class, _ := gotClass.Load().(string); class != relay.NodeClassFoundation {
+		t.Fatalf("registered node_class = %q, want foundation", class)
+	}
+}
+
+// The runtime path has its own guard: even a session whose config bypassed
+// Start-time validation is rejected before the probe can send anything to the
+// hub.
+func TestRunSessionRejectsFoundationAutoBeforeProbe(t *testing.T) {
+	var hubRequests atomic.Int32
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hubRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hub.Close()
+
+	eng := New(Config{
+		BrokerURL:  "https://broker.test",
+		NodeClass:  " Foundation ",
+		Mode:       ModeAuto,
+		HubAddr:    "hub.example:9443",
+		HubHTTPURL: hub.URL,
+		Token:      "foundation-secret",
+		Identity:   testIdentity,
+	}, Events{})
+	err := eng.runSession(context.Background(), eng.cfg.brokerClient())
+	if err == nil {
+		t.Fatal("runSession() error = nil, want foundation auto-mode rejection")
+	}
+	if hubRequests.Load() != 0 {
+		t.Fatalf("hub requests = %d, want 0", hubRequests.Load())
+	}
+}
+
+// A broker that predates node_class silently drops the field; a foundation
+// relay must refuse to serve mislabeled rather than run as volunteer-class.
+func TestDirectSessionRejectsUnattestedFoundationClass(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"relay_new","public_host":"relay.example","public_port":443}`))
+	}))
+	defer broker.Close()
+
+	raw := Config{
+		BrokerURL:   broker.URL,
+		NodeClass:   relay.NodeClassFoundation,
+		Mode:        ModeDirect,
+		ListenPort:  freePort(t),
+		Identity:    testIdentity,
+		DisableXray: true,
+		ConfigDir:   t.TempDir(),
+	}.withDefaults()
+	cfg, err := raw.effectiveConfig()
+	if err != nil {
+		t.Fatalf("effectiveConfig: %v", err)
+	}
+	eng := New(raw, Events{})
+	err = eng.runDirectSession(context.Background(), cfg.brokerClient(), cfg, "fnd-relay", testIdentity, "127.0.0.1", directOnlyListenHost)
+	if err == nil || !strings.Contains(err.Error(), "node_class") {
+		t.Fatalf("runDirectSession() error = %v, want an unattested-node-class error", err)
+	}
+}

--- a/internal/relayruntime/engine/foundation_test.go
+++ b/internal/relayruntime/engine/foundation_test.go
@@ -283,6 +283,92 @@ func TestRunSessionRejectsFoundationAutoBeforeProbe(t *testing.T) {
 	}
 }
 
+// A foundation posture against a plaintext non-loopback broker can never
+// register (every request is refused pre-flight), so validation must reject
+// it at Start instead of letting the supervisor retry it forever.
+func TestValidateRejectsFoundationPlaintextBroker(t *testing.T) {
+	for name, cfg := range map[string]Config{
+		"token":      {FoundationToken: "fnd-secret", BrokerURL: "http://broker.example"},
+		"class-only": {NodeClass: relay.NodeClassFoundation, Mode: ModeDirect, BrokerURL: "http://broker.example"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := cfg.withDefaults().validate()
+			if err == nil || !strings.Contains(err.Error(), "https") {
+				t.Fatalf("validate() error = %v, want a plaintext-broker rejection", err)
+			}
+		})
+	}
+
+	// Loopback http (local integration tests) and https both stay valid.
+	for name, brokerURL := range map[string]string{
+		"loopback http": "http://127.0.0.1:9999",
+		"https":         "https://broker.openrung.org",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := Config{FoundationToken: "fnd-secret", BrokerURL: brokerURL}
+			if err := cfg.withDefaults().validate(); err != nil {
+				t.Fatalf("validate() rejected %s: %v", name, err)
+			}
+		})
+	}
+}
+
+// A verification failure on the expired-lease re-register path must end the
+// session (fail closed, like the initial registration) rather than leaving
+// the relay online and mislabeled while re-registering forever.
+func TestReRegisterAttestationFailureFailsSession(t *testing.T) {
+	var registers atomic.Int32
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/relays/register" {
+			w.WriteHeader(http.StatusCreated)
+			if registers.Add(1) == 1 {
+				// First registration is properly attested.
+				_, _ = w.Write([]byte(`{"id":"relay_1","public_host":"relay.example","public_port":443,"node_class":"foundation"}`))
+				return
+			}
+			// The re-register response no longer attests foundation class.
+			_, _ = w.Write([]byte(`{"id":"relay_2","public_host":"relay.example","public_port":443}`))
+			return
+		}
+		// Every heartbeat reports the pruned-relay 404 to force re-registration.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"relay not found"}`))
+	}))
+	defer broker.Close()
+
+	raw := Config{
+		BrokerURL:   broker.URL,
+		NodeClass:   relay.NodeClassFoundation,
+		Mode:        ModeDirect,
+		ListenPort:  freePort(t),
+		Identity:    testIdentity,
+		DisableXray: true,
+		ConfigDir:   t.TempDir(),
+	}.withDefaults()
+	cfg, err := raw.effectiveConfig()
+	if err != nil {
+		t.Fatalf("effectiveConfig: %v", err)
+	}
+	cfg.HeartbeatInterval = 50 * time.Millisecond
+	eng := New(raw, Events{})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eng.runDirectSession(context.Background(), cfg.brokerClient(), cfg, "fnd-relay", testIdentity, "relay.example", directOnlyListenHost)
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "node_class") {
+			t.Fatalf("runDirectSession() error = %v, want a fail-closed re-register attestation error", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("session kept running after a failed re-register attestation")
+	}
+	if registers.Load() < 2 {
+		t.Fatalf("registers = %d, want at least 2 (initial + re-register)", registers.Load())
+	}
+}
+
 // A broker that predates node_class silently drops the field; a foundation
 // relay must refuse to serve mislabeled rather than run as volunteer-class.
 func TestDirectSessionRejectsUnattestedFoundationClass(t *testing.T) {

--- a/internal/relayruntime/engine/renderconfig_test.go
+++ b/internal/relayruntime/engine/renderconfig_test.go
@@ -1,0 +1,89 @@
+package engine
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+)
+
+type renderedXrayConfig struct {
+	Inbounds []struct {
+		Listen   string `json:"listen"`
+		Port     int    `json:"port"`
+		Protocol string `json:"protocol"`
+	} `json:"inbounds"`
+}
+
+func renderAndParse(t *testing.T, eng *Engine) renderedXrayConfig {
+	t.Helper()
+	raw, err := eng.RenderXrayConfig()
+	if err != nil {
+		t.Fatalf("RenderXrayConfig: %v", err)
+	}
+	var parsed renderedXrayConfig
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("rendered config is not valid JSON: %v", err)
+	}
+	if len(parsed.Inbounds) != 1 || parsed.Inbounds[0].Protocol != "vless" {
+		t.Fatalf("unexpected inbounds: %+v", parsed.Inbounds)
+	}
+	return parsed
+}
+
+func TestRenderXrayConfigDirect(t *testing.T) {
+	identityReports := 0
+	eng := New(Config{
+		BrokerURL:  "http://127.0.0.1:1",
+		Mode:       ModeDirect,
+		ListenPort: 8443,
+		Identity:   testIdentity,
+	}, Events{OnIdentity: func(Identity) { identityReports++ }})
+
+	parsed := renderAndParse(t, eng)
+	if parsed.Inbounds[0].Listen != directOnlyListenHost || parsed.Inbounds[0].Port != 8443 {
+		t.Fatalf("inbound = %s:%d, want %s:8443", parsed.Inbounds[0].Listen, parsed.Inbounds[0].Port, directOnlyListenHost)
+	}
+	// A complete identity renders as-is; nothing is generated or re-reported.
+	if identityReports != 0 {
+		t.Fatalf("OnIdentity fired %d times for a complete identity, want 0", identityReports)
+	}
+}
+
+func TestRenderXrayConfigWSSPinsIPv4Wildcard(t *testing.T) {
+	eng := New(Config{
+		BrokerURL:       "https://broker.test",
+		FoundationToken: "fnd-secret",
+		Mode:            ModeDirect,
+		WSSFronts:       wssTestFronts(),
+		Identity:        testIdentity,
+	}, Events{})
+
+	parsed := renderAndParse(t, eng)
+	if parsed.Inbounds[0].Listen != wssDirectListenHost || parsed.Inbounds[0].Port != 443 {
+		t.Fatalf("inbound = %s:%d, want %s:443", parsed.Inbounds[0].Listen, parsed.Inbounds[0].Port, wssDirectListenHost)
+	}
+}
+
+func TestRenderXrayConfigTunnelUsesLoopback(t *testing.T) {
+	eng := New(Config{
+		Mode:     ModeTunnel,
+		HubAddr:  "hub.example:9443",
+		Identity: testIdentity,
+	}, Events{})
+
+	parsed := renderAndParse(t, eng)
+	ip := net.ParseIP(parsed.Inbounds[0].Listen)
+	if ip == nil || !ip.IsLoopback() {
+		t.Fatalf("tunnel render listen = %q, want a loopback address", parsed.Inbounds[0].Listen)
+	}
+	if parsed.Inbounds[0].Port <= 0 {
+		t.Fatalf("tunnel render port = %d, want a reserved port", parsed.Inbounds[0].Port)
+	}
+}
+
+func TestRenderXrayConfigValidatesFirst(t *testing.T) {
+	eng := New(Config{Mode: ModeTunnel, Identity: testIdentity}, Events{}) // tunnel without a hub
+	if _, err := eng.RenderXrayConfig(); err == nil {
+		t.Fatal("RenderXrayConfig() error = nil, want a validation error")
+	}
+}

--- a/internal/relayruntime/engine/renderconfig_test.go
+++ b/internal/relayruntime/engine/renderconfig_test.go
@@ -3,8 +3,12 @@ package engine
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -165,6 +169,80 @@ func TestConcurrentRendersConvergeOnOneIdentity(t *testing.T) {
 	if last.ClientID != winner.ClientID || last.ShortID != winner.ShortID {
 		t.Fatalf("registered identity (%s/%s) does not match the rendered one (%s/%s)",
 			last.ClientID, last.ShortID, winner.ClientID, winner.ShortID)
+	}
+}
+
+// UpdateConfig must wait for an in-flight identity preparation: without the
+// shared lock, a render generating keys across an UpdateConfig would write
+// its stale identity back over the just-installed configuration.
+func TestUpdateConfigWaitsForInFlightIdentityGeneration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake xray requires a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	startedPath := filepath.Join(dir, "started")
+	releasePath := filepath.Join(dir, "release")
+	fakeXray := filepath.Join(dir, "xray")
+	script := fmt.Sprintf(`#!/bin/sh
+touch %q
+while [ ! -e %q ]; do sleep 0.05; done
+echo "Private key: generated-private-key"
+echo "Public key: generated-public-key"
+`, startedPath, releasePath)
+	if err := os.WriteFile(fakeXray, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake xray: %v", err)
+	}
+
+	// Missing Reality keys force prepareIdentity through the fake xray, which
+	// holds the identity lock until the release file appears.
+	partial := testIdentity
+	partial.RealityPrivateKey = ""
+	partial.RealityPublicKey = ""
+	eng := New(Config{
+		BrokerURL: "http://127.0.0.1:1",
+		Mode:      ModeDirect,
+		XrayPath:  fakeXray,
+		Identity:  partial,
+	}, Events{})
+
+	renderDone := make(chan error, 1)
+	go func() {
+		_, err := eng.RenderXrayConfig()
+		renderDone <- err
+	}()
+	eventually(t, 5*time.Second, "identity generation in flight", func() bool {
+		_, err := os.Stat(startedPath)
+		return err == nil
+	})
+
+	updateDone := make(chan error, 1)
+	go func() {
+		updateDone <- eng.UpdateConfig(Config{
+			BrokerURL: "http://127.0.0.1:1",
+			Mode:      ModeDirect,
+			XrayPath:  fakeXray,
+			Identity:  testIdentity,
+		})
+	}()
+	select {
+	case err := <-updateDone:
+		t.Fatalf("UpdateConfig returned (%v) while identity generation was still in flight", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if err := os.WriteFile(releasePath, []byte("go"), 0o600); err != nil {
+		t.Fatalf("release fake xray: %v", err)
+	}
+	if err := <-renderDone; err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if err := <-updateDone; err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+
+	if got := eng.currentConfig().Identity; got != testIdentity {
+		t.Fatalf("identity after UpdateConfig = %+v, want the installed testIdentity (a stale render writeback overwrote it)", got)
 	}
 }
 

--- a/internal/relayruntime/engine/renderconfig_test.go
+++ b/internal/relayruntime/engine/renderconfig_test.go
@@ -87,3 +87,30 @@ func TestRenderXrayConfigValidatesFirst(t *testing.T) {
 		t.Fatal("RenderXrayConfig() error = nil, want a validation error")
 	}
 }
+
+// Rendering while running is refused: it would let prepareIdentity's
+// generate-and-report flow race the live session's.
+func TestRenderXrayConfigRefusesWhileRunning(t *testing.T) {
+	_, addr := startTestHub(t)
+	eng := New(Config{
+		Mode:         ModeTunnel,
+		HubAddr:      addr,
+		HubPlaintext: true,
+		Identity:     testIdentity,
+		DisableXray:  true,
+		ConfigDir:    t.TempDir(),
+	}, Events{})
+	if err := eng.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer eng.Stop()
+
+	if _, err := eng.RenderXrayConfig(); err == nil {
+		t.Fatal("RenderXrayConfig() error = nil, want a running-engine refusal")
+	}
+
+	eng.Stop()
+	if _, err := eng.RenderXrayConfig(); err != nil {
+		t.Fatalf("RenderXrayConfig after Stop: %v", err)
+	}
+}

--- a/internal/relayruntime/engine/renderconfig_test.go
+++ b/internal/relayruntime/engine/renderconfig_test.go
@@ -1,9 +1,13 @@
 package engine
 
 import (
+	"bytes"
 	"encoding/json"
 	"net"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 )
 
 type renderedXrayConfig struct {
@@ -88,8 +92,85 @@ func TestRenderXrayConfigValidatesFirst(t *testing.T) {
 	}
 }
 
-// Rendering while running is refused: it would let prepareIdentity's
-// generate-and-report flow race the live session's.
+// Concurrent renders on an idle engine must converge on ONE generated
+// identity: prepareIdentity serializes generation and always starts from the
+// freshest stored identity, so every returned config matches the identity a
+// subsequent Start registers with.
+func TestConcurrentRendersConvergeOnOneIdentity(t *testing.T) {
+	// Reality keys present so generation never shells out to xray; the
+	// missing client ID, short ID, and seed are what the racers would fork.
+	partial := testIdentity
+	partial.ClientID = ""
+	partial.ShortID = ""
+	partial.IdentitySeed = ""
+
+	var mu sync.Mutex
+	var persisted []Identity
+	broker := &fakeBroker{}
+	ts := httptest.NewServer(broker.handler())
+	defer ts.Close()
+
+	eng := New(Config{
+		BrokerURL:   ts.URL,
+		Mode:        ModeDirect,
+		PublicHost:  "203.0.113.7",
+		ListenPort:  freePort(t),
+		Identity:    partial,
+		DisableXray: true,
+		ConfigDir:   t.TempDir(),
+	}, Events{OnIdentity: func(id Identity) {
+		mu.Lock()
+		persisted = append(persisted, id)
+		mu.Unlock()
+	}})
+
+	const renders = 16
+	configs := make([][]byte, renders)
+	errs := make([]error, renders)
+	var wg sync.WaitGroup
+	wg.Add(renders)
+	for i := 0; i < renders; i++ {
+		go func(i int) {
+			defer wg.Done()
+			configs[i], errs[i] = eng.RenderXrayConfig()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("render %d: %v", i, err)
+		}
+		if !bytes.Equal(configs[i], configs[0]) {
+			t.Fatalf("render %d produced a different config: one identity must win\n%s\nvs\n%s", i, configs[i], configs[0])
+		}
+	}
+	mu.Lock()
+	if len(persisted) != 1 {
+		mu.Unlock()
+		t.Fatalf("OnIdentity fired %d times across %d concurrent renders, want exactly 1", len(persisted), renders)
+	}
+	winner := persisted[0]
+	mu.Unlock()
+
+	// The identity a subsequent Start registers with is the rendered one.
+	if err := eng.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer eng.Stop()
+	eventually(t, 5*time.Second, "relay online", func() bool {
+		return eng.Status().Phase == PhaseOnline
+	})
+	_, _, last := broker.stats()
+	if last.ClientID != winner.ClientID || last.ShortID != winner.ShortID {
+		t.Fatalf("registered identity (%s/%s) does not match the rendered one (%s/%s)",
+			last.ClientID, last.ShortID, winner.ClientID, winner.ShortID)
+	}
+}
+
+// Rendering while running is refused: a live direct session rebinds xray to a
+// runtime-reserved loopback port, so a mid-session render would not describe
+// the running relay.
 func TestRenderXrayConfigRefusesWhileRunning(t *testing.T) {
 	_, addr := startTestHub(t)
 	eng := New(Config{

--- a/internal/relayruntime/engine/wss_test.go
+++ b/internal/relayruntime/engine/wss_test.go
@@ -1,0 +1,294 @@
+package engine
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+// wssTestFronts returns a deliberately unsorted front list so tests observe
+// the canonicalization the engine must apply before signing.
+func wssTestFronts() []relay.WSSFrontDescriptor {
+	return []relay.WSSFrontDescriptor{
+		{ID: "front-b", URL: "wss://cdn-b.example/api/v1/wss-bridge", ProtocolVersion: relay.WSSProtocolVersion},
+		{ID: "front-a", URL: "wss://cdn-a.example/api/v1/wss-bridge", ProtocolVersion: relay.WSSProtocolVersion},
+	}
+}
+
+func testIdentityKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	key, err := relay.ParseIdentitySeed(testIdentity.IdentitySeed)
+	if err != nil {
+		t.Fatalf("parse test identity seed: %v", err)
+	}
+	return key
+}
+
+func validWSSConfig(brokerURL string) Config {
+	return Config{
+		BrokerURL:       brokerURL,
+		FoundationToken: "fnd-secret",
+		Mode:            ModeDirect,
+		WSSFronts:       wssTestFronts(),
+		ListenPort:      443,
+		Identity:        testIdentity,
+		DisableXray:     true,
+	}
+}
+
+// The gate invariant: a non-foundation relay configured with WSS fronts fails
+// fast — at Start and again on the runtime path — rather than registering.
+func TestWSSFrontsRequireFoundationClassFailFast(t *testing.T) {
+	var brokerRequests atomic.Int32
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		brokerRequests.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"relay_x"}`))
+	}))
+	defer broker.Close()
+
+	for name, nodeClass := range map[string]string{"unstated": "", "volunteer": relay.NodeClassVolunteer} {
+		t.Run(name, func(t *testing.T) {
+			cfg := validWSSConfig(broker.URL)
+			cfg.FoundationToken = ""
+			cfg.NodeClass = nodeClass
+			eng := New(cfg, Events{})
+			if err := eng.Start(); err == nil || !strings.Contains(err.Error(), "foundation") {
+				eng.Stop()
+				t.Fatalf("Start() error = %v, want a foundation-class rejection", err)
+			}
+
+			// New never validates, so exercise the runtime-path guard directly:
+			// the session must fail before a single broker request.
+			if err := eng.runSession(context.Background(), eng.cfg.brokerClient()); err == nil {
+				t.Fatal("runSession() error = nil, want a foundation-class rejection")
+			}
+			if brokerRequests.Load() != 0 {
+				t.Fatalf("broker requests = %d, want 0 (must fail fast, not register)", brokerRequests.Load())
+			}
+		})
+	}
+}
+
+func TestWSSValidationGates(t *testing.T) {
+	base := Config{
+		BrokerURL:  "https://broker.openrung.org",
+		NodeClass:  relay.NodeClassFoundation,
+		Mode:       ModeDirect,
+		WSSFronts:  wssTestFronts(),
+		ListenPort: 443,
+		Identity:   testIdentity,
+	}
+	if err := base.withDefaults().validate(); err != nil {
+		t.Fatalf("valid WSS config rejected: %v", err)
+	}
+
+	for name, mutate := range map[string]func(*Config){
+		"volunteer class":    func(c *Config) { c.NodeClass = relay.NodeClassVolunteer },
+		"tunnel mode":        func(c *Config) { c.Mode, c.HubAddr = ModeTunnel, "hub.example:9443" },
+		"auto mode with hub": func(c *Config) { c.Mode, c.HubAddr = ModeAuto, "hub.example:9443" },
+		"non-443 port":       func(c *Config) { c.ListenPort = 8443 },
+		"connection logging": func(c *Config) { c.ConnectionLogOutput = &syncBuffer{} },
+		"ephemeral identity": func(c *Config) { c.Identity.IdentitySeed = "" },
+		"invalid identity":   func(c *Config) { c.Identity.IdentitySeed = "not-base64" },
+		"malformed front": func(c *Config) {
+			c.WSSFronts = []relay.WSSFrontDescriptor{{ID: "front-a", URL: "https://cdn.example/api/v1/wss-bridge", ProtocolVersion: relay.WSSProtocolVersion}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := base
+			mutate(&cfg)
+			if err := cfg.withDefaults().validate(); err == nil {
+				t.Fatal("validate() error = nil, want WSS posture rejection")
+			}
+		})
+	}
+}
+
+// The full session: the engine canonicalizes the fronts, signs identity and
+// WSS capability with matching expiries such that broker-side verification
+// passes, and goes online only after the broker echoes the exact fronts under
+// the stable relay ID.
+func TestWSSSessionSignsCapabilityAndVerifiesEcho(t *testing.T) {
+	stubIPv6(t, "2001:db8::1", nil)
+	expectedRelayID := relay.DeriveRelayID(testIdentityKey(t).Public().(ed25519.PublicKey))
+
+	var mu sync.Mutex
+	var received relay.RegisterRequest
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/relays/register" {
+			_, _ = w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		var req relay.RegisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode registration: %v", err)
+		}
+		if err := relay.VerifyWSSCapability(req, time.Now()); err != nil {
+			t.Errorf("broker-side capability verification failed: %v", err)
+		}
+		mu.Lock()
+		received = req
+		mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(relay.RegisterResponse{Descriptor: relay.Descriptor{
+			ID:         expectedRelayID,
+			NodeClass:  relay.NodeClassFoundation,
+			WSSFronts:  slices.Clone(req.WSSFronts),
+			PublicHost: req.PublicHost,
+			PublicPort: req.PublicPort,
+		}})
+	}))
+	defer broker.Close()
+
+	cfg := validWSSConfig(broker.URL)
+	cfg.ConfigDir = t.TempDir()
+	eng := New(cfg, Events{})
+	if err := eng.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer eng.Stop()
+
+	eventually(t, 5*time.Second, "WSS relay online", func() bool {
+		s := eng.Status()
+		return s.Phase == PhaseOnline && s.RelayID == expectedRelayID
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received.WSSFronts) != 2 || received.WSSFronts[0].ID != "front-a" || received.WSSFronts[1].ID != "front-b" {
+		t.Fatalf("registration fronts not canonical: %#v", received.WSSFronts)
+	}
+	if received.WSSCapabilityProof == "" || received.WSSCapabilityExpiresAt != received.IdentityExpiresAt {
+		t.Fatalf("capability proof fields = proof:%t expiry:%q identity-expiry:%q",
+			received.WSSCapabilityProof != "", received.WSSCapabilityExpiresAt, received.IdentityExpiresAt)
+	}
+	if received.NodeClass != relay.NodeClassFoundation {
+		t.Fatalf("registered node_class = %q, want foundation", received.NodeClass)
+	}
+}
+
+// Fail-closed on broker echo tampering: dropped fronts, a rewritten front, or
+// a relay ID that does not match the stable identity all abort the session.
+func TestWSSSessionRejectsBrokerEchoTampering(t *testing.T) {
+	expectedRelayID := relay.DeriveRelayID(testIdentityKey(t).Public().(ed25519.PublicKey))
+	canonical, err := relay.NormalizeWSSFronts(wssTestFronts())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, responseDescriptor := range map[string]relay.Descriptor{
+		"dropped fronts": {
+			ID: expectedRelayID, NodeClass: relay.NodeClassFoundation,
+		},
+		"wrong relay ID": {
+			ID: "relay_wrong", NodeClass: relay.NodeClassFoundation,
+			WSSFronts: slices.Clone(canonical),
+		},
+		"rewritten front": {
+			ID: expectedRelayID, NodeClass: relay.NodeClassFoundation,
+			WSSFronts: []relay.WSSFrontDescriptor{
+				{ID: "front-a", URL: "wss://other.example/api/v1/wss-bridge", ProtocolVersion: relay.WSSProtocolVersion},
+				{ID: "front-b", URL: "wss://cdn-b.example/api/v1/wss-bridge", ProtocolVersion: relay.WSSProtocolVersion},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(relay.RegisterResponse{Descriptor: responseDescriptor})
+			}))
+			defer broker.Close()
+
+			raw := validWSSConfig(broker.URL)
+			raw.ConfigDir = t.TempDir()
+			raw = raw.withDefaults()
+			cfg, err := raw.effectiveConfig()
+			if err != nil {
+				t.Fatalf("effectiveConfig: %v", err)
+			}
+			eng := New(raw, Events{})
+			err = eng.runDirectSession(context.Background(), cfg.brokerClient(), cfg, "wss-relay", testIdentity, "2001:db8::1", directOnlyListenHost)
+			if err == nil {
+				t.Fatal("runDirectSession() error = nil, want fail-closed broker echo rejection")
+			}
+		})
+	}
+}
+
+// A WSS registration must use exactly the explicit stable seed: a session
+// whose prepared identity diverges from the configured seed is refused before
+// registration.
+func TestWSSSessionRejectsIdentityMismatch(t *testing.T) {
+	var brokerRequests atomic.Int32
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		brokerRequests.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"relay_x"}`))
+	}))
+	defer broker.Close()
+
+	raw := validWSSConfig(broker.URL).withDefaults()
+	raw.ConfigDir = t.TempDir()
+	cfg, err := raw.effectiveConfig()
+	if err != nil {
+		t.Fatalf("effectiveConfig: %v", err)
+	}
+	// A healed/regenerated identity: same everything except a different seed.
+	divergent := testIdentity
+	divergent.IdentitySeed = "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE="
+	eng := New(raw, Events{})
+	err = eng.runDirectSession(context.Background(), cfg.brokerClient(), cfg, "wss-relay", divergent, "2001:db8::1", directOnlyListenHost)
+	if err == nil || !strings.Contains(err.Error(), "stable identity seed") {
+		t.Fatalf("runDirectSession() error = %v, want an identity-mismatch rejection", err)
+	}
+	if brokerRequests.Load() != 0 {
+		t.Fatalf("broker requests = %d, want 0", brokerRequests.Load())
+	}
+}
+
+func TestVerifyRegisteredDescriptor(t *testing.T) {
+	identityKey := testIdentityKey(t)
+	stableID := relay.DeriveRelayID(identityKey.Public().(ed25519.PublicKey))
+	canonical, err := relay.NormalizeWSSFronts(wssTestFronts())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	volunteerReq := relay.RegisterRequest{}
+	if err := verifyRegisteredDescriptor(volunteerReq, relay.Descriptor{ID: "relay_1"}, identityKey); err != nil {
+		t.Fatalf("plain volunteer registration rejected: %v", err)
+	}
+
+	foundationReq := relay.RegisterRequest{NodeClass: relay.NodeClassFoundation}
+	if err := verifyRegisteredDescriptor(foundationReq, relay.Descriptor{ID: "relay_1"}, identityKey); err == nil {
+		t.Fatal("unattested foundation class accepted")
+	}
+	if err := verifyRegisteredDescriptor(foundationReq, relay.Descriptor{ID: "relay_1", NodeClass: relay.NodeClassFoundation}, identityKey); err != nil {
+		t.Fatalf("attested foundation registration rejected: %v", err)
+	}
+
+	wssReq := relay.RegisterRequest{NodeClass: relay.NodeClassFoundation, WSSFronts: canonical}
+	good := relay.Descriptor{ID: stableID, NodeClass: relay.NodeClassFoundation, WSSFronts: slices.Clone(canonical)}
+	if err := verifyRegisteredDescriptor(wssReq, good, identityKey); err != nil {
+		t.Fatalf("exact WSS echo rejected: %v", err)
+	}
+	if err := verifyRegisteredDescriptor(wssReq, relay.Descriptor{ID: stableID, NodeClass: relay.NodeClassFoundation}, identityKey); err == nil {
+		t.Fatal("dropped WSS fronts accepted")
+	}
+	wrongID := good
+	wrongID.ID = "relay_wrong"
+	if err := verifyRegisteredDescriptor(wssReq, wrongID, identityKey); err == nil {
+		t.Fatal("wrong relay ID accepted for a WSS registration")
+	}
+}


### PR DESCRIPTION
## Summary

Makes `internal/relayruntime/engine` (used by desktop-volunteer) the single relay orchestrator by porting in the four capabilities that today exist only in `cmd/relay/main.go`, each behind an option. `cmd/relay` itself is untouched in this PR.

| cmd/relay feature | Engine option |
|---|---|
| `-foundation-token` / `-node-class` posture | `Config.FoundationToken`, `Config.NodeClass` |
| `-wss-fronts` registration + capability signing | `Config.WSSFronts` |
| `-connection-log` console output | `Config.ConnectionLogOutput io.Writer` |
| `-print-config-only` | `Engine.RenderXrayConfig()` |

All four flow through a new `effectiveConfig()` step (posture application + normalization + guards) that runs both at `Start` validation and again at the top of every session, so the guards hold on the runtime path even for callers that bypass validation.

## Invariants preserved (each has an explicit test)

- **Canonical routes + redirect refusal**: all engine broker traffic goes through `relayruntime.BrokerClient`, which uses only the register/heartbeat routes and refuses every redirect. `TestEngineBrokerUsesCanonicalRoutesAndRefusesRedirects` pins both through the client the engine builds.
- **Foundation ⇒ direct mode, credential never in the hub path**: the token posture rewrites any mode to direct; an explicit foundation class in auto (with a hub) or tunnel mode is rejected at validation *and* in `runSession` before `autoResolve` can transmit anything. `TestFoundationTokenSessionRegistersDirectWithoutTouchingHub` runs a full session with a hub configured and asserts zero hub requests; `TestRunSessionRejectsFoundationAutoBeforeProbe` covers the runtime-path guard. The foundation bearer also refuses plaintext non-loopback brokers before sending (`TestFoundationRefusesPlaintextBroker`).
- **WSS fronts gated to foundation class, fail fast**: a non-foundation config with fronts fails validation and the runtime-path guard without a single broker request (`TestWSSFrontsRequireFoundationClassFailFast`). The rest of the cmd/relay posture carries over: direct mode, port 443, no connection logging, explicit stable identity seed, capability signed with the identity-proof expiry, and fail-closed verification of the broker echo (exact fronts, stable relay ID, attested class) on initial registration and every re-registration.

## Resolved divergences

- **`transport` stays off the wire.** cmd/relay sends `transport=direct`; the engine's registration has never carried the field and still doesn't (the broker and the WSS capability eligibility both treat empty as direct). Keeps existing desktop-volunteer requests byte-identical.
- **Unset `NodeClass` stays unstated.** cmd/relay normalizes empty to `volunteer` and sends it; the engine leaves an empty class off the wire (same broker semantics), again to avoid changing the deployed GUI's registration bytes. An explicit `volunteer`/`foundation` is normalized and sent.
- **No listen-host knob.** The engine owns its listen host, so cmd/relay's WSS listen-host validation cases don't exist here; the engine pins a WSS relay's xray to `0.0.0.0` itself (`wssDirectListenHost`).
- **Connection-log shape.** cmd/relay's `-connection-log=false` skips the observer entirely; the engine's observer is also its traffic-counter source, so it always runs for non-WSS direct sessions and `ConnectionLogOutput` only controls where the per-connection lines go (nil = nowhere, as today). The WSS posture (no observer at all, no per-connection records) is preserved exactly.
- **Foundation + auto-without-hub is allowed.** Engine auto mode with no hub never probes and deterministically degrades to direct, mirroring cmd/relay's hubless direct default, so the direct-mode guards accept it.
- **Failure handling stays supervised.** Where cmd/relay exits on a fail-closed registration check, the engine surfaces the error and retries under its existing supervisor backoff — that is the engine's contract and is unchanged.
- **`RenderXrayConfig` renders the canonical direct-form binding** (loopback for tunnel, IPv4 wildcard for WSS), like `-print-config-only`; a live direct session still rebinds xray behind the observer at runtime.

## Testing

- `go build ./...` + `go test ./...`: root, `desktop/`, `desktop-volunteer/` all green; `gofmt` clean.
- `go test -race ./internal/relayruntime/engine/` green.
- `cmd/relay` untouched; its tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (second commit)

A 10-angle review pass on the first commit produced 13 findings; the five actionable ones are fixed in `df7482e`:

- **Fail-closed re-register**: a `verifyRegisteredDescriptor` failure after an expired-lease re-registration now ends the session (matching the initial-registration path) instead of staying `PhaseOnline` mislabeled with a stale lease token and re-registering every heartbeat tick.
- **Start-time transport check**: `validate()` rejects a foundation posture with a plaintext non-loopback `BrokerURL` via the newly exported `relayruntime.ValidateSecureBrokerURL` (loopback http for tests still allowed), instead of retrying a deterministic pre-flight refusal forever.
- **`RenderXrayConfig` running-guard**: refuses while the engine runs, so identity generation cannot race a live session and fork the persisted seed.
- **Locked connection-log writer**: `ConnectionLogOutput` writes are serialized by the engine; the field now documents that the caller's writer need not be goroutine-safe.
- **`brokerClient` normalization**: the node-class half of `RequireSecureTransport` is case/space-insensitive, closing a latent gap for unnormalized configs.

Plus **`Config.PublicHost`** (cmd/relay's `-public-host`), which the review flagged as the missing piece for engine WSS relays: direct mode uses it verbatim (and skips the IPv6 rotation recheck — an explicit host is pinned), auto mode still prefers the probe-observed address. Without it, a WSS relay could only advertise an auto-detected IPv6 while xray binds the IPv4 wildcard.

Remaining findings (deliberate C1 structure or lower-priority cleanups: cmd/relay logic duplication to collapse in C2, `effectiveConfig` call topology, test-helper dedup, WSS register-before-bind ordering, typed-nil writer) are tracked in the review report and left for follow-ups.
