### PR TITLE
Collapse the proxy-port callback seam and its constant cycle

### DIFF
--- a/cmd/client/host.go
+++ b/cmd/client/host.go
@@ -13,8 +13,7 @@ import (
 // engineHost bundles the connection engine with the CLI host wiring the TUI
 // and the headless connect driver share: internal/clientstate persistence
 // (recents, crash-recovery proxy snapshot, and the stable proxy port — the
-// same on-disk state the desktop app reads), per-OS system proxy control, and
-// the stable proxy-port resolver (OPENRUNG_PROXY_PORT honored, not persisted).
+// same on-disk state the desktop app reads) and per-OS system proxy control.
 type engineHost struct {
 	engine *connectcore.Engine
 	store  *clientstate.Store // nil when the config directory is unavailable
@@ -33,10 +32,6 @@ func newEngineHost(sink connectcore.EventSink, singBoxPath string) *engineHost {
 	engine.OSProxy = osProxyAdapter{ctrl: proxymode.New()}
 	// TUN mode is gated on this hook; proxy mode never invokes it.
 	engine.Elevation = elevation{}
-	// The one storage hook: recents, the crash-recovery proxy snapshot, and the
-	// stable proxy port the engine resolves through internal/proxyconfig. Left
-	// nil when the config directory is unavailable, which the engine degrades
-	// on rather than fails.
 	if store, err := clientstate.New(); err == nil {
 		host.store = store
 		engine.Persistence = storeAdapter{store: store}
@@ -44,9 +39,8 @@ func newEngineHost(sink connectcore.EventSink, singBoxPath string) *engineHost {
 	return host
 }
 
-// helperStore narrows the store for proxyconfig's shell helper, as a nil
-// interface when the config directory was unavailable: a nil *clientstate.Store
-// inside a non-nil interface would slip past proxyconfig's own nil check.
+// helperStore must return a nil interface, never a nil pointer inside one, which
+// proxyconfig's nil check cannot see through.
 func (h *engineHost) helperStore() proxyconfig.HelperStore {
 	if h.store == nil {
 		return nil
@@ -96,8 +90,6 @@ func (a storeAdapter) SaveRecents(recents []connectcore.RecentNode) error {
 	return a.store.SaveRecents(stored)
 }
 
-// The proxy-port half needs no translation: the store already speaks
-// proxyconfig's shape, which is why the engine can resolve through it directly.
 func (a storeAdapter) LoadProxyPort() (int, bool) { return a.store.LoadProxyPort() }
 
 func (a storeAdapter) LoadOrSaveProxyPort(candidate int) (int, error) {

--- a/cmd/client/host.go
+++ b/cmd/client/host.go
@@ -33,21 +33,25 @@ func newEngineHost(sink connectcore.EventSink, singBoxPath string) *engineHost {
 	engine.OSProxy = osProxyAdapter{ctrl: proxymode.New()}
 	// TUN mode is gated on this hook; proxy mode never invokes it.
 	engine.Elevation = elevation{}
+	// The one storage hook: recents, the crash-recovery proxy snapshot, and the
+	// stable proxy port the engine resolves through internal/proxyconfig. Left
+	// nil when the config directory is unavailable, which the engine degrades
+	// on rather than fails.
 	if store, err := clientstate.New(); err == nil {
 		host.store = store
 		engine.Persistence = storeAdapter{store: store}
 	}
-	engine.ResolveProxyPort = func() (connectcore.ProxyPortResolution, error) {
-		resolution, err := proxyconfig.ResolvePort(host.store)
-		if err != nil {
-			return connectcore.ProxyPortResolution{}, err
-		}
-		return connectcore.ProxyPortResolution{
-			Port:               resolution.Port,
-			PersistenceWarning: resolution.PersistenceWarning,
-		}, nil
-	}
 	return host
+}
+
+// helperStore narrows the store for proxyconfig's shell helper, as a nil
+// interface when the config directory was unavailable: a nil *clientstate.Store
+// inside a non-nil interface would slip past proxyconfig's own nil check.
+func (h *engineHost) helperStore() proxyconfig.HelperStore {
+	if h.store == nil {
+		return nil
+	}
+	return h.store
 }
 
 // shellProxyHelper resolves the stable local endpoint and writes the
@@ -63,7 +67,7 @@ func (h *engineHost) shellProxyHelper() (proxyconfig.Info, error) {
 	if err != nil {
 		return proxyconfig.Info{}, err
 	}
-	return proxyconfig.WriteShellHelper(h.store, port)
+	return proxyconfig.WriteShellHelper(h.helperStore(), port)
 }
 
 // The adapters below mirror desktop/vpnservice/adapters.go over the shared
@@ -90,6 +94,14 @@ func (a storeAdapter) SaveRecents(recents []connectcore.RecentNode) error {
 		stored = append(stored, clientstate.RecentNode(r))
 	}
 	return a.store.SaveRecents(stored)
+}
+
+// The proxy-port half needs no translation: the store already speaks
+// proxyconfig's shape, which is why the engine can resolve through it directly.
+func (a storeAdapter) LoadProxyPort() (int, bool) { return a.store.LoadProxyPort() }
+
+func (a storeAdapter) LoadOrSaveProxyPort(candidate int) (int, error) {
+	return a.store.LoadOrSaveProxyPort(candidate)
 }
 
 func (a storeAdapter) SaveProxySnapshot(snap connectcore.OSProxySnapshot) error {

--- a/cmd/client/host_test.go
+++ b/cmd/client/host_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"openrung/internal/clientstate"
+	"openrung/internal/connectcore"
+)
+
+// storeAdapter is the engine's whole storage hook — recents, the crash-recovery
+// proxy snapshot, and the stable proxy port it resolves through proxyconfig.
+var _ connectcore.Persistence = storeAdapter{}
+
+// A missing configuration directory must reach proxyconfig as a nil interface.
+// A nil *clientstate.Store wrapped in a non-nil interface would sail past
+// proxyconfig's nil check and panic inside the shell helper instead of
+// reporting that the directory is unavailable.
+func TestHelperStoreIsNilWithoutAConfigurationDirectory(t *testing.T) {
+	host := &engineHost{}
+	if store := host.helperStore(); store != nil {
+		t.Fatalf("helperStore() = %#v; want a nil interface", store)
+	}
+
+	host.store = clientstate.NewInDir(t.TempDir())
+	if store := host.helperStore(); store == nil {
+		t.Fatal("helperStore() = nil with a usable configuration directory")
+	}
+}

--- a/cmd/client/host_test.go
+++ b/cmd/client/host_test.go
@@ -7,13 +7,10 @@ import (
 	"openrung/internal/connectcore"
 )
 
-// storeAdapter is the engine's whole storage hook — recents, the crash-recovery
-// proxy snapshot, and the stable proxy port it resolves through proxyconfig.
 var _ connectcore.Persistence = storeAdapter{}
 
-// A missing configuration directory must reach proxyconfig as a nil interface.
-// A nil *clientstate.Store wrapped in a non-nil interface would sail past
-// proxyconfig's nil check and panic inside the shell helper instead of
+// A missing configuration directory must reach proxyconfig as a nil interface,
+// or its nil check is defeated and the shell helper panics instead of
 // reporting that the directory is unavailable.
 func TestHelperStoreIsNilWithoutAConfigurationDirectory(t *testing.T) {
 	host := &engineHost{}

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -315,7 +315,7 @@ func (m tuiModel) resolveProxyCmd() tea.Cmd {
 		if err != nil {
 			return proxyInfoMsg{err: err.Error()}
 		}
-		msg := proxyInfoMsg{endpoint: connectcore.ProxyHost + ":" + strconv.Itoa(port)}
+		msg := proxyInfoMsg{endpoint: proxyconfig.Host + ":" + strconv.Itoa(port)}
 		if warning := driver.LocalProxyPortWarning(); warning != nil {
 			msg.warn = warning.Error()
 		}

--- a/desktop/vpnservice/adapters.go
+++ b/desktop/vpnservice/adapters.go
@@ -32,8 +32,6 @@ func (a storeAdapter) SaveRecents(recents []connectcore.RecentNode) error {
 	return a.store.SaveRecents(stored)
 }
 
-// The proxy-port half needs no translation: the store already speaks
-// proxyconfig's shape, which is why the engine can resolve through it directly.
 func (a storeAdapter) LoadProxyPort() (int, bool) { return a.store.LoadProxyPort() }
 
 func (a storeAdapter) LoadOrSaveProxyPort(candidate int) (int, error) {
@@ -60,9 +58,8 @@ func (a storeAdapter) ClearProxySnapshot() error {
 	return a.store.ClearProxySnapshot()
 }
 
-// helperStore narrows the store for proxyconfig's shell helper, as a nil
-// interface when the config directory was unavailable: a nil *clientstate.Store
-// inside a non-nil interface would slip past proxyconfig's own nil check.
+// helperStore must return a nil interface, never a nil pointer inside one, which
+// proxyconfig's nil check cannot see through.
 func (s *Service) helperStore() proxyconfig.HelperStore {
 	if s.store == nil {
 		return nil

--- a/desktop/vpnservice/adapters.go
+++ b/desktop/vpnservice/adapters.go
@@ -5,6 +5,7 @@ import (
 
 	"openrung/internal/clientstate"
 	"openrung/internal/connectcore"
+	"openrung/internal/proxyconfig"
 	"openrung/internal/proxymode"
 )
 
@@ -31,6 +32,14 @@ func (a storeAdapter) SaveRecents(recents []connectcore.RecentNode) error {
 	return a.store.SaveRecents(stored)
 }
 
+// The proxy-port half needs no translation: the store already speaks
+// proxyconfig's shape, which is why the engine can resolve through it directly.
+func (a storeAdapter) LoadProxyPort() (int, bool) { return a.store.LoadProxyPort() }
+
+func (a storeAdapter) LoadOrSaveProxyPort(candidate int) (int, error) {
+	return a.store.LoadOrSaveProxyPort(candidate)
+}
+
 func (a storeAdapter) SaveProxySnapshot(snap connectcore.OSProxySnapshot) error {
 	typed, ok := snap.(proxymode.Snapshot)
 	if !ok {
@@ -49,6 +58,16 @@ func (a storeAdapter) LoadProxySnapshot() (connectcore.OSProxySnapshot, bool) {
 
 func (a storeAdapter) ClearProxySnapshot() error {
 	return a.store.ClearProxySnapshot()
+}
+
+// helperStore narrows the store for proxyconfig's shell helper, as a nil
+// interface when the config directory was unavailable: a nil *clientstate.Store
+// inside a non-nil interface would slip past proxyconfig's own nil check.
+func (s *Service) helperStore() proxyconfig.HelperStore {
+	if s.store == nil {
+		return nil
+	}
+	return s.store
 }
 
 // osProxyAdapter implements connectcore.OSProxy over the per-OS controllers in

--- a/desktop/vpnservice/adapters_test.go
+++ b/desktop/vpnservice/adapters_test.go
@@ -1,0 +1,29 @@
+package vpnservice
+
+import (
+	"testing"
+
+	"openrung/internal/clientstate"
+	"openrung/internal/connectcore"
+)
+
+// storeAdapter is the engine's whole storage hook — recents, the crash-recovery
+// proxy snapshot, and the stable proxy port it resolves through proxyconfig —
+// so the desktop app and the terminal client wire the same one thing.
+var _ connectcore.Persistence = storeAdapter{}
+
+// A missing configuration directory must reach proxyconfig as a nil interface.
+// A nil *clientstate.Store wrapped in a non-nil interface would sail past
+// proxyconfig's nil check and panic inside the shell helper instead of
+// reporting that the directory is unavailable.
+func TestHelperStoreIsNilWithoutAConfigurationDirectory(t *testing.T) {
+	s := &Service{}
+	if store := s.helperStore(); store != nil {
+		t.Fatalf("helperStore() = %#v; want a nil interface", store)
+	}
+
+	s.store = clientstate.NewInDir(t.TempDir())
+	if store := s.helperStore(); store == nil {
+		t.Fatal("helperStore() = nil with a usable configuration directory")
+	}
+}

--- a/desktop/vpnservice/adapters_test.go
+++ b/desktop/vpnservice/adapters_test.go
@@ -7,14 +7,10 @@ import (
 	"openrung/internal/connectcore"
 )
 
-// storeAdapter is the engine's whole storage hook — recents, the crash-recovery
-// proxy snapshot, and the stable proxy port it resolves through proxyconfig —
-// so the desktop app and the terminal client wire the same one thing.
 var _ connectcore.Persistence = storeAdapter{}
 
-// A missing configuration directory must reach proxyconfig as a nil interface.
-// A nil *clientstate.Store wrapped in a non-nil interface would sail past
-// proxyconfig's nil check and panic inside the shell helper instead of
+// A missing configuration directory must reach proxyconfig as a nil interface,
+// or its nil check is defeated and the shell helper panics instead of
 // reporting that the directory is unavailable.
 func TestHelperStoreIsNilWithoutAConfigurationDirectory(t *testing.T) {
 	s := &Service{}

--- a/desktop/vpnservice/service.go
+++ b/desktop/vpnservice/service.go
@@ -116,16 +116,6 @@ func New() *Service {
 	engine.PunchInsecure = true
 	engine.Sink = &engineSink{s: s}
 	engine.OSProxy = osProxyAdapter{ctrl: proxymode.New()}
-	engine.ResolveProxyPort = func() (connectcore.ProxyPortResolution, error) {
-		resolution, err := proxyconfig.ResolvePort(s.store)
-		if err != nil {
-			return connectcore.ProxyPortResolution{}, err
-		}
-		return connectcore.ProxyPortResolution{
-			Port:               resolution.Port,
-			PersistenceWarning: resolution.PersistenceWarning,
-		}, nil
-	}
 	s.engine = engine
 	s.state = engine.State()
 	return s
@@ -135,6 +125,10 @@ func New() *Service {
 // frontend as callable bindings; they are lifecycle hooks for package main.
 func (s *Service) Startup(ctx context.Context) {
 	s.engine.SingBoxPath = s.SingBoxPath
+	// The one storage hook: recents, the crash-recovery proxy snapshot, and the
+	// stable proxy port the engine resolves through internal/proxyconfig. Left
+	// nil when the config directory is unavailable, which the engine degrades
+	// on rather than fails.
 	if store, err := clientstate.New(); err == nil {
 		s.store = store
 		s.engine.Persistence = storeAdapter{store: store}
@@ -228,7 +222,7 @@ func (s *Service) GetProxyInfo() (NativeProxyInfo, error) {
 	if !native.ShellIntegration {
 		return native, nil
 	}
-	info, err = proxyconfig.WriteShellHelper(s.store, port)
+	info, err = proxyconfig.WriteShellHelper(s.helperStore(), port)
 	if err != nil {
 		message := err.Error()
 		native.ShellIntegrationError = &message

--- a/desktop/vpnservice/service.go
+++ b/desktop/vpnservice/service.go
@@ -125,10 +125,6 @@ func New() *Service {
 // frontend as callable bindings; they are lifecycle hooks for package main.
 func (s *Service) Startup(ctx context.Context) {
 	s.engine.SingBoxPath = s.SingBoxPath
-	// The one storage hook: recents, the crash-recovery proxy snapshot, and the
-	// stable proxy port the engine resolves through internal/proxyconfig. Left
-	// nil when the config directory is unavailable, which the engine degrades
-	// on rather than fails.
 	if store, err := clientstate.New(); err == nil {
 		s.store = store
 		s.engine.Persistence = storeAdapter{store: store}

--- a/desktop/vpnservice/service_test.go
+++ b/desktop/vpnservice/service_test.go
@@ -128,14 +128,25 @@ func TestGetProxyInfoKeepsEndpointWhenShellHelperCannotBeWritten(t *testing.T) {
 	}
 }
 
+// withStore wires a store the way Startup does: the same value backs the shell
+// helper and the engine's persistence hook, through which the engine resolves
+// the stable port. A test that set only one of the two would no longer be
+// exercising the path the app runs.
+func withStore(s *Service, store *clientstate.Store) *Service {
+	s.store = store
+	s.engine.Persistence = storeAdapter{store: store}
+	return s
+}
+
 func TestGetProxyInfoSurfacesNonFatalPersistenceWarning(t *testing.T) {
 	t.Setenv(proxyconfig.PortEnv, "")
 	blocker := filepath.Join(t.TempDir(), "not-a-directory")
 	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	s := New()
-	s.store = clientstate.NewInDir(filepath.Join(blocker, "openrung"))
+	// A store whose configuration directory cannot be created: resolution still
+	// yields a usable endpoint, and the failure to persist it is a warning.
+	s := withStore(New(), clientstate.NewInDir(filepath.Join(blocker, "openrung")))
 
 	info, err := s.GetProxyInfo()
 	if err != nil {
@@ -146,6 +157,37 @@ func TestGetProxyInfoSurfacesNonFatalPersistenceWarning(t *testing.T) {
 	}
 	if info.PersistenceWarning == nil || !strings.Contains(*info.PersistenceWarning, "may change next launch") {
 		t.Fatalf("missing persistence warning: %+v", info)
+	}
+}
+
+// With no override, the endpoint is chosen once and then reused: the desktop
+// app must offer the same address on the next launch, since users configure it
+// in a browser. The engine reaches the store through its persistence hook —
+// there is no separate port-resolution callback to wire.
+func TestGetProxyInfoReusesThePersistedEndpointOnTheNextLaunch(t *testing.T) {
+	t.Setenv(proxyconfig.PortEnv, "")
+	dir := t.TempDir()
+
+	first := withStore(New(), clientstate.NewInDir(dir))
+	info, err := first.GetProxyInfo()
+	if err != nil {
+		t.Fatalf("first launch: %v", err)
+	}
+	if info.Port <= 0 {
+		t.Fatalf("no endpoint allocated: %+v", info)
+	}
+	if info.PersistenceWarning != nil {
+		t.Fatalf("writable store still warned: %s", *info.PersistenceWarning)
+	}
+
+	// A second Service over the same directory stands in for the next launch.
+	next := withStore(New(), clientstate.NewInDir(dir))
+	again, err := next.GetProxyInfo()
+	if err != nil {
+		t.Fatalf("next launch: %v", err)
+	}
+	if again.Port != info.Port {
+		t.Fatalf("endpoint changed across launches: %d -> %d", info.Port, again.Port)
 	}
 }
 

--- a/desktop/vpnservice/service_test.go
+++ b/desktop/vpnservice/service_test.go
@@ -128,10 +128,8 @@ func TestGetProxyInfoKeepsEndpointWhenShellHelperCannotBeWritten(t *testing.T) {
 	}
 }
 
-// withStore wires a store the way Startup does: the same value backs the shell
-// helper and the engine's persistence hook, through which the engine resolves
-// the stable port. A test that set only one of the two would no longer be
-// exercising the path the app runs.
+// withStore wires a store the way Startup does: one value backs both the shell
+// helper and the engine's persistence hook.
 func withStore(s *Service, store *clientstate.Store) *Service {
 	s.store = store
 	s.engine.Persistence = storeAdapter{store: store}
@@ -144,8 +142,7 @@ func TestGetProxyInfoSurfacesNonFatalPersistenceWarning(t *testing.T) {
 	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	// A store whose configuration directory cannot be created: resolution still
-	// yields a usable endpoint, and the failure to persist it is a warning.
+	// The configuration directory cannot be created.
 	s := withStore(New(), clientstate.NewInDir(filepath.Join(blocker, "openrung")))
 
 	info, err := s.GetProxyInfo()
@@ -160,10 +157,8 @@ func TestGetProxyInfoSurfacesNonFatalPersistenceWarning(t *testing.T) {
 	}
 }
 
-// With no override, the endpoint is chosen once and then reused: the desktop
-// app must offer the same address on the next launch, since users configure it
-// in a browser. The engine reaches the store through its persistence hook —
-// there is no separate port-resolution callback to wire.
+// The desktop app must offer the same address on the next launch, since users
+// configure it in a browser.
 func TestGetProxyInfoReusesThePersistedEndpointOnTheNextLaunch(t *testing.T) {
 	t.Setenv(proxyconfig.PortEnv, "")
 	dir := t.TempDir()

--- a/internal/connectcore/engine.go
+++ b/internal/connectcore/engine.go
@@ -27,6 +27,7 @@ import (
 	"openrung/internal/client"
 	"openrung/internal/clienttelemetry"
 	"openrung/internal/discovery"
+	"openrung/internal/proxyconfig"
 	"openrung/internal/punch"
 	"openrung/internal/relay"
 )
@@ -210,7 +211,7 @@ func (c *candidateResult) teardown() {
 }
 
 // Engine is the connection engine. The platform hooks (Sink, Persistence,
-// OSProxy, Elevation, ResolveProxyPort) and options must be assigned before
+// OSProxy, Elevation) and options must be assigned before
 // Start or the first Connect; the engine never mutates them. The capture mode
 // is the one setting a host may change later, through SetMode (see mode.go),
 // which the TUI's Settings toggle uses.
@@ -233,10 +234,6 @@ type Engine struct {
 	// TunnelMTU overrides the generated TUN inbound's MTU. Zero keeps the
 	// sing-box config default. Proxy mode has no TUN device and ignores it.
 	TunnelMTU int
-
-	// ResolveProxyPort resolves the stable local proxy port; the engine pins
-	// the first successful resolution for the process (see LocalProxyPort).
-	ResolveProxyPort func() (ProxyPortResolution, error)
 
 	// SingBoxPath overrides the sing-box binary path (defaults to "sing-box"
 	// resolved via PATH). Packaging points this at the bundled binary.
@@ -280,7 +277,7 @@ type Engine struct {
 
 	// proxyPortMu pins only a successfully resolved endpoint for this process.
 	// A transient resolution failure remains retryable on the next call.
-	// ResolveProxyPort persists automatic selections across launches.
+	// Persistence carries automatic selections across launches.
 	proxyPortMu   sync.Mutex
 	proxyPort     int
 	proxyPortWarn error
@@ -912,7 +909,7 @@ func (s *Engine) candidateConfigInput(cand relay.Descriptor, port int) client.Si
 		input.MTU = s.TunnelMTU
 		return input
 	}
-	input.ProxyListenAddress = ProxyHost
+	input.ProxyListenAddress = proxyconfig.Host
 	input.ProxyListenPort = port
 	return input
 }
@@ -1112,7 +1109,7 @@ func (s *Engine) applyProxy(conn *connection, port int) {
 		return
 	}
 	if s.OSProxy == nil || !s.OSProxy.Supported() {
-		s.appendLog(fmt.Sprintf("system proxy unavailable here; set manual proxy %s:%d", ProxyHost, port))
+		s.appendLog(fmt.Sprintf("system proxy unavailable here; set manual proxy %s:%d", proxyconfig.Host, port))
 		return
 	}
 	if !conn.snapshotTaken {
@@ -1130,8 +1127,8 @@ func (s *Engine) applyProxy(conn *connection, port int) {
 	// Mark restoration pending before Set: platform controllers can mutate OS
 	// state and only then fail while notifying applications of the change.
 	conn.proxySet = true
-	if err := s.OSProxy.Set(ProxyHost, port); err != nil {
-		s.appendLog(fmt.Sprintf("system proxy set failed; set manual proxy %s:%d", ProxyHost, port))
+	if err := s.OSProxy.Set(proxyconfig.Host, port); err != nil {
+		s.appendLog(fmt.Sprintf("system proxy set failed; set manual proxy %s:%d", proxyconfig.Host, port))
 		// A failed Set may have partially applied: put the captured setting back
 		// so the user's proxy is never left pointing at us with nothing there.
 		if restoreErr := s.OSProxy.Restore(conn.snapshot); restoreErr != nil {
@@ -1154,7 +1151,7 @@ func (s *Engine) applyProxy(conn *connection, port int) {
 	if s.Persistence != nil {
 		_ = s.Persistence.SaveProxySnapshot(conn.snapshot)
 	}
-	s.appendLog(fmt.Sprintf("proxy listening on %s:%d", ProxyHost, port))
+	s.appendLog(fmt.Sprintf("proxy listening on %s:%d", proxyconfig.Host, port))
 }
 
 // releaseProxy points the OS proxy back at the user's captured setting while

--- a/internal/connectcore/engine_test.go
+++ b/internal/connectcore/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"openrung/internal/client"
+	"openrung/internal/proxyconfig"
 	"openrung/internal/relay"
 )
 
@@ -343,28 +344,24 @@ func TestFailedStatusCarriesError(t *testing.T) {
 
 func TestLocalProxyPortRetriesAfterResolutionFailure(t *testing.T) {
 	s := New()
-	fail := true
-	next := 46685
-	s.ResolveProxyPort = func() (ProxyPortResolution, error) {
-		if fail {
-			return ProxyPortResolution{}, errors.New("resolution unavailable")
-		}
-		port := next
-		next++ // a later resolution would hand out a different endpoint
-		return ProxyPortResolution{Port: port}, nil
-	}
+	s.Persistence = &fakePersistence{}
+
+	// An unusable override is the real transient failure: resolution reports it
+	// and pins nothing, so correcting it and calling again still works.
+	t.Setenv(proxyconfig.PortEnv, "not-a-port")
 	if _, err := s.LocalProxyPort(); err == nil {
 		t.Fatal("first failed resolution unexpectedly succeeded")
 	}
 
-	fail = false
+	t.Setenv(proxyconfig.PortEnv, "46685")
 	port, err := s.LocalProxyPort()
 	if err != nil || port != 46685 {
 		t.Fatalf("retry = %d, %v; want 46685, nil", port, err)
 	}
 
-	// Once resolution succeeds, later calls keep that endpoint even though the
-	// resolver would now hand out a different one.
+	// Once resolution succeeds, later calls keep that endpoint even though
+	// resolving again would now hand out a different one.
+	t.Setenv(proxyconfig.PortEnv, "46686")
 	pinned, err := s.LocalProxyPort()
 	if err != nil || pinned != port {
 		t.Fatalf("successful endpoint was not pinned: %d, %v", pinned, err)
@@ -402,12 +399,23 @@ func (f *fakeProxyController) Restore(snap OSProxySnapshot) error {
 	return f.restoreErr
 }
 
-// fakePersistence is an in-memory Persistence for engine tests.
+// fakePersistence is an in-memory Persistence for engine tests. It counts the
+// proxy-port calls so a test can assert the engine consulted persistence, or
+// (in TUN mode) that it never did.
 type fakePersistence struct {
 	mu      sync.Mutex
 	recents []RecentNode
 	snap    OSProxySnapshot
 	hasSnap bool
+
+	port int // the persisted port; 0 means none stored yet
+	// winner stands in for another process that persisted first between this
+	// one's load and its save: the locked store then reports that port instead
+	// of the candidate offered.
+	winner    int
+	saveErr   error
+	loadCalls int
+	saveCalls int
 }
 
 func (f *fakePersistence) LoadRecents() []RecentNode {
@@ -421,6 +429,36 @@ func (f *fakePersistence) SaveRecents(recents []RecentNode) error {
 	defer f.mu.Unlock()
 	f.recents = append([]RecentNode(nil), recents...)
 	return nil
+}
+
+func (f *fakePersistence) LoadProxyPort() (int, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.loadCalls++
+	return f.port, f.port != 0
+}
+
+// LoadOrSaveProxyPort mirrors the real store: the first writer wins and every
+// later caller is told the winner, so concurrent first launches agree.
+func (f *fakePersistence) LoadOrSaveProxyPort(candidate int) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.saveCalls++
+	if f.saveErr != nil {
+		return 0, f.saveErr
+	}
+	if f.winner != 0 {
+		f.port = f.winner
+	} else if f.port == 0 {
+		f.port = candidate
+	}
+	return f.port, nil
+}
+
+func (f *fakePersistence) portCalls() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.loadCalls, f.saveCalls
 }
 
 func (f *fakePersistence) SaveProxySnapshot(snap OSProxySnapshot) error {

--- a/internal/connectcore/engine_test.go
+++ b/internal/connectcore/engine_test.go
@@ -346,8 +346,7 @@ func TestLocalProxyPortRetriesAfterResolutionFailure(t *testing.T) {
 	s := New()
 	s.Persistence = &fakePersistence{}
 
-	// An unusable override is the real transient failure: resolution reports it
-	// and pins nothing, so correcting it and calling again still works.
+	// An unusable override reports an error and pins nothing.
 	t.Setenv(proxyconfig.PortEnv, "not-a-port")
 	if _, err := s.LocalProxyPort(); err == nil {
 		t.Fatal("first failed resolution unexpectedly succeeded")
@@ -359,8 +358,7 @@ func TestLocalProxyPortRetriesAfterResolutionFailure(t *testing.T) {
 		t.Fatalf("retry = %d, %v; want 46685, nil", port, err)
 	}
 
-	// Once resolution succeeds, later calls keep that endpoint even though
-	// resolving again would now hand out a different one.
+	// Later calls keep that endpoint even though resolving again would not.
 	t.Setenv(proxyconfig.PortEnv, "46686")
 	pinned, err := s.LocalProxyPort()
 	if err != nil || pinned != port {
@@ -399,9 +397,7 @@ func (f *fakeProxyController) Restore(snap OSProxySnapshot) error {
 	return f.restoreErr
 }
 
-// fakePersistence is an in-memory Persistence for engine tests. It counts the
-// proxy-port calls so a test can assert the engine consulted persistence, or
-// (in TUN mode) that it never did.
+// fakePersistence is an in-memory Persistence for engine tests.
 type fakePersistence struct {
 	mu      sync.Mutex
 	recents []RecentNode
@@ -409,9 +405,8 @@ type fakePersistence struct {
 	hasSnap bool
 
 	port int // the persisted port; 0 means none stored yet
-	// winner stands in for another process that persisted first between this
-	// one's load and its save: the locked store then reports that port instead
-	// of the candidate offered.
+	// winner stands in for another process that persisted first, which the
+	// locked store reports instead of the candidate offered.
 	winner    int
 	saveErr   error
 	loadCalls int
@@ -438,8 +433,6 @@ func (f *fakePersistence) LoadProxyPort() (int, bool) {
 	return f.port, f.port != 0
 }
 
-// LoadOrSaveProxyPort mirrors the real store: the first writer wins and every
-// later caller is told the winner, so concurrent first launches agree.
 func (f *fakePersistence) LoadOrSaveProxyPort(candidate int) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/connectcore/interfaces.go
+++ b/internal/connectcore/interfaces.go
@@ -86,10 +86,16 @@ type Notice struct {
 }
 
 // Persistence stores the small pieces of client state the engine reads and
-// writes across sessions: the "recents" row and, while connected, the OS
-// proxy snapshot used to recover after a crash. A nil Persistence disables
-// persistence; the engine still runs (recents are session-local, crash
-// recovery is skipped).
+// writes across sessions: the "recents" row, the stable local proxy port, and,
+// while connected, the OS proxy snapshot used to recover after a crash. A nil
+// Persistence disables persistence; the engine still runs (recents are
+// session-local, crash recovery is skipped, and the local endpoint is picked
+// fresh each launch with a warning).
+//
+// The proxy-port half is exactly proxyconfig.PortStore, which is how the
+// engine resolves its endpoint through the shared policy without a
+// host-supplied callback: hosts implement this one hook and the engine passes
+// it straight through (see LocalProxyPort).
 type Persistence interface {
 	// LoadRecents returns the persisted recents (newest first), or an empty
 	// slice when none are stored or the data is unreadable — recents are a
@@ -97,6 +103,13 @@ type Persistence interface {
 	LoadRecents() []RecentNode
 	// SaveRecents persists the recents list (best-effort).
 	SaveRecents(recents []RecentNode) error
+	// LoadProxyPort returns the persisted stable local proxy port and whether
+	// one was stored.
+	LoadProxyPort() (int, bool)
+	// LoadOrSaveProxyPort persists candidate and returns the port that won —
+	// another process's choice when two first launches race, so every process
+	// agrees on the endpoint.
+	LoadOrSaveProxyPort(candidate int) (int, error)
 	// SaveProxySnapshot persists the OS proxy snapshot captured before a
 	// connect, so a crash mid-session can be cleaned up on the next launch.
 	SaveProxySnapshot(snap OSProxySnapshot) error

--- a/internal/connectcore/interfaces.go
+++ b/internal/connectcore/interfaces.go
@@ -91,11 +91,6 @@ type Notice struct {
 // Persistence disables persistence; the engine still runs (recents are
 // session-local, crash recovery is skipped, and the local endpoint is picked
 // fresh each launch with a warning).
-//
-// The proxy-port half is exactly proxyconfig.PortStore, which is how the
-// engine resolves its endpoint through the shared policy without a
-// host-supplied callback: hosts implement this one hook and the engine passes
-// it straight through (see LocalProxyPort).
 type Persistence interface {
 	// LoadRecents returns the persisted recents (newest first), or an empty
 	// slice when none are stored or the data is unreadable — recents are a
@@ -103,8 +98,6 @@ type Persistence interface {
 	LoadRecents() []RecentNode
 	// SaveRecents persists the recents list (best-effort).
 	SaveRecents(recents []RecentNode) error
-	// LoadProxyPort returns the persisted stable local proxy port and whether
-	// one was stored.
 	LoadProxyPort() (int, bool)
 	// LoadOrSaveProxyPort persists candidate and returns the port that won —
 	// another process's choice when two first launches race, so every process

--- a/internal/connectcore/ladder_test.go
+++ b/internal/connectcore/ladder_test.go
@@ -89,11 +89,8 @@ func newLadderService(t *testing.T, relays func() []relay.Descriptor) (*Engine, 
 	s.Sink = sink
 	s.PunchEnabled = false
 	s.OSProxy = &fakeProxyController{supported: false}
-	// No Persistence: the engine resolves its endpoint through the real
-	// proxyconfig policy, which with no store allocates a fresh kernel-selected
-	// loopback port (and warns that it will not survive the next launch). Tests
-	// asserting endpoint stability are therefore exercising the engine's own
-	// pinning.
+	// No Persistence: each engine allocates a fresh loopback port, so tests
+	// asserting endpoint stability exercise the engine's own pinning.
 	s.fetchRelays = func(ctx context.Context, brokerURL string, limit int, clientID, sessionID string) (discovery.Fetch, error) {
 		return discovery.Fetch{BrokerURL: brokerURL, Response: listOf(relays()...)}, nil
 	}

--- a/internal/connectcore/ladder_test.go
+++ b/internal/connectcore/ladder_test.go
@@ -16,6 +16,7 @@ import (
 
 	"openrung/internal/clienttelemetry"
 	"openrung/internal/discovery"
+	"openrung/internal/proxyconfig"
 	"openrung/internal/relay"
 )
 
@@ -73,21 +74,6 @@ func relayAt(id, countryCode, city, country, host string) relay.Descriptor {
 	return r
 }
 
-// allocateTestProxyPort stands in for desktop port resolution: a fresh
-// kernel-selected loopback port on every call, so a test that asserts endpoint
-// stability is exercising the engine's pinning, not the resolver.
-func allocateTestProxyPort() (ProxyPortResolution, error) {
-	listener, err := net.Listen("tcp", ProxyHost+":0")
-	if err != nil {
-		return ProxyPortResolution{}, err
-	}
-	port := listener.Addr().(*net.TCPAddr).Port
-	if err := listener.Close(); err != nil {
-		return ProxyPortResolution{}, err
-	}
-	return ProxyPortResolution{Port: port}, nil
-}
-
 // newLadderService builds an Engine with every network seam faked out; the
 // returned engine still runs the real ladder, telemetry manager, and state
 // machine.
@@ -103,7 +89,11 @@ func newLadderService(t *testing.T, relays func() []relay.Descriptor) (*Engine, 
 	s.Sink = sink
 	s.PunchEnabled = false
 	s.OSProxy = &fakeProxyController{supported: false}
-	s.ResolveProxyPort = allocateTestProxyPort
+	// No Persistence: the engine resolves its endpoint through the real
+	// proxyconfig policy, which with no store allocates a fresh kernel-selected
+	// loopback port (and warns that it will not survive the next launch). Tests
+	// asserting endpoint stability are therefore exercising the engine's own
+	// pinning.
 	s.fetchRelays = func(ctx context.Context, brokerURL string, limit int, clientID, sessionID string) (discovery.Fetch, error) {
 		return discovery.Fetch{BrokerURL: brokerURL, Response: listOf(relays()...)}, nil
 	}
@@ -139,7 +129,7 @@ func waitForStatus(t *testing.T, s *Engine, want Status) State {
 func TestRecoveryReportsStableProxyPortCollisionBeforeBlamingRelays(t *testing.T) {
 	fixtures := []relay.Descriptor{relayAt("a", "JP", "Tokyo", "Japan", "127.0.0.10")}
 	s, _ := newLadderService(t, func() []relay.Descriptor { return fixtures })
-	listener, err := net.Listen("tcp", ProxyHost+":0")
+	listener, err := net.Listen("tcp", proxyconfig.Host+":0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +147,7 @@ func TestRecoveryReportsStableProxyPortCollisionBeforeBlamingRelays(t *testing.T
 	if result != nil {
 		result.teardown()
 	}
-	if err == nil || stage != "proxy_bind" || !strings.Contains(err.Error(), ProxyPortEnv) {
+	if err == nil || stage != "proxy_bind" || !strings.Contains(err.Error(), proxyconfig.PortEnv) {
 		t.Fatalf("reladder = result=%v stage=%q err=%v; want proxy_bind collision", result, stage, err)
 	}
 	if tunnelStarted.Load() {
@@ -170,7 +160,7 @@ func TestInitialConnectRechecksStableProxyPortAfterDiscovery(t *testing.T) {
 	fixtures := []relay.Descriptor{relayAt("a", "JP", "Tokyo", "Japan", "127.0.0.10")}
 	s, _ := newLadderService(t, func() []relay.Descriptor { return fixtures })
 
-	reservation, err := net.Listen("tcp", ProxyHost+":0")
+	reservation, err := net.Listen("tcp", proxyconfig.Host+":0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,16 +168,13 @@ func TestInitialConnectRechecksStableProxyPortAfterDiscovery(t *testing.T) {
 	if err := reservation.Close(); err != nil {
 		t.Fatal(err)
 	}
-	// The stable endpoint resolves to a fixed port, standing in for a desktop
-	// OPENRUNG_PROXY_PORT override.
-	s.ResolveProxyPort = func() (ProxyPortResolution, error) {
-		return ProxyPortResolution{Port: port}, nil
-	}
+	// The stable endpoint resolves to a fixed port through the real override.
+	t.Setenv(proxyconfig.PortEnv, strconv.Itoa(port))
 
 	var claimed net.Listener
 	s.fetchRelays = func(ctx context.Context, brokerURL string, limit int, clientID, sessionID string) (discovery.Fetch, error) {
 		var listenErr error
-		claimed, listenErr = net.Listen("tcp", net.JoinHostPort(ProxyHost, strconv.Itoa(port)))
+		claimed, listenErr = net.Listen("tcp", net.JoinHostPort(proxyconfig.Host, strconv.Itoa(port)))
 		if listenErr != nil {
 			return discovery.Fetch{}, listenErr
 		}
@@ -210,7 +197,7 @@ func TestInitialConnectRechecksStableProxyPortAfterDiscovery(t *testing.T) {
 	}
 	state := waitForStatus(t, s, StatusFailed)
 	waitIdle(t, s)
-	if state.LastError == nil || !strings.Contains(*state.LastError, ProxyPortEnv) {
+	if state.LastError == nil || !strings.Contains(*state.LastError, proxyconfig.PortEnv) {
 		t.Fatalf("lastError = %v; want stable proxy collision", state.LastError)
 	}
 	if tunnelStarted.Load() {

--- a/internal/connectcore/proxyport.go
+++ b/internal/connectcore/proxyport.go
@@ -1,73 +1,73 @@
 package connectcore
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
+
+	"openrung/internal/proxyconfig"
 )
 
-// The generic pieces of the stable local proxy endpoint, moved from
-// desktop/proxyconfig (docs/adr/001 PR A1): the engine owns the loopback
-// host, the override env name, the pre-ladder bind check, and the per-process
-// pinning of a resolved port. Resolution itself (env override, persisted
-// port, shell helper) stays behind ResolveProxyPort, in the shared
-// internal/proxyconfig package (PR A3).
+// The engine's use of the stable local proxy endpoint. internal/proxyconfig
+// owns the endpoint itself — the loopback host, the OPENRUNG_PROXY_PORT
+// override, the port-validity rule, and the resolution policy (env override,
+// persisted port, fresh allocation). What lives here is the engine's own
+// policy on top of it: when to check the port is free, and pinning a resolved
+// endpoint for the process.
 
-const (
-	// ProxyHost is intentionally fixed to IPv4 loopback. The mixed HTTP/SOCKS
-	// inbound has no authentication and must never become a LAN-facing proxy.
-	ProxyHost = "127.0.0.1"
-	// ProxyPortEnv is the supported process-level override for the stable port.
-	ProxyPortEnv = "OPENRUNG_PROXY_PORT"
-)
-
-// ProxyPortResolution separates a usable process-local endpoint from a
-// non-fatal persistence warning. Losing persistence must never prevent
-// access, but the UI should not promise restart stability when saving failed.
-type ProxyPortResolution struct {
-	Port               int
-	PersistenceWarning error
-}
+// Persistence carries proxyconfig's port-store shape, which is what lets
+// LocalProxyPort hand the engine's own storage hook straight to the shared
+// resolution policy instead of taking a callback from each host.
+var _ proxyconfig.PortStore = Persistence(nil)
 
 // EnsureProxyPortAvailable performs an early, actionable bind check before
 // relay discovery. It deliberately does not choose another port: silently
 // rotating a stable endpoint would break browser and shell configuration. As
 // before, sing-box's later bind retains a small bind-and-close race window.
 func EnsureProxyPortAvailable(port int) error {
-	if !validPort(port) {
+	if !proxyconfig.ValidPort(port) {
 		return fmt.Errorf("proxy port %d is outside 1..65535", port)
 	}
-	listener, err := net.Listen("tcp", net.JoinHostPort(ProxyHost, strconv.Itoa(port)))
+	listener, err := net.Listen("tcp", net.JoinHostPort(proxyconfig.Host, strconv.Itoa(port)))
 	if err != nil {
-		return fmt.Errorf("local proxy port %d is unavailable; set %s to another unused port: %w", port, ProxyPortEnv, err)
+		return fmt.Errorf("local proxy port %d is unavailable; set %s to another unused port: %w", port, proxyconfig.PortEnv, err)
 	}
 	return listener.Close()
 }
 
-func validPort(port int) bool {
-	return port >= 1 && port <= 65535
-}
-
-// LocalProxyPort resolves the stable endpoint through ResolveProxyPort,
-// pinning only a successfully resolved endpoint for this process. A transient
-// resolution failure remains retryable on the next call.
+// LocalProxyPort resolves the stable endpoint through proxyconfig, pinning
+// only a successfully resolved endpoint for this process. A transient
+// resolution failure (an unusable override, an allocation that failed) remains
+// retryable on the next call.
+//
+// Persistence is the engine's one storage hook and satisfies
+// proxyconfig.PortStore, so it is handed over as-is: a nil hook means no
+// configuration directory, which resolves to a fresh port plus the non-fatal
+// warning that it may change next launch.
 func (s *Engine) LocalProxyPort() (int, error) {
 	s.proxyPortMu.Lock()
 	defer s.proxyPortMu.Unlock()
 	if s.proxyPort != 0 {
 		return s.proxyPort, nil
 	}
-	if s.ResolveProxyPort == nil {
-		return 0, errors.New("no local proxy port resolver configured")
-	}
-	resolution, err := s.ResolveProxyPort()
+	resolution, err := proxyconfig.ResolvePort(s.portStore())
 	if err != nil {
 		return 0, err
 	}
 	s.proxyPort = resolution.Port
 	s.proxyPortWarn = resolution.PersistenceWarning
 	return s.proxyPort, nil
+}
+
+// portStore narrows the persistence hook to the half proxyconfig needs. The
+// explicit nil check keeps a nil Persistence a nil interface rather than a
+// non-nil one holding a nil value, which proxyconfig's own nil check could not
+// see through.
+func (s *Engine) portStore() proxyconfig.PortStore {
+	if s.Persistence == nil {
+		return nil
+	}
+	return s.Persistence
 }
 
 // LocalProxyPortWarning returns the pinned resolution's non-fatal persistence

--- a/internal/connectcore/proxyport.go
+++ b/internal/connectcore/proxyport.go
@@ -8,16 +8,9 @@ import (
 	"openrung/internal/proxyconfig"
 )
 
-// The engine's use of the stable local proxy endpoint. internal/proxyconfig
-// owns the endpoint itself — the loopback host, the OPENRUNG_PROXY_PORT
-// override, the port-validity rule, and the resolution policy (env override,
-// persisted port, fresh allocation). What lives here is the engine's own
-// policy on top of it: when to check the port is free, and pinning a resolved
-// endpoint for the process.
+// internal/proxyconfig owns the endpoint and its resolution policy; the engine
+// adds only when to check the port is free and how long a resolution sticks.
 
-// Persistence carries proxyconfig's port-store shape, which is what lets
-// LocalProxyPort hand the engine's own storage hook straight to the shared
-// resolution policy instead of taking a callback from each host.
 var _ proxyconfig.PortStore = Persistence(nil)
 
 // EnsureProxyPortAvailable performs an early, actionable bind check before
@@ -35,15 +28,10 @@ func EnsureProxyPortAvailable(port int) error {
 	return listener.Close()
 }
 
-// LocalProxyPort resolves the stable endpoint through proxyconfig, pinning
-// only a successfully resolved endpoint for this process. A transient
-// resolution failure (an unusable override, an allocation that failed) remains
-// retryable on the next call.
-//
-// Persistence is the engine's one storage hook and satisfies
-// proxyconfig.PortStore, so it is handed over as-is: a nil hook means no
-// configuration directory, which resolves to a fresh port plus the non-fatal
-// warning that it may change next launch.
+// LocalProxyPort pins only a successfully resolved endpoint for this process,
+// so a transient failure (an unusable override, a failed allocation) stays
+// retryable on the next call. A nil Persistence means no configuration
+// directory: a fresh port plus a non-fatal warning that it may change.
 func (s *Engine) LocalProxyPort() (int, error) {
 	s.proxyPortMu.Lock()
 	defer s.proxyPortMu.Unlock()
@@ -59,10 +47,8 @@ func (s *Engine) LocalProxyPort() (int, error) {
 	return s.proxyPort, nil
 }
 
-// portStore narrows the persistence hook to the half proxyconfig needs. The
-// explicit nil check keeps a nil Persistence a nil interface rather than a
-// non-nil one holding a nil value, which proxyconfig's own nil check could not
-// see through.
+// portStore must return a nil interface, never a nil pointer inside one, which
+// proxyconfig's nil check cannot see through.
 func (s *Engine) portStore() proxyconfig.PortStore {
 	if s.Persistence == nil {
 		return nil

--- a/internal/connectcore/proxyport_test.go
+++ b/internal/connectcore/proxyport_test.go
@@ -1,18 +1,21 @@
 package connectcore
 
 import (
+	"errors"
 	"net"
 	"strings"
 	"testing"
+
+	"openrung/internal/proxyconfig"
 )
 
 func TestEnsureProxyPortAvailableReportsStablePortCollision(t *testing.T) {
-	listener, err := net.Listen("tcp", ProxyHost+":0")
+	listener, err := net.Listen("tcp", proxyconfig.Host+":0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
-	if err := EnsureProxyPortAvailable(port); err == nil || !strings.Contains(err.Error(), ProxyPortEnv) {
+	if err := EnsureProxyPortAvailable(port); err == nil || !strings.Contains(err.Error(), proxyconfig.PortEnv) {
 		t.Fatalf("occupied port error = %v", err)
 	}
 	if err := listener.Close(); err != nil {
@@ -20,5 +23,118 @@ func TestEnsureProxyPortAvailableReportsStablePortCollision(t *testing.T) {
 	}
 	if err := EnsureProxyPortAvailable(port); err != nil {
 		t.Fatalf("released port still unavailable: %v", err)
+	}
+}
+
+// The engine resolves its endpoint through proxyconfig using its own
+// Persistence hook, with no host-supplied callback in between. These pin the
+// invariants that survived collapsing that seam.
+
+// An explicit override is this launch's choice, not the installation's: it
+// wins over anything stored and is never written back.
+func TestLocalProxyPortOverrideWinsAndIsNotPersisted(t *testing.T) {
+	store := &fakePersistence{port: 51000}
+	s := New()
+	s.Persistence = store
+	t.Setenv(proxyconfig.PortEnv, "46685")
+
+	port, err := s.LocalProxyPort()
+	if err != nil || port != 46685 {
+		t.Fatalf("LocalProxyPort = %d, %v; want the override", port, err)
+	}
+	if _, saves := store.portCalls(); saves != 0 {
+		t.Fatalf("override was persisted (%d saves)", saves)
+	}
+	if store.port != 51000 {
+		t.Fatalf("override overwrote the stored port: %d", store.port)
+	}
+	if warning := s.LocalProxyPortWarning(); warning != nil {
+		t.Fatalf("override reported a persistence warning: %v", warning)
+	}
+}
+
+// Automatic selection is stable across launches and across processes: the
+// first launch allocates and persists, and every later engine — in this or
+// another process — is handed the same endpoint by the store.
+func TestLocalProxyPortAutomaticSelectionIsStableAcrossEngines(t *testing.T) {
+	t.Setenv(proxyconfig.PortEnv, "")
+	store := &fakePersistence{}
+
+	first := New()
+	first.Persistence = store
+	allocated, err := first.LocalProxyPort()
+	if err != nil {
+		t.Fatalf("first resolution: %v", err)
+	}
+	if store.port != allocated {
+		t.Fatalf("first launch persisted %d but returned %d", store.port, allocated)
+	}
+	if warning := first.LocalProxyPortWarning(); warning != nil {
+		t.Fatalf("successful persistence still warned: %v", warning)
+	}
+
+	// A second engine over the same store stands in for the next launch.
+	second := New()
+	second.Persistence = store
+	reused, err := second.LocalProxyPort()
+	if err != nil || reused != allocated {
+		t.Fatalf("next launch = %d, %v; want the persisted %d", reused, err, allocated)
+	}
+}
+
+// Two first launches at once must not end up on different endpoints. The store
+// is nothing to load from when each of them looks, so both allocate; the
+// locked save reports whichever landed first, and the loser adopts it.
+func TestLocalProxyPortAdoptsAnotherProcessWinner(t *testing.T) {
+	t.Setenv(proxyconfig.PortEnv, "")
+	store := &fakePersistence{winner: 51234}
+
+	s := New()
+	s.Persistence = store
+	port, err := s.LocalProxyPort()
+	if err != nil {
+		t.Fatalf("resolution: %v", err)
+	}
+	if port != 51234 {
+		t.Fatalf("kept its own allocation %d instead of the store's winner 51234", port)
+	}
+	if warning := s.LocalProxyPortWarning(); warning != nil {
+		t.Fatalf("losing the race warned: %v", warning)
+	}
+}
+
+// Losing persistence must never deny access: the endpoint still resolves and
+// stays put for this process, and the failure is reported as a warning beside
+// it rather than as an error.
+func TestLocalProxyPortPersistenceFailureIsANonFatalWarning(t *testing.T) {
+	t.Setenv(proxyconfig.PortEnv, "")
+
+	for name, engine := range map[string]*Engine{
+		"no configuration directory": func() *Engine {
+			s := New() // nil Persistence
+			return s
+		}(),
+		"unwritable store": func() *Engine {
+			s := New()
+			s.Persistence = &fakePersistence{saveErr: errors.New("read-only config directory")}
+			return s
+		}(),
+	} {
+		port, err := engine.LocalProxyPort()
+		if err != nil {
+			t.Fatalf("%s: resolution failed instead of warning: %v", name, err)
+		}
+		if !proxyconfig.ValidPort(port) {
+			t.Fatalf("%s: unusable port %d", name, port)
+		}
+		warning := engine.LocalProxyPortWarning()
+		if warning == nil || !strings.Contains(warning.Error(), "may change next launch") {
+			t.Fatalf("%s: warning = %v", name, warning)
+		}
+		// Still pinned for this process, so the endpoint a user configured in a
+		// browser keeps working for the life of the session.
+		if again, _ := engine.LocalProxyPort(); again != port {
+			t.Fatalf("%s: endpoint moved within the process: %d then %d", name, port, again)
+		}
 	}
 }

--- a/internal/connectcore/proxyport_test.go
+++ b/internal/connectcore/proxyport_test.go
@@ -26,12 +26,8 @@ func TestEnsureProxyPortAvailableReportsStablePortCollision(t *testing.T) {
 	}
 }
 
-// The engine resolves its endpoint through proxyconfig using its own
-// Persistence hook, with no host-supplied callback in between. These pin the
-// invariants that survived collapsing that seam.
-
-// An explicit override is this launch's choice, not the installation's: it
-// wins over anything stored and is never written back.
+// An override is this launch's choice, not the installation's: it wins over
+// anything stored and is never written back.
 func TestLocalProxyPortOverrideWinsAndIsNotPersisted(t *testing.T) {
 	store := &fakePersistence{port: 51000}
 	s := New()
@@ -53,9 +49,8 @@ func TestLocalProxyPortOverrideWinsAndIsNotPersisted(t *testing.T) {
 	}
 }
 
-// Automatic selection is stable across launches and across processes: the
-// first launch allocates and persists, and every later engine — in this or
-// another process — is handed the same endpoint by the store.
+// Without an override the endpoint is chosen once and reused on later
+// launches.
 func TestLocalProxyPortAutomaticSelectionIsStableAcrossEngines(t *testing.T) {
 	t.Setenv(proxyconfig.PortEnv, "")
 	store := &fakePersistence{}
@@ -82,9 +77,8 @@ func TestLocalProxyPortAutomaticSelectionIsStableAcrossEngines(t *testing.T) {
 	}
 }
 
-// Two first launches at once must not end up on different endpoints. The store
-// is nothing to load from when each of them looks, so both allocate; the
-// locked save reports whichever landed first, and the loser adopts it.
+// Two simultaneous first launches must not end up on different endpoints: both
+// allocate, and the one that loses the locked save adopts the winner's port.
 func TestLocalProxyPortAdoptsAnotherProcessWinner(t *testing.T) {
 	t.Setenv(proxyconfig.PortEnv, "")
 	store := &fakePersistence{winner: 51234}
@@ -103,9 +97,8 @@ func TestLocalProxyPortAdoptsAnotherProcessWinner(t *testing.T) {
 	}
 }
 
-// Losing persistence must never deny access: the endpoint still resolves and
-// stays put for this process, and the failure is reported as a warning beside
-// it rather than as an error.
+// Losing persistence must never deny access: the endpoint still resolves, stays
+// put for this process, and reports a warning rather than an error.
 func TestLocalProxyPortPersistenceFailureIsANonFatalWarning(t *testing.T) {
 	t.Setenv(proxyconfig.PortEnv, "")
 

--- a/internal/connectcore/tun_test.go
+++ b/internal/connectcore/tun_test.go
@@ -110,10 +110,8 @@ func TestTUNConnectSkipsProxyPortAndOSProxy(t *testing.T) {
 	s.Elevation = permitElevation{}
 	proxy := &fakeProxyController{supported: true}
 	s.OSProxy = proxy
-	s.ResolveProxyPort = func() (ProxyPortResolution, error) {
-		t.Error("TUN mode resolved the stable proxy port")
-		return ProxyPortResolution{}, errors.New("unreachable")
-	}
+	store := &fakePersistence{}
+	s.Persistence = store
 	if err := s.SetMode(ModeTUN); err != nil {
 		t.Fatal(err)
 	}
@@ -135,6 +133,11 @@ func TestTUNConnectSkipsProxyPortAndOSProxy(t *testing.T) {
 	}
 	if proxy.sets != 0 {
 		t.Fatalf("TUN mode set the OS proxy %d times", proxy.sets)
+	}
+	// The stable endpoint is never resolved, so TUN mode also never allocates
+	// or persists a port for a listener that will not exist.
+	if loads, saves := store.portCalls(); loads != 0 || saves != 0 {
+		t.Fatalf("TUN mode touched proxy-port persistence: %d loads, %d saves", loads, saves)
 	}
 
 	// The generated config is the unchanged full-device TUN shape.

--- a/internal/connectcore/tun_test.go
+++ b/internal/connectcore/tun_test.go
@@ -134,8 +134,8 @@ func TestTUNConnectSkipsProxyPortAndOSProxy(t *testing.T) {
 	if proxy.sets != 0 {
 		t.Fatalf("TUN mode set the OS proxy %d times", proxy.sets)
 	}
-	// The stable endpoint is never resolved, so TUN mode also never allocates
-	// or persists a port for a listener that will not exist.
+	// TUN mode never allocates or persists a port for a listener that will not
+	// exist.
 	if loads, saves := store.portCalls(); loads != 0 || saves != 0 {
 		t.Fatalf("TUN mode touched proxy-port persistence: %d loads, %d saves", loads, saves)
 	}

--- a/internal/connectcore/wss.go
+++ b/internal/connectcore/wss.go
@@ -15,6 +15,7 @@ import (
 
 	"openrung/internal/client"
 	"openrung/internal/clienttelemetry"
+	"openrung/internal/proxyconfig"
 	"openrung/internal/relay"
 )
 
@@ -311,7 +312,7 @@ func (s *Engine) attemptWSSCandidate(
 	s.appendLog(fmt.Sprintf("connected through WSS front %s", front.ID))
 	return s.startCandidate(result, client.SingBoxConfigInput{
 		Relay: candidate, Mode: client.ModeProxy,
-		ProxyListenAddress: ProxyHost, ProxyListenPort: proxyPort,
+		ProxyListenAddress: proxyconfig.Host, ProxyListenPort: proxyPort,
 		BridgeHost: ip.String(), BridgePort: port,
 	})
 }

--- a/internal/proxyconfig/proxyconfig.go
+++ b/internal/proxyconfig/proxyconfig.go
@@ -11,23 +11,52 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	"openrung/internal/clientstate"
-	"openrung/internal/connectcore"
 )
 
 const (
-	// Host and PortEnv are owned by the connection engine (which fixes the
-	// listen address to IPv4 loopback and honors the override before its bind
-	// check); re-exported here so the shell helper and resolution stay in
-	// lockstep with the endpoint the engine actually binds.
-	Host    = connectcore.ProxyHost
-	PortEnv = connectcore.ProxyPortEnv
+	// Host is the local proxy's listen address, and is intentionally fixed to
+	// IPv4 loopback: the mixed HTTP/SOCKS inbound has no authentication, so a
+	// LAN-facing bind address would turn the client into an open proxy.
+	Host = "127.0.0.1"
+	// PortEnv is the supported process-level override for the stable port. An
+	// explicit value wins over the persisted one and is never persisted itself
+	// (see ResolvePort).
+	PortEnv = "OPENRUNG_PROXY_PORT"
 	// ShellProxyEnv marks an environment activated by OpenRung's generated
 	// helper. A child OpenRung process uses it to avoid proxying its own
 	// bootstrap requests through the not-yet-listening local endpoint.
 	ShellProxyEnv = "OPENRUNG_SHELL_PROXY"
 )
+
+// This package is the single owner of the stable local endpoint: the host, the
+// override variable, the port-validity rule, and the resolution policy. It
+// depends on no other openrung package, so the connection engine can resolve
+// its endpoint through it directly rather than through a host-supplied
+// callback (docs/adr/001; the callback seam and the constant re-export that
+// forced it are gone).
+
+// PortStore is the persistence ResolvePort needs, and HelperStore the
+// persistence WriteShellHelper needs. Both are satisfied by
+// *clientstate.Store; keeping them as interfaces here is what lets the engine
+// pass its own persistence hook straight through without this package
+// depending on the concrete store.
+//
+// A caller with no usable configuration directory passes a nil interface —
+// never a nil *clientstate.Store, which would be a non-nil interface holding a
+// nil pointer and would defeat the nil checks below.
+type PortStore interface {
+	// LoadProxyPort returns the persisted port and whether one was stored.
+	LoadProxyPort() (int, bool)
+	// LoadOrSaveProxyPort persists candidate and returns the port that won,
+	// which is another process's choice when two first launches race.
+	LoadOrSaveProxyPort(candidate int) (int, error)
+}
+
+type HelperStore interface {
+	// SaveProxyEnvScript writes the port-qualified shell helper and returns
+	// its path.
+	SaveProxyEnvScript(port int, script []byte) (string, error)
+}
 
 // Info is the user-facing local proxy configuration. The shell commands are
 // copyable: EnableCommand sources the generated helper and activates it in the
@@ -52,16 +81,18 @@ type PortResolution struct {
 // ResolvePort selects one port for this installation. An explicit environment
 // override wins but is not persisted; otherwise the stored port is reused, or
 // a kernel-selected loopback port is allocated and saved for future launches.
-func ResolvePort(store *clientstate.Store) (PortResolution, error) {
+func ResolvePort(store PortStore) (PortResolution, error) {
 	return resolvePort(store, os.LookupEnv, freeLoopbackPort)
 }
 
-func resolvePort(store *clientstate.Store, lookupEnv func(string) (string, bool), allocate func() (int, error)) (PortResolution, error) {
+func resolvePort(store PortStore, lookupEnv func(string) (string, bool), allocate func() (int, error)) (PortResolution, error) {
 	if raw, ok := lookupEnv(PortEnv); ok && strings.TrimSpace(raw) != "" {
 		port, err := strconv.Atoi(strings.TrimSpace(raw))
-		if err != nil || !validPort(port) {
+		if err != nil || !ValidPort(port) {
 			return PortResolution{}, fmt.Errorf("%s must be an integer from 1 to 65535 (got %q)", PortEnv, raw)
 		}
+		// An override is deliberately not persisted: it is a property of this
+		// launch, not of the installation.
 		return PortResolution{Port: port}, nil
 	}
 	if store != nil {
@@ -73,7 +104,7 @@ func resolvePort(store *clientstate.Store, lookupEnv func(string) (string, bool)
 	if err != nil {
 		return PortResolution{}, fmt.Errorf("allocate local proxy port: %w", err)
 	}
-	if !validPort(port) {
+	if !ValidPort(port) {
 		return PortResolution{}, fmt.Errorf("allocator returned invalid proxy port %d", port)
 	}
 	resolution := PortResolution{Port: port}
@@ -118,7 +149,7 @@ func SanitizeInheritedProxyEnvironment() {
 		return
 	}
 	port, err := strconv.Atoi(rawPort)
-	if err != nil || !validPort(port) {
+	if err != nil || !ValidPort(port) {
 		return
 	}
 
@@ -141,7 +172,7 @@ func SanitizeInheritedProxyEnvironment() {
 
 // WriteShellHelper writes the sourceable helper for port and returns all
 // display/copy values derived from the same endpoint.
-func WriteShellHelper(store *clientstate.Store, port int) (Info, error) {
+func WriteShellHelper(store HelperStore, port int) (Info, error) {
 	info, err := EndpointInfo(port)
 	if err != nil {
 		return Info{}, err
@@ -165,7 +196,7 @@ func WriteShellHelper(store *clientstate.Store, port int) (Info, error) {
 
 // EndpointInfo returns display metadata without requiring shell-helper I/O.
 func EndpointInfo(port int) (Info, error) {
-	if !validPort(port) {
+	if !ValidPort(port) {
 		return Info{}, fmt.Errorf("proxy port %d is outside 1..65535", port)
 	}
 	return Info{
@@ -184,7 +215,10 @@ func freeLoopbackPort() (int, error) {
 	return listener.Addr().(*net.TCPAddr).Port, nil
 }
 
-func validPort(port int) bool {
+// ValidPort reports whether port is a usable TCP port. It is exported because
+// the connection engine's pre-ladder bind check applies the same rule to the
+// same endpoint.
+func ValidPort(port int) bool {
 	return port >= 1 && port <= 65535
 }
 
@@ -225,7 +259,7 @@ func savedExportedName(variable shellVariable) string {
 }
 
 func shellScript(port int) (string, error) {
-	if !validPort(port) {
+	if !ValidPort(port) {
 		return "", fmt.Errorf("proxy port %d is outside 1..65535", port)
 	}
 	variables := shellVariables(port)

--- a/internal/proxyconfig/proxyconfig.go
+++ b/internal/proxyconfig/proxyconfig.go
@@ -18,9 +18,8 @@ const (
 	// IPv4 loopback: the mixed HTTP/SOCKS inbound has no authentication, so a
 	// LAN-facing bind address would turn the client into an open proxy.
 	Host = "127.0.0.1"
-	// PortEnv is the supported process-level override for the stable port. An
-	// explicit value wins over the persisted one and is never persisted itself
-	// (see ResolvePort).
+	// PortEnv overrides the stable port for one launch: an explicit value wins
+	// over the persisted one and is never persisted itself.
 	PortEnv = "OPENRUNG_PROXY_PORT"
 	// ShellProxyEnv marks an environment activated by OpenRung's generated
 	// helper. A child OpenRung process uses it to avoid proxying its own
@@ -28,24 +27,10 @@ const (
 	ShellProxyEnv = "OPENRUNG_SHELL_PROXY"
 )
 
-// This package is the single owner of the stable local endpoint: the host, the
-// override variable, the port-validity rule, and the resolution policy. It
-// depends on no other openrung package, so the connection engine can resolve
-// its endpoint through it directly rather than through a host-supplied
-// callback (docs/adr/001; the callback seam and the constant re-export that
-// forced it are gone).
-
-// PortStore is the persistence ResolvePort needs, and HelperStore the
-// persistence WriteShellHelper needs. Both are satisfied by
-// *clientstate.Store; keeping them as interfaces here is what lets the engine
-// pass its own persistence hook straight through without this package
-// depending on the concrete store.
-//
-// A caller with no usable configuration directory passes a nil interface —
-// never a nil *clientstate.Store, which would be a non-nil interface holding a
-// nil pointer and would defeat the nil checks below.
+// A caller with no usable configuration directory passes a nil PortStore or
+// HelperStore — never a nil concrete store, which would be a non-nil interface
+// holding a nil pointer and would defeat the nil checks below.
 type PortStore interface {
-	// LoadProxyPort returns the persisted port and whether one was stored.
 	LoadProxyPort() (int, bool)
 	// LoadOrSaveProxyPort persists candidate and returns the port that won,
 	// which is another process's choice when two first launches race.
@@ -53,8 +38,6 @@ type PortStore interface {
 }
 
 type HelperStore interface {
-	// SaveProxyEnvScript writes the port-qualified shell helper and returns
-	// its path.
 	SaveProxyEnvScript(port int, script []byte) (string, error)
 }
 
@@ -91,8 +74,6 @@ func resolvePort(store PortStore, lookupEnv func(string) (string, bool), allocat
 		if err != nil || !ValidPort(port) {
 			return PortResolution{}, fmt.Errorf("%s must be an integer from 1 to 65535 (got %q)", PortEnv, raw)
 		}
-		// An override is deliberately not persisted: it is a property of this
-		// launch, not of the installation.
 		return PortResolution{Port: port}, nil
 	}
 	if store != nil {
@@ -215,9 +196,7 @@ func freeLoopbackPort() (int, error) {
 	return listener.Addr().(*net.TCPAddr).Port, nil
 }
 
-// ValidPort reports whether port is a usable TCP port. It is exported because
-// the connection engine's pre-ladder bind check applies the same rule to the
-// same endpoint.
+// ValidPort reports whether port is a usable TCP port.
 func ValidPort(port int) bool {
 	return port >= 1 && port <= 65535
 }

--- a/internal/proxyconfig/proxyconfig_test.go
+++ b/internal/proxyconfig/proxyconfig_test.go
@@ -14,6 +14,15 @@ import (
 	"openrung/internal/clientstate"
 )
 
+// The real store satisfies both narrow interfaces, which is what keeps this
+// package free of a dependency on it — and with it, free of the import cycle
+// that once forced the loopback host and override constants to be re-exported
+// from the connection engine. Only a test may name clientstate here.
+var (
+	_ PortStore   = (*clientstate.Store)(nil)
+	_ HelperStore = (*clientstate.Store)(nil)
+)
+
 func TestResolvePortUsesEnvironmentOverrideWithoutPersistingIt(t *testing.T) {
 	store := clientstate.NewInDir(t.TempDir())
 	if err := store.SaveProxyPort(41111); err != nil {

--- a/internal/proxyconfig/proxyconfig_test.go
+++ b/internal/proxyconfig/proxyconfig_test.go
@@ -14,10 +14,8 @@ import (
 	"openrung/internal/clientstate"
 )
 
-// The real store satisfies both narrow interfaces, which is what keeps this
-// package free of a dependency on it — and with it, free of the import cycle
-// that once forced the loopback host and override constants to be re-exported
-// from the connection engine. Only a test may name clientstate here.
+// Only a test may name the concrete store: the package itself must not depend
+// on it.
 var (
 	_ PortStore   = (*clientstate.Store)(nil)
 	_ HelperStore = (*clientstate.Store)(nil)


### PR DESCRIPTION
Track B cleanup after ADR-001 B3. No UI or connection behavior changes.

## The knot

`internal/proxyconfig` re-exported `Host` and `PortEnv` from `connectcore`:

```go
Host    = connectcore.ProxyHost
PortEnv = connectcore.ProxyPortEnv
```

That import meant `connectcore` could not import `proxyconfig` back, so the engine could not call the resolution policy it needed. Instead it took a callback, `Engine.ResolveProxyPort func() (ProxyPortResolution, error)`, and each host filled it with the same closure translating `proxyconfig.PortResolution` into the identical `connectcore.ProxyPortResolution` — 10 duplicated lines in `cmd/client/host.go` and 10 more in `desktop/vpnservice/service.go`. `ProxyPortResolution` existed only because the type it mirrors could not be named.

## The untangle

`proxyconfig` is now the outright owner of the stable local endpoint — the loopback host, the override variable, the port-validity rule (`ValidPort`, previously duplicated), and the resolution policy — and imports **no openrung package at all**:

```
$ go list -deps openrung/internal/proxyconfig | grep openrung
openrung/internal/proxyconfig

$ go list -deps openrung/internal/connectcore | grep -E 'proxyconfig|clientstate'
openrung/internal/proxyconfig
```

`connectcore` imports it directly, and the cycle is now structurally impossible rather than merely absent — re-adding the back-edge would not compile.

`Engine.ResolveProxyPort` and `connectcore.ProxyPortResolution` are deleted, along with `connectcore.ProxyHost` and `connectcore.ProxyPortEnv`. `LocalProxyPort` calls `proxyconfig.ResolvePort` with the storage hook the engine already had:

```go
resolution, err := proxyconfig.ResolvePort(s.portStore())
```

## Persistence instead of a second hook

Rather than add a new engine field, the existing `Persistence` interface absorbed the two port methods, making it exactly `proxyconfig.PortStore`. That is the property that lets the engine hand its own hook straight to the shared policy, and it is asserted at compile time so it cannot drift:

```go
var _ proxyconfig.PortStore = Persistence(nil)
```

Hosts now wire **one** thing. Both `storeAdapter`s gained two pass-through methods (`*clientstate.Store` already speaks proxyconfig's shape), and both closures are gone. `proxyconfig`'s entry points take small interfaces — `PortStore` for `ResolvePort`, `HelperStore` for `WriteShellHelper` — so it never names the concrete store; a test asserts `*clientstate.Store` satisfies both.

**One trap this introduced, and how it is handled.** Both hosts previously passed a possibly-nil `*clientstate.Store` to `WriteShellHelper`, relying on its `store == nil` check. Through an interface parameter, a nil pointer becomes a *non-nil* interface and would sail past that check into a nil-receiver panic. Each host now has a `helperStore()` that returns a true nil interface when the config directory is unavailable, and each has a test pinning it.

## Behavior preserved

Every invariant has a test; the ones that were previously implicit are now explicit.

| Invariant | Coverage |
| --- | --- |
| Override wins, is not persisted | `TestLocalProxyPortOverrideWinsAndIsNotPersisted` asserts the stored port is left untouched and zero saves occur |
| Automatic selection stable across launches | `TestLocalProxyPortAutomaticSelectionIsStableAcrossEngines`; on the desktop side `TestGetProxyInfoReusesThePersistedEndpointOnTheNextLaunch` over a real `clientstate` dir |
| Stable across processes | `TestLocalProxyPortAdoptsAnotherProcessWinner` — the fake store now models a racing writer, so the loser genuinely adopts the winner's port |
| Persistence failure is a non-fatal warning | `TestLocalProxyPortPersistenceFailureIsANonFatalWarning` covers both no-config-directory and unwritable-store |
| Resolution pinned per process | asserted in the two tests above and in the rewritten `TestLocalProxyPortRetriesAfterResolutionFailure` |
| Transient failure stays retryable | same test, now driven by a real unusable override rather than a stub that returned an error |
| Bind check and actionable error | `TestEnsureProxyPortAvailableReportsStablePortCollision`, unchanged |
| Proxy resolves, TUN never does | `TestTUNConnectSkipsProxyPortAndOSProxy` now asserts zero load *and* zero save calls against persistence |
| Desktop and CLI identical | both wire one `Persistence`; `var _ connectcore.Persistence = storeAdapter{}` in each module |

Two test-quality notes worth flagging:

- `TestGetProxyInfoSurfacesNonFatalPersistenceWarning` set `s.store` but not the engine's hook. Under the old callback that still exercised the unwritable-store path; under the new wiring it would have silently fallen through to the *nil*-store path and kept passing while testing something else. It now wires both through a `withStore` helper that mirrors `Startup`.
- I checked the new desktop stability test is not vacuous by temporarily unwiring `Persistence` in `withStore`: `--- FAIL: TestGetProxyInfoReusesThePersistedEndpointOnTheNextLaunch`.

The connectcore ladder tests dropped their `allocateTestProxyPort` stub and now run the real resolution policy (no store → fresh loopback port + warning), so they exercise the shipped path instead of a fake.

## Verification

`gofmt`, `go vet`, and `go test` clean in the root, `desktop`, and `desktop-volunteer` modules; `GOOS=windows` and `GOOS=linux` cross-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)