### PR TITLE
feat(desktop): add native split tunneling

### DIFF
--- a/desktop/frontend/src/native/OpenRungVpn.ts
+++ b/desktop/frontend/src/native/OpenRungVpn.ts
@@ -33,6 +33,8 @@ const realBridge: OpenRungVpnModule = {
   getState: () => wailsService()!.GetState(),
   getIdentity: () => wailsService()!.GetIdentity(),
   getProxyInfo: () => wailsService()!.GetProxyInfo(),
+  getSplitTunnel: () => wailsService()!.GetSplitTunnel(),
+  setSplitTunnel: enabled => wailsService()!.SetSplitTunnel(enabled),
 };
 
 /** The active VPN module: the Go bridge when running under Wails, else the mock. */

--- a/desktop/frontend/src/native/mock.ts
+++ b/desktop/frontend/src/native/mock.ts
@@ -52,6 +52,7 @@ function sampleRelay(loc: Located, index: number): RelayDescriptor {
 }
 
 export class MockOpenRungVpn implements OpenRungVpnModule {
+  private splitTunnel = false;
   private state: NativeVpnState = {
     status: 'disconnected',
     relayLabel: null,
@@ -147,6 +148,17 @@ export class MockOpenRungVpn implements OpenRungVpnModule {
       enableCommand: '. "$HOME/.config/openrung/proxy-env.sh" && openrung_proxy_on',
       disableCommand: 'openrung_proxy_off',
     };
+  }
+
+  async getSplitTunnel(): Promise<boolean> {
+    return this.splitTunnel;
+  }
+
+  async setSplitTunnel(enabled: boolean): Promise<void> {
+    if (this.state.status !== 'disconnected' && this.state.status !== 'failed') {
+      throw new Error('disconnect before changing split tunneling');
+    }
+    this.splitTunnel = enabled;
   }
 
   async listRelaysForDirectory(): Promise<RelayListResponse> {

--- a/desktop/frontend/src/native/types.ts
+++ b/desktop/frontend/src/native/types.ts
@@ -62,4 +62,8 @@ export interface OpenRungVpnModule {
   getState(): Promise<NativeVpnState>;
   getIdentity(): Promise<NativeIdentity>;
   getProxyInfo(): Promise<NativeProxyInfo>;
+  /** Whether private/mainland-China destinations bypass the relay. */
+  getSplitTunnel(): Promise<boolean>;
+  /** Changes the routing policy for subsequent connections. */
+  setSplitTunnel(enabled: boolean): Promise<void>;
 }

--- a/desktop/frontend/src/native/wails.d.ts
+++ b/desktop/frontend/src/native/wails.d.ts
@@ -13,6 +13,8 @@ export interface WailsServiceBindings {
   GetState(): Promise<NativeVpnState>;
   GetIdentity(): Promise<NativeIdentity>;
   GetProxyInfo(): Promise<NativeProxyInfo>;
+  GetSplitTunnel(): Promise<boolean>;
+  SetSplitTunnel(enabled: boolean): Promise<void>;
   ListRelaysForDirectory(): Promise<RelayListResponse>;
 }
 

--- a/desktop/frontend/src/screens/SettingsScreen.tsx
+++ b/desktop/frontend/src/screens/SettingsScreen.tsx
@@ -18,8 +18,12 @@ interface Props {
 export function SettingsScreen({ consoleOpen, connectionStatus, onToggleConsole }: Props) {
   const [proxyInfo, setProxyInfo] = useState<NativeProxyInfo | null>(null);
   const [proxyError, setProxyError] = useState<string | null>(null);
+  const [splitTunnel, setSplitTunnel] = useState<boolean | null>(null);
+  const [routingError, setRoutingError] = useState<string | null>(null);
+  const [routingSaving, setRoutingSaving] = useState(false);
   const [copied, setCopied] = useState<'endpoint' | 'enable' | 'disable' | null>(null);
   const connected = connectionStatus === 'connected';
+  const canChangeRouting = connectionStatus === 'disconnected' || connectionStatus === 'failed';
 
   useEffect(() => {
     let active = true;
@@ -34,6 +38,35 @@ export function SettingsScreen({ consoleOpen, connectionStatus, onToggleConsole 
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    let active = true;
+    void OpenRungVpn.getSplitTunnel()
+      .then(enabled => {
+        if (active) setSplitTunnel(enabled);
+      })
+      .catch(error => {
+        if (active) setRoutingError(String(error));
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const toggleSplitTunnel = async () => {
+    if (splitTunnel == null || routingSaving || !canChangeRouting) return;
+    const enabled = !splitTunnel;
+    setRoutingSaving(true);
+    setRoutingError(null);
+    try {
+      await OpenRungVpn.setSplitTunnel(enabled);
+      setSplitTunnel(enabled);
+    } catch (error) {
+      setRoutingError(String(error));
+    } finally {
+      setRoutingSaving(false);
+    }
+  };
 
   const copy = async (kind: 'endpoint' | 'enable' | 'disable', value: string) => {
     try {
@@ -52,6 +85,32 @@ export function SettingsScreen({ consoleOpen, connectionStatus, onToggleConsole 
       <span className="or-section-header">CONNECTION</span>
       <SettingRow title="Broker" subtitle={AppConfig.DEFAULT_BROKER_URL} />
       <SettingRow title="Tunnel mode" subtitle="System proxy (per-app, no admin)" />
+      <SettingRow
+        title="Split tunneling"
+        subtitle={
+          routingError ??
+          (splitTunnel == null
+            ? 'Loading routing preference…'
+            : canChangeRouting
+              ? splitTunnel
+                ? 'Mainland China sites and private networks connect directly.'
+                : 'All configured proxy traffic uses the relay.'
+              : 'Disconnect before changing the routing policy.')
+        }
+        trailing={
+          <button
+            type="button"
+            className={`or-switch ${splitTunnel ? 'is-on' : ''}`}
+            role="switch"
+            aria-label="Split tunneling"
+            aria-checked={splitTunnel ?? false}
+            disabled={splitTunnel == null || routingSaving || !canChangeRouting}
+            onClick={() => void toggleSplitTunnel()}
+          >
+            <span className="or-switch-thumb" />
+          </button>
+        }
+      />
 
       <span className="or-section-header">LOCAL PROXY</span>
       {proxyInfo != null ? (

--- a/desktop/frontend/src/style.css
+++ b/desktop/frontend/src/style.css
@@ -734,6 +734,45 @@ button {
   opacity: 0.42;
 }
 
+.or-switch {
+  position: relative;
+  flex: none;
+  width: 42px;
+  height: 24px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--or-border-dim, #294f35);
+  background: rgba(125, 169, 137, 0.18);
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.or-switch.is-on {
+  border-color: var(--or-terminal-green, #65f58a);
+  background: rgba(101, 245, 138, 0.28);
+}
+
+.or-switch:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.or-switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--or-dim-text, #7da989);
+  transition: transform 140ms ease, background 140ms ease;
+}
+
+.or-switch.is-on .or-switch-thumb {
+  transform: translateX(18px);
+  background: var(--or-terminal-green, #65f58a);
+  box-shadow: 0 0 8px var(--or-glow-soft, rgba(101, 245, 138, 0.25));
+}
+
 /* about screen */
 .or-about-hero {
   display: flex;

--- a/desktop/vpnservice/service.go
+++ b/desktop/vpnservice/service.go
@@ -13,6 +13,7 @@ package vpnservice
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"sync"
 	"time"
@@ -128,6 +129,9 @@ func (s *Service) Startup(ctx context.Context) {
 	if store, err := clientstate.New(); err == nil {
 		s.store = store
 		s.engine.Persistence = storeAdapter{store: store}
+		if store.LoadSplitTunnel() {
+			_ = s.engine.SetSplitTunnel(true)
+		}
 	}
 	// Crash recovery and persisted recents; the engine's log lines arrive
 	// through the sink.
@@ -170,6 +174,34 @@ func (s *Service) Connect(brokerURL, targetCountry, targetRelayID string) error 
 
 func (s *Service) Disconnect() error {
 	return s.engine.Disconnect()
+}
+
+// GetSplitTunnel returns the persisted routing policy currently selected for
+// the next connection.
+func (s *Service) GetSplitTunnel() bool {
+	return s.engine.SplitTunnel()
+}
+
+// SetSplitTunnel changes and persists the routing policy. A live connection
+// must be disconnected first so its direct/proxy rules cannot change midway.
+func (s *Service) SetSplitTunnel(enabled bool) error {
+	if s.store == nil {
+		return errors.New("routing settings storage is unavailable")
+	}
+	previous := s.engine.SplitTunnel()
+	if err := s.engine.SetSplitTunnel(enabled); err != nil {
+		return err
+	}
+	if err := s.store.SaveSplitTunnel(enabled); err != nil {
+		_ = s.engine.SetSplitTunnel(previous)
+		return err
+	}
+	if enabled {
+		s.appendLog("split tunneling enabled: mainland China and private networks use direct routing")
+	} else {
+		s.appendLog("split tunneling disabled: all configured proxy traffic uses the relay")
+	}
+	return nil
 }
 
 func (s *Service) GetState() NativeVpnState {

--- a/desktop/vpnservice/service_test.go
+++ b/desktop/vpnservice/service_test.go
@@ -224,3 +224,33 @@ func TestStoreAdapterRoundTripsSnapshotAndRecents(t *testing.T) {
 		t.Fatalf("recents round trip = %+v", got)
 	}
 }
+
+func TestSplitTunnelPreferencePersistsThroughService(t *testing.T) {
+	store := clientstate.NewInDir(t.TempDir())
+	s := withStore(New(), store)
+	if s.GetSplitTunnel() {
+		t.Fatal("split tunneling should default off")
+	}
+	if err := s.SetSplitTunnel(true); err != nil {
+		t.Fatalf("SetSplitTunnel(true): %v", err)
+	}
+	if !s.GetSplitTunnel() || !store.LoadSplitTunnel() {
+		t.Fatal("service did not apply and persist split tunneling")
+	}
+	if err := s.SetSplitTunnel(false); err != nil {
+		t.Fatalf("SetSplitTunnel(false): %v", err)
+	}
+	if s.GetSplitTunnel() || store.LoadSplitTunnel() {
+		t.Fatal("service did not apply and persist full-proxy routing")
+	}
+}
+
+func TestSplitTunnelRequiresSettingsStorage(t *testing.T) {
+	s := New()
+	if err := s.SetSplitTunnel(true); err == nil {
+		t.Fatal("SetSplitTunnel succeeded without persistent settings storage")
+	}
+	if s.GetSplitTunnel() {
+		t.Fatal("failed SetSplitTunnel changed the engine policy")
+	}
+}

--- a/internal/client/singbox_config.go
+++ b/internal/client/singbox_config.go
@@ -41,6 +41,10 @@ type SingBoxConfigInput struct {
 	TunnelIPv6Address string
 	DNSServers        []string
 	MTU               int
+	// SplitTunnel sends private networks and the built-in mainland-China
+	// domain set through the direct outbound while keeping the proxy as the
+	// fail-closed default for every other destination.
+	SplitTunnel bool
 	// Mode selects the inbound (TUN by default; mixed loopback for proxy mode).
 	Mode InboundMode
 	// ProxyListenAddress and ProxyListenPort configure the mixed inbound in
@@ -98,15 +102,20 @@ func BuildSingBoxConfig(input SingBoxConfigInput) ([]byte, error) {
 		serverPort = input.BridgePort
 	}
 
+	directOutbound := map[string]any{
+		"type": "direct",
+		"tag":  "direct",
+	}
+	if input.SplitTunnel {
+		directOutbound["domain_resolver"] = "dns-direct"
+	}
+
 	cfg := map[string]any{
 		"log": map[string]any{
 			"level":     "info",
 			"timestamp": true,
 		},
-		"dns": map[string]any{
-			"servers": dnsServerObjects(dnsServers),
-			"final":   "dns-0",
-		},
+		"dns": buildDNSConfig(dnsServers, input.SplitTunnel),
 		"inbounds": []any{
 			inbound,
 		},
@@ -134,26 +143,13 @@ func BuildSingBoxConfig(input SingBoxConfigInput) ([]byte, error) {
 					},
 				},
 			},
-			map[string]any{
-				"type": "direct",
-				"tag":  "direct",
-			},
+			directOutbound,
 			map[string]any{
 				"type": "block",
 				"tag":  "block",
 			},
 		},
-		"route": map[string]any{
-			"auto_detect_interface":   true,
-			"default_domain_resolver": "dns-0",
-			"rules": []any{
-				map[string]any{
-					"protocol": "dns",
-					"action":   "hijack-dns",
-				},
-			},
-			"final": "proxy",
-		},
+		"route": buildRouteConfig(input.Mode, input.SplitTunnel),
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/internal/client/singbox_config_test.go
+++ b/internal/client/singbox_config_test.go
@@ -2,6 +2,9 @@ package client
 
 import (
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -35,6 +38,9 @@ func TestBuildSingBoxConfig(t *testing.T) {
 	if proxy["server_port"].(float64) != 443 {
 		t.Fatalf("unexpected server port: %+v", proxy["server_port"])
 	}
+	if _, ok := outbounds[1].(map[string]any)["domain_resolver"]; ok {
+		t.Fatal("full-tunnel direct outbound unexpectedly received a split DNS resolver")
+	}
 
 	tls := proxy["tls"].(map[string]any)
 	reality := tls["reality"].(map[string]any)
@@ -63,6 +69,135 @@ func TestBuildSingBoxConfig(t *testing.T) {
 	if dns0["type"] != "tcp" || dns0["detour"] != "proxy" {
 		t.Fatalf("expected TCP DNS through proxy, got %+v", dns0)
 	}
+	if _, ok := dns["rules"]; ok {
+		t.Fatal("full-tunnel config unexpectedly contains split DNS rules")
+	}
+}
+
+func TestBuildSingBoxProxyModeSplitTunnelRoutesChinaAndPrivateDirect(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	cfg, err := BuildSingBoxConfig(SingBoxConfigInput{
+		Relay:           validRelay(now),
+		Mode:            ModeProxy,
+		ProxyListenPort: 7890,
+		SplitTunnel:     true,
+	})
+	if err != nil {
+		t.Fatalf("build split proxy config: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(cfg, &decoded); err != nil {
+		t.Fatalf("config should be valid JSON: %v", err)
+	}
+
+	dns := decoded["dns"].(map[string]any)
+	servers := dns["servers"].([]any)
+	local := servers[len(servers)-1].(map[string]any)
+	if local["type"] != "local" || local["tag"] != "dns-direct" {
+		t.Fatalf("missing local direct resolver: %+v", servers)
+	}
+	dnsRule := dns["rules"].([]any)[0].(map[string]any)
+	if dnsRule["action"] != "route" || dnsRule["server"] != "dns-direct" {
+		t.Fatalf("unexpected split DNS rule: %+v", dnsRule)
+	}
+	if !containsJSONValue(dnsRule["domain_suffix"].([]any), ".cn") ||
+		!containsJSONValue(dnsRule["domain_suffix"].([]any), "baidu.com") {
+		t.Fatalf("split DNS domains missing China coverage: %+v", dnsRule["domain_suffix"])
+	}
+
+	direct := decoded["outbounds"].([]any)[1].(map[string]any)
+	if direct["domain_resolver"] != "dns-direct" {
+		t.Fatalf("direct outbound resolver = %v, want dns-direct", direct["domain_resolver"])
+	}
+
+	route := decoded["route"].(map[string]any)
+	if route["final"] != "proxy" {
+		t.Fatalf("split mode must keep fail-closed proxy final, got %v", route["final"])
+	}
+	rules := route["rules"].([]any)
+	if len(rules) != 3 {
+		t.Fatalf("proxy split route rules = %d, want 3: %+v", len(rules), rules)
+	}
+	privateRule := rules[1].(map[string]any)
+	if privateRule["ip_is_private"] != true || privateRule["outbound"] != "direct" {
+		t.Fatalf("unexpected private-network rule: %+v", privateRule)
+	}
+	domainRule := rules[2].(map[string]any)
+	if domainRule["outbound"] != "direct" ||
+		!containsJSONValue(domainRule["domain_suffix"].([]any), "bilibili.com") {
+		t.Fatalf("unexpected direct-domain rule: %+v", domainRule)
+	}
+	for _, raw := range rules {
+		if raw.(map[string]any)["action"] == "sniff" {
+			t.Fatalf("mixed proxy inbound should not pay a sniffing delay: %+v", rules)
+		}
+	}
+}
+
+func TestBuildSingBoxTUNSplitTunnelSniffsBeforeDomainRouting(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	cfg, err := BuildSingBoxConfig(SingBoxConfigInput{
+		Relay:       validRelay(now),
+		Mode:        ModeTUN,
+		SplitTunnel: true,
+	})
+	if err != nil {
+		t.Fatalf("build split TUN config: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(cfg, &decoded); err != nil {
+		t.Fatalf("config should be valid JSON: %v", err)
+	}
+	rules := decoded["route"].(map[string]any)["rules"].([]any)
+	if len(rules) != 4 {
+		t.Fatalf("TUN split route rules = %d, want 4: %+v", len(rules), rules)
+	}
+	sniff := rules[2].(map[string]any)
+	if sniff["inbound"] != "tun-in" || sniff["action"] != "sniff" {
+		t.Fatalf("TUN split config must sniff before domain routing: %+v", rules)
+	}
+	if rules[3].(map[string]any)["outbound"] != "direct" {
+		t.Fatalf("domain route must follow TUN sniff: %+v", rules)
+	}
+}
+
+func TestSplitTunnelConfigAcceptedBySingBox(t *testing.T) {
+	binary := os.Getenv("OPENRUNG_TEST_SING_BOX")
+	if binary == "" {
+		t.Skip("set OPENRUNG_TEST_SING_BOX to run config compatibility validation")
+	}
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	candidate := validRelay(now)
+	// validRelay uses a readable placeholder key for structural unit tests;
+	// sing-box's checker correctly requires a real X25519 public key.
+	candidate.RealityPublicKey = "qYnwTernLtZYTfY7pQr1fLu27Am2MuKKvXW8n6bmTU4"
+	cfg, err := BuildSingBoxConfig(SingBoxConfigInput{
+		Relay:           candidate,
+		Mode:            ModeProxy,
+		ProxyListenPort: 7890,
+		SplitTunnel:     true,
+	})
+	if err != nil {
+		t.Fatalf("build split proxy config: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "split.json")
+	if err := os.WriteFile(path, cfg, 0o600); err != nil {
+		t.Fatalf("write split config: %v", err)
+	}
+	if output, err := exec.Command(binary, "check", "-c", path).CombinedOutput(); err != nil {
+		t.Fatalf("sing-box rejected split config: %v\n%s", err, output)
+	}
+}
+
+func containsJSONValue(values []any, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildSingBoxConfigExcludesIPv6RelayFromTUNRoute(t *testing.T) {

--- a/internal/client/split_tunnel.go
+++ b/internal/client/split_tunnel.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package client
+
+// splitTunnelDomainSuffixes is the built-in direct-routing set used when the
+// desktop's split-tunnel option is enabled. The list deliberately starts with
+// country-code and local-network suffixes, then covers popular mainland-China
+// services whose public names use generic TLDs. Keeping the data in the client
+// means a connection never depends on downloading a remote rule-set before the
+// relay is usable.
+//
+// Values use sing-box's domain_suffix semantics: a bare registrable domain
+// matches both the apex and its subdomains, while the leading-dot country-code
+// entry matches every name below that TLD.
+var splitTunnelDomainSuffixes = []string{
+	".cn",
+	".lan",
+	".local",
+	"1688.com",
+	"58.com",
+	"alibaba.com",
+	"alicdn.com",
+	"alipay.com",
+	"aliyun.com",
+	"amap.com",
+	"autohome.com",
+	"autonav.com",
+	"baidu.com",
+	"bcebos.com",
+	"bdstatic.com",
+	"bilibili.com",
+	"bilivideo.com",
+	"bytedance.com",
+	"byteimg.com",
+	"csdn.net",
+	"ctrip.com",
+	"dianping.com",
+	"dingtalk.com",
+	"douban.com",
+	"douyin.com",
+	"douyu.com",
+	"eastmoney.com",
+	"ele.me",
+	"ganji.com",
+	"gitee.com",
+	"gtimg.com",
+	"hdslb.com",
+	"honor.com",
+	"huawei.com",
+	"huya.com",
+	"iqiyi.com",
+	"ixigua.com",
+	"jd.com",
+	"jdcache.com",
+	"jdcloud.com",
+	"kingsoft.com",
+	"kuaishou.com",
+	"kwimgs.com",
+	"meituan.com",
+	"mi.com",
+	"miui.com",
+	"myqcloud.com",
+	"netease.com",
+	"oppo.com",
+	"pinduoduo.com",
+	"pstatp.com",
+	"qhimg.com",
+	"qiyi.com",
+	"qq.com",
+	"qunar.com",
+	"sina.com",
+	"smzdm.com",
+	"so.com",
+	"sogou.com",
+	"suning.com",
+	"taobao.com",
+	"tencent.com",
+	"tmall.com",
+	"toutiao.com",
+	"tudou.com",
+	"vivo.com",
+	"vip.com",
+	"wechat.com",
+	"weibo.com",
+	"wps.com",
+	"xhscdn.com",
+	"xiaohongshu.com",
+	"xueqiu.com",
+	"youku.com",
+	"zhihu.com",
+	"zhimg.com",
+}
+
+func buildDNSConfig(servers []string, splitTunnel bool) map[string]any {
+	configured := dnsServerObjects(servers)
+	dns := map[string]any{
+		"servers": configured,
+		"final":   "dns-0",
+	}
+	if !splitTunnel {
+		return dns
+	}
+
+	// Foreign lookups keep using dns-0 through the relay. Direct destinations
+	// use the platform resolver so they receive the same nearby/CDN answers as
+	// other applications on the local network.
+	dns["servers"] = append(configured, map[string]any{
+		"type": "local",
+		"tag":  "dns-direct",
+	})
+	dns["rules"] = []any{
+		map[string]any{
+			"domain_suffix": splitTunnelDomainSuffixes,
+			"action":        "route",
+			"server":        "dns-direct",
+		},
+	}
+	dns["reverse_mapping"] = true
+	return dns
+}
+
+func buildRouteConfig(mode InboundMode, splitTunnel bool) map[string]any {
+	rules := []any{
+		map[string]any{
+			"protocol": "dns",
+			"action":   "hijack-dns",
+		},
+	}
+	if splitTunnel {
+		// Private addresses should never take a detour through a public relay.
+		rules = append(rules, map[string]any{
+			"ip_is_private": true,
+			"action":        "route",
+			"outbound":      "direct",
+		})
+		// A mixed HTTP/SOCKS inbound already carries the requested hostname. TUN
+		// traffic generally arrives as an IP connection, so sniff only that
+		// inbound before applying the same domain rule.
+		if mode == ModeTUN {
+			rules = append(rules, map[string]any{
+				"inbound": "tun-in",
+				"action":  "sniff",
+			})
+		}
+		rules = append(rules, map[string]any{
+			"domain_suffix": splitTunnelDomainSuffixes,
+			"action":        "route",
+			"outbound":      "direct",
+		})
+	}
+
+	return map[string]any{
+		"auto_detect_interface":   true,
+		"default_domain_resolver": "dns-0",
+		"rules":                   rules,
+		"final":                   "proxy",
+	}
+}

--- a/internal/clientstate/store.go
+++ b/internal/clientstate/store.go
@@ -23,6 +23,7 @@ const (
 	proxyPortLockFile = "proxy-port.lock"
 	proxyEnvFile      = "proxy-env-%d.sh"
 	proxySnapshotHdr  = "proxy-snapshot.json"
+	routingPrefsFile  = "routing.json"
 )
 
 // RecentNode mirrors the contract's RecentNode (openrung-mobile-app
@@ -36,6 +37,10 @@ type RecentNode struct {
 
 type proxyEndpoint struct {
 	Port int `json:"port"`
+}
+
+type routingPreferences struct {
+	SplitTunnel bool `json:"splitTunnel"`
 }
 
 // Store reads and writes the on-disk state. dir is resolved once; it is a field
@@ -81,6 +86,25 @@ func (s *Store) LoadRecents() []RecentNode {
 // SaveRecents persists the recents list (best-effort).
 func (s *Store) SaveRecents(recents []RecentNode) error {
 	return s.writeJSON(recentsFile, recents)
+}
+
+// LoadSplitTunnel returns the persisted desktop routing preference. Missing,
+// unreadable, and corrupt files preserve the historical full-proxy default.
+func (s *Store) LoadSplitTunnel() bool {
+	data, err := os.ReadFile(filepath.Join(s.dir, routingPrefsFile))
+	if err != nil {
+		return false
+	}
+	var prefs routingPreferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		return false
+	}
+	return prefs.SplitTunnel
+}
+
+// SaveSplitTunnel atomically persists the desktop routing preference.
+func (s *Store) SaveSplitTunnel(enabled bool) error {
+	return s.writeJSON(routingPrefsFile, routingPreferences{SplitTunnel: enabled})
 }
 
 // LoadProxyPort returns the stable per-install loopback proxy port. Missing,

--- a/internal/clientstate/store_test.go
+++ b/internal/clientstate/store_test.go
@@ -30,6 +30,33 @@ func TestRecentsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSplitTunnelPreferenceRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewInDir(dir)
+	if store.LoadSplitTunnel() {
+		t.Fatal("fresh store enabled split tunneling")
+	}
+	if err := store.SaveSplitTunnel(true); err != nil {
+		t.Fatalf("SaveSplitTunnel(true): %v", err)
+	}
+	if !store.LoadSplitTunnel() {
+		t.Fatal("saved split-tunnel preference was not loaded")
+	}
+	if err := store.SaveSplitTunnel(false); err != nil {
+		t.Fatalf("SaveSplitTunnel(false): %v", err)
+	}
+	if store.LoadSplitTunnel() {
+		t.Fatal("disabled split-tunnel preference was not loaded")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, routingPrefsFile), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if store.LoadSplitTunnel() {
+		t.Fatal("corrupt routing preference did not fall back to full proxy")
+	}
+}
+
 func TestProxyPortLifecycle(t *testing.T) {
 	dir := t.TempDir()
 	store := NewInDir(dir)

--- a/internal/connectcore/engine.go
+++ b/internal/connectcore/engine.go
@@ -272,6 +272,9 @@ type Engine struct {
 	// mode is the capture mode (see mode.go). Its zero value is ModeProxy, so
 	// a host that never calls SetMode keeps the pre-B3 behavior.
 	mode Mode
+	// splitTunnel is the routing policy applied to every generated candidate
+	// config. Its zero value preserves the historical full-proxy behavior.
+	splitTunnel bool
 
 	directory *directoryCache
 
@@ -904,7 +907,9 @@ func (s *Engine) attemptDirectCandidate(ctx context.Context, conn *connection, c
 // route exclusions — BuildSingBoxConfig owns) in TUN mode.
 func (s *Engine) candidateConfigInput(cand relay.Descriptor, port int) client.SingBoxConfigInput {
 	mode := s.Mode()
-	input := client.SingBoxConfigInput{Relay: cand, Mode: mode.inboundMode()}
+	input := client.SingBoxConfigInput{
+		Relay: cand, Mode: mode.inboundMode(), SplitTunnel: s.SplitTunnel(),
+	}
 	if mode == ModeTUN {
 		input.MTU = s.TunnelMTU
 		return input

--- a/internal/connectcore/routing.go
+++ b/internal/connectcore/routing.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package connectcore
+
+import "errors"
+
+// SplitTunnel reports whether subsequent connections will route private
+// networks and the built-in mainland-China destination set directly. The
+// proxy remains the final route for every destination outside that set.
+func (s *Engine) SplitTunnel() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.splitTunnel
+}
+
+// SetSplitTunnel selects the routing policy for subsequent connections. A
+// live session keeps the policy it started with; changing it requires a clean
+// reconnect because every candidate and recovery config must agree.
+func (s *Engine) SetSplitTunnel(enabled bool) error {
+	s.connectMu.Lock()
+	defer s.connectMu.Unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn != nil {
+		return errors.New("disconnect before changing split tunneling")
+	}
+	s.splitTunnel = enabled
+	return nil
+}

--- a/internal/connectcore/routing_test.go
+++ b/internal/connectcore/routing_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package connectcore
+
+import "testing"
+
+func TestSplitTunnelDefaultsOffAndShapesCandidateConfig(t *testing.T) {
+	s := New()
+	if s.SplitTunnel() {
+		t.Fatal("split tunneling must default off for backward compatibility")
+	}
+
+	if err := s.SetSplitTunnel(true); err != nil {
+		t.Fatalf("SetSplitTunnel: %v", err)
+	}
+	if !s.SplitTunnel() {
+		t.Fatal("split tunneling did not turn on")
+	}
+	input := s.candidateConfigInput(usableRelay("split", "CN", "Shanghai", "China"), 46685)
+	if !input.SplitTunnel {
+		t.Fatal("candidate config lost the engine split-tunnel policy")
+	}
+	if input.ProxyListenPort != 46685 {
+		t.Fatalf("candidate proxy port = %d, want 46685", input.ProxyListenPort)
+	}
+}
+
+func TestSetSplitTunnelRefusedWhileConnectionIsLive(t *testing.T) {
+	s := New()
+	s.mu.Lock()
+	s.conn = &connection{}
+	s.mu.Unlock()
+
+	if err := s.SetSplitTunnel(true); err == nil {
+		t.Fatal("SetSplitTunnel succeeded during a live connection")
+	}
+	if s.SplitTunnel() {
+		t.Fatal("refused SetSplitTunnel still changed the policy")
+	}
+
+	s.mu.Lock()
+	s.conn = nil
+	s.mu.Unlock()
+	if err := s.SetSplitTunnel(true); err != nil {
+		t.Fatalf("SetSplitTunnel after disconnect: %v", err)
+	}
+}

--- a/internal/connectcore/wss.go
+++ b/internal/connectcore/wss.go
@@ -311,7 +311,7 @@ func (s *Engine) attemptWSSCandidate(
 	go serveWSS(result, serveCtx, bridge)
 	s.appendLog(fmt.Sprintf("connected through WSS front %s", front.ID))
 	return s.startCandidate(result, client.SingBoxConfigInput{
-		Relay: candidate, Mode: client.ModeProxy,
+		Relay: candidate, Mode: client.ModeProxy, SplitTunnel: s.SplitTunnel(),
 		ProxyListenAddress: proxyconfig.Host, ProxyListenPort: proxyPort,
 		BridgeHost: ip.String(), BridgePort: port,
 	})


### PR DESCRIPTION
## Summary

- add a persisted, opt-in split-tunneling preference to the desktop app
- route private networks and a conservative list of mainland China domain suffixes directly while keeping the proxy as the final route
- use the local DNS resolver for direct domains and the proxied resolver for remaining domains
- expose the policy in Settings and prevent changes while a connection is active

## Implementation notes

- preserves the historical full-proxy behavior by default
- propagates the preference through normal and WSS fallback connection paths
- adds TUN sniffing before domain-based route selection
- persists the preference in the existing client state directory
- keeps unknown domains on the proxy path to favor reachability

## Validation

- `go test ./...`
- `cd desktop && go test ./...`
- `cd desktop/frontend && npm test -- --run`
- `cd desktop/frontend && npm run build`
- generated split-proxy and split-TUN configs accepted by the bundled sing-box binary
