### PR TITLE
Geographic diversity slots in the broker's ranked relay page

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -67,6 +67,9 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	// Rollback lever for the geographic diversity slots in the ranked relay
+	// page; enabled unless explicitly turned off (and inert in legacy ranking).
+	pageDiversity := envEnabled("OPENRUNG_RELAY_PAGE_DIVERSITY")
 
 	// Fail closed: with no registration token, anyone can register a relay and
 	// poison the directory that clients route their VPN traffic through. Require
@@ -146,6 +149,8 @@ func run() error {
 		GeoIP:                      geoResolver,
 		SigningSeed:                signingSeed,
 		WSSTicketSigningSeed:       wssTicketSeed,
+		RelayRanking:               rankingMode,
+		RelayPageDiversityDisabled: !pageDiversity,
 	}
 	// The Postgres store aggregates dashboard queries in SQL; the JSONL sink's
 	// dashboard is aggregated in Go from its in-memory record set.
@@ -189,7 +194,7 @@ func run() error {
 		close(shutdownDone)
 	}()
 
-	slog.Info("starting broker", "version", buildinfo.Version(baseVersion), "revision", buildinfo.Revision(), "addr", *addr, "lease_ttl", leaseTTL.String(), "telemetry_store", *telemetryStore, "telemetry_file", *telemetryFile, "relay_store", *relayStore, "relay_ranking", rankingMode, "dashboard_enabled", dashboardToken != "", "operational_api_enabled", apiToken != "", "foundation_registration_enabled", foundationToken != "", "wss_ticket_issuance_enabled", len(wssTicketSeed) != 0, "status_interval", statusInterval.String(), "geoip_enabled", geoResolver != nil)
+	slog.Info("starting broker", "version", buildinfo.Version(baseVersion), "revision", buildinfo.Revision(), "addr", *addr, "lease_ttl", leaseTTL.String(), "telemetry_store", *telemetryStore, "telemetry_file", *telemetryFile, "relay_store", *relayStore, "relay_ranking", rankingMode, "relay_page_diversity", pageDiversity, "dashboard_enabled", dashboardToken != "", "operational_api_enabled", apiToken != "", "foundation_registration_enabled", foundationToken != "", "wss_ticket_issuance_enabled", len(wssTicketSeed) != 0, "status_interval", statusInterval.String(), "geoip_enabled", geoResolver != nil)
 	err = server.ListenAndServe()
 	if errors.Is(err, http.ErrServerClosed) {
 		<-shutdownDone
@@ -329,6 +334,17 @@ func envTrue(key string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// envEnabled is the default-enabled counterpart of envTrue: only an explicit
+// falsy value disables the behavior.
+func envEnabled(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
 	}
 }
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -69,7 +69,10 @@ func run() error {
 	}
 	// Rollback lever for the geographic diversity slots in the ranked relay
 	// page; enabled unless explicitly turned off (and inert in legacy ranking).
-	pageDiversity := envEnabled("OPENRUNG_RELAY_PAGE_DIVERSITY")
+	pageDiversity, err := parseRelayPageDiversity(os.Getenv("OPENRUNG_RELAY_PAGE_DIVERSITY"))
+	if err != nil {
+		return err
+	}
 
 	// Fail closed: with no registration token, anyone can register a relay and
 	// poison the directory that clients route their VPN traffic through. Require
@@ -337,14 +340,20 @@ func envTrue(key string) bool {
 	}
 }
 
-// envEnabled is the default-enabled counterpart of envTrue: only an explicit
-// falsy value disables the behavior.
-func envEnabled(key string) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
-	case "0", "false", "no", "off":
-		return false
+// parseRelayPageDiversity maps OPENRUNG_RELAY_PAGE_DIVERSITY onto the
+// diversity rollback lever: empty or truthy enables, an explicit falsy value
+// (including the off/disabled/none vocabulary the geoip knob accepts)
+// disables, and anything else refuses to start — this flag exists to be set
+// mid-incident, when a typo that silently left the feature enabled would be
+// worse than a visible crash-loop.
+func parseRelayPageDiversity(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off", "disabled", "none":
+		return false, nil
 	default:
-		return true
+		return false, errors.New("OPENRUNG_RELAY_PAGE_DIVERSITY must be a boolean value such as true or false")
 	}
 }
 

--- a/cmd/broker/main_test.go
+++ b/cmd/broker/main_test.go
@@ -122,3 +122,22 @@ func TestParseOptionalWSSTicketSeed(t *testing.T) {
 		}
 	}
 }
+
+func TestParseRelayPageDiversity(t *testing.T) {
+	for _, value := range []string{"", "1", "true", "yes", " On "} {
+		if enabled, err := parseRelayPageDiversity(value); err != nil || !enabled {
+			t.Errorf("parseRelayPageDiversity(%q) = (%v, %v), want enabled", value, enabled, err)
+		}
+	}
+	for _, value := range []string{"0", "false", "no", "off", "Disabled", "none"} {
+		if enabled, err := parseRelayPageDiversity(value); err != nil || enabled {
+			t.Errorf("parseRelayPageDiversity(%q) = (%v, %v), want disabled", value, enabled, err)
+		}
+	}
+	// A rollback typo must refuse to start, never silently stay enabled.
+	for _, value := range []string{"banana", "enable", "flase"} {
+		if _, err := parseRelayPageDiversity(value); err == nil {
+			t.Errorf("parseRelayPageDiversity(%q) accepted an unrecognized value", value)
+		}
+	}
+}

--- a/deploy/broker/.env.example
+++ b/deploy/broker/.env.example
@@ -123,6 +123,14 @@ OPENRUNG_ALLOW_ANONYMOUS_REGISTRATION=true
 # Relay ranking: global (default, live-metric scoring) or legacy (IPv6-first).
 #OPENRUNG_RELAY_RANKING=global
 
+# Geographic diversity slots in the ranked relay page (global ranking only):
+# when a region the fleet spans is missing from a served page, up to two tail
+# slots go to that region's best-ranked relays so every client's latency
+# probing can steer it to its nearest region. Enabled by default; set false to
+# roll back to the pure global-order page head. Any other value refuses to
+# start, so a typo cannot silently leave the feature running mid-incident.
+#OPENRUNG_RELAY_PAGE_DIVERSITY=true
+
 # ---------------------------------------------------------------------------
 # Relay geolocation (optional)
 # ---------------------------------------------------------------------------

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -383,7 +383,7 @@ docker inspect openrung-broker \
 | `OPENRUNG_RELAY_STORE`               | no       | `memory`                            | Relay state backend: `memory` or `postgres`                    |
 | `OPENRUNG_RELAY_DATABASE_URL`        | if pg    | —                                   | PostgreSQL URL when `OPENRUNG_RELAY_STORE=postgres`            |
 | `OPENRUNG_RELAY_RANKING`             | no       | `global`                            | Relay ranking mode: `global` or `legacy`                       |
-| `OPENRUNG_RELAY_PAGE_DIVERSITY`      | no       | enabled                             | Set `false` to disable the geographic diversity slots in the ranked relay page (global mode only) |
+| `OPENRUNG_RELAY_PAGE_DIVERSITY`      | no       | enabled                             | Set `false` to disable the geographic diversity slots in the ranked relay page (global mode only); unrecognized values refuse to start |
 | `OPENRUNG_GEOIP_ENDPOINT`            | no       | ipwho.is                            | IP-geolocation endpoint for relay city/country; `off` disables |
 | `OPENRUNG_TELEMETRY_STORE`           | no       | `jsonl`                             | Telemetry backend: `jsonl` or `postgres`                       |
 | `OPENRUNG_TELEMETRY_DATABASE_URL`    | no       | relay database URL                  | PostgreSQL URL when `OPENRUNG_TELEMETRY_STORE=postgres`        |

--- a/deploy/broker/README.md
+++ b/deploy/broker/README.md
@@ -383,6 +383,7 @@ docker inspect openrung-broker \
 | `OPENRUNG_RELAY_STORE`               | no       | `memory`                            | Relay state backend: `memory` or `postgres`                    |
 | `OPENRUNG_RELAY_DATABASE_URL`        | if pg    | —                                   | PostgreSQL URL when `OPENRUNG_RELAY_STORE=postgres`            |
 | `OPENRUNG_RELAY_RANKING`             | no       | `global`                            | Relay ranking mode: `global` or `legacy`                       |
+| `OPENRUNG_RELAY_PAGE_DIVERSITY`      | no       | enabled                             | Set `false` to disable the geographic diversity slots in the ranked relay page (global mode only) |
 | `OPENRUNG_GEOIP_ENDPOINT`            | no       | ipwho.is                            | IP-geolocation endpoint for relay city/country; `off` disables |
 | `OPENRUNG_TELEMETRY_STORE`           | no       | `jsonl`                             | Telemetry backend: `jsonl` or `postgres`                       |
 | `OPENRUNG_TELEMETRY_DATABASE_URL`    | no       | relay database URL                  | PostgreSQL URL when `OPENRUNG_TELEMETRY_STORE=postgres`        |

--- a/internal/broker/diversity.go
+++ b/internal/broker/diversity.go
@@ -1,0 +1,77 @@
+package broker
+
+import (
+	"strings"
+
+	"openrung/internal/relay"
+)
+
+// maxDiversitySlots caps how many page slots geographic coverage may
+// repurpose, so the global ranking still decides most of the page.
+const maxDiversitySlots = 2
+
+// relayRegions maps ISO country codes to the coarse regions used for page
+// diversity. Deliberately tiny and fleet-shaped: a code outside the map (or a
+// descriptor whose geo lookup has not resolved) belongs to no region, so it
+// can neither claim a diversity slot nor count a region as represented.
+var relayRegions = map[string]string{
+	"KR": "asia",
+	"JP": "asia",
+	"SG": "asia",
+	"IN": "asia",
+	"DE": "europe",
+	"FI": "europe",
+	"SE": "europe",
+}
+
+func relayRegion(desc relay.Descriptor) string {
+	return relayRegions[strings.ToUpper(desc.CountryCode)]
+}
+
+// diversifyRelayPage rewrites the head of the globally ranked relay list —
+// the served page — so every region the eligible fleet spans is represented
+// on it: each region missing from the page swaps its best-ranked below-fold
+// relay with a relay from the page's tail. The page is exactly the probe set
+// of the clients' latency ranker, so carrying at least one relay per region
+// lets every client steer itself to its nearest region without the broker
+// knowing where the client is. The global #1 is never displaced, at most
+// maxDiversitySlots relays are, and displaced relays swap below the fold
+// rather than disappearing, so the WSS reservation that runs after this can
+// still consider them.
+func diversifyRelayPage(relays []relay.Descriptor, limit int) []relay.Descriptor {
+	if limit <= 1 || len(relays) <= limit {
+		return relays
+	}
+
+	represented := make(map[string]bool)
+	for _, desc := range relays[:limit] {
+		if region := relayRegion(desc); region != "" {
+			represented[region] = true
+		}
+	}
+
+	// Global order below the fold picks each missing region's best relay.
+	var fills []int
+	for i := limit; i < len(relays) && len(fills) < maxDiversitySlots; i++ {
+		region := relayRegion(relays[i])
+		if region == "" || represented[region] {
+			continue
+		}
+		represented[region] = true
+		fills = append(fills, i)
+	}
+	if len(fills) == 0 {
+		return relays
+	}
+
+	out := append([]relay.Descriptor(nil), relays...)
+	slot := limit - 1
+	for _, fill := range fills {
+		if slot < 1 {
+			break
+		}
+		out[slot], out[fill] = out[fill], out[slot]
+		slot--
+	}
+	return out
+}

--- a/internal/broker/diversity.go
+++ b/internal/broker/diversity.go
@@ -11,21 +11,34 @@ import (
 const maxDiversitySlots = 2
 
 // relayRegions maps ISO country codes to the coarse regions used for page
-// diversity. Deliberately tiny and fleet-shaped: a code outside the map (or a
-// descriptor whose geo lookup has not resolved) belongs to no region, so it
-// can neither claim a diversity slot nor count a region as represented.
+// diversity. It covers every country the fleet's deploy targets span (the
+// Hetzner/Linode hosts plus deploy/relay/aws/wss-origin-targets.json), and
+// resolveRelayGeo warns when a relay resolves to a code outside the map, so
+// the map falling behind the fleet is visible instead of silently shrinking
+// coverage. A code outside the map (or an unresolved geo lookup) belongs to
+// no region: it can neither claim a diversity slot nor count a region as
+// represented, and it is never protected from displacement.
 var relayRegions = map[string]string{
 	"KR": "asia",
 	"JP": "asia",
 	"SG": "asia",
 	"IN": "asia",
+	"HK": "asia",
+	"ID": "asia",
 	"DE": "europe",
 	"FI": "europe",
 	"SE": "europe",
+	"US": "americas",
+	"BR": "americas",
+	"AU": "oceania",
+}
+
+func regionForCountryCode(code string) string {
+	return relayRegions[strings.ToUpper(code)]
 }
 
 func relayRegion(desc relay.Descriptor) string {
-	return relayRegions[strings.ToUpper(desc.CountryCode)]
+	return regionForCountryCode(desc.CountryCode)
 }
 
 // diversifyRelayPage rewrites the head of the globally ranked relay list —
@@ -43,33 +56,67 @@ func diversifyRelayPage(relays []relay.Descriptor, limit int) []relay.Descriptor
 		return relays
 	}
 
-	represented := make(map[string]bool)
+	// representatives counts each known region's relays on the page so a fill
+	// never displaces a region's only representative: coverage must only ever
+	// grow, or the pass could trade one missing region for another.
+	representatives := make(map[string]int)
+	pageHasWSS := false
 	for _, desc := range relays[:limit] {
 		if region := relayRegion(desc); region != "" {
-			represented[region] = true
+			representatives[region]++
 		}
+		pageHasWSS = pageHasWSS || wssRelayEligible(desc)
 	}
 
 	// Global order below the fold picks each missing region's best relay.
 	var fills []int
+	fillHasWSS := false
+	claimed := make(map[string]bool)
 	for i := limit; i < len(relays) && len(fills) < maxDiversitySlots; i++ {
 		region := relayRegion(relays[i])
-		if region == "" || represented[region] {
+		if region == "" || representatives[region] > 0 || claimed[region] {
 			continue
 		}
-		represented[region] = true
+		claimed[region] = true
 		fills = append(fills, i)
+		fillHasWSS = fillHasWSS || wssRelayEligible(relays[i])
 	}
 	if len(fills) == 0 {
 		return relays
 	}
 
-	out := append([]relay.Descriptor(nil), relays...)
+	// reserveWSSCandidate overwrites the last slot when the page carries no
+	// WSS-eligible relay and one exists below the fold. When no fill would
+	// satisfy the reservation itself, keep fills out of that slot, or the
+	// reservation would silently cancel a fill.
 	slot := limit - 1
+	if !pageHasWSS && !fillHasWSS {
+		for _, desc := range relays[limit:] {
+			if wssRelayEligible(desc) {
+				slot = limit - 2
+				break
+			}
+		}
+	}
+
+	out := append([]relay.Descriptor(nil), relays...)
 	for _, fill := range fills {
+		// The victim is the deepest page slot that is neither the global #1
+		// nor its region's only representative on the page.
+		for slot >= 1 {
+			region := relayRegion(out[slot])
+			if region == "" || representatives[region] > 1 {
+				break
+			}
+			slot--
+		}
 		if slot < 1 {
 			break
 		}
+		if region := relayRegion(out[slot]); region != "" {
+			representatives[region]--
+		}
+		representatives[relayRegion(out[fill])]++
 		out[slot], out[fill] = out[fill], out[slot]
 		slot--
 	}

--- a/internal/broker/diversity_test.go
+++ b/internal/broker/diversity_test.go
@@ -1,0 +1,235 @@
+package broker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+func geoRelay(id, countryCode string) relay.Descriptor {
+	return relay.Descriptor{ID: id, GeoLocation: relay.GeoLocation{CountryCode: countryCode}}
+}
+
+func relayIDs(relays []relay.Descriptor) []string {
+	ids := make([]string, len(relays))
+	for i, desc := range relays {
+		ids[i] = desc.ID
+	}
+	return ids
+}
+
+func TestDiversifyRelayPage(t *testing.T) {
+	tests := []struct {
+		name   string
+		relays []relay.Descriptor
+		limit  int
+		want   []string
+	}{
+		{
+			name: "page already diverse stays byte-identical",
+			relays: []relay.Descriptor{
+				geoRelay("kr1", "KR"), geoRelay("de1", "DE"), geoRelay("kr2", "KR"),
+				geoRelay("kr3", "KR"), geoRelay("jp1", "JP"),
+				geoRelay("de2", "DE"), geoRelay("fi1", "FI"),
+			},
+			limit: 5,
+			want:  []string{"kr1", "de1", "kr2", "kr3", "jp1"},
+		},
+		{
+			name: "below-fold europe fills the tail without touching the top",
+			relays: []relay.Descriptor{
+				geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("kr3", "KR"),
+				geoRelay("kr4", "KR"), geoRelay("kr5", "KR"),
+				geoRelay("kr6", "KR"), geoRelay("de1", "DE"), geoRelay("fi1", "FI"),
+			},
+			limit: 5,
+			want:  []string{"kr1", "kr2", "kr3", "kr4", "de1"},
+		},
+		{
+			name: "two missing regions fill at most two tail slots",
+			relays: []relay.Descriptor{
+				geoRelay("us1", "US"), geoRelay("us2", "US"), geoRelay("us3", "US"),
+				geoRelay("us4", "US"), geoRelay("us5", "US"),
+				geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("de1", "DE"),
+				geoRelay("fi1", "FI"),
+			},
+			limit: 5,
+			// Best-ranked relay per missing region, best region first at the
+			// deepest repurposed slot; kr2 and fi1 never enter (one fill per
+			// region), us4/us5 are displaced.
+			want: []string{"us1", "us2", "us3", "de1", "kr1"},
+		},
+		{
+			name: "fleet smaller than the page is untouched",
+			relays: []relay.Descriptor{
+				geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("de1", "DE"),
+			},
+			limit: 5,
+			want:  []string{"kr1", "kr2", "de1"},
+		},
+		{
+			name: "unknown country codes never win a diversity slot",
+			relays: []relay.Descriptor{
+				geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("kr3", "KR"),
+				geoRelay("kr4", "KR"), geoRelay("kr5", "KR"),
+				geoRelay("mystery1", ""), geoRelay("mystery2", "XX"), geoRelay("de1", "DE"),
+			},
+			limit: 5,
+			want:  []string{"kr1", "kr2", "kr3", "kr4", "de1"},
+		},
+		{
+			name: "single-slot page never displaces the global best",
+			relays: []relay.Descriptor{
+				geoRelay("kr1", "KR"), geoRelay("de1", "DE"),
+			},
+			limit: 1,
+			want:  []string{"kr1"},
+		},
+		{
+			name: "two-slot page fills only the second slot",
+			relays: []relay.Descriptor{
+				geoRelay("us1", "US"), geoRelay("us2", "US"),
+				geoRelay("kr1", "KR"), geoRelay("de1", "DE"),
+			},
+			limit: 2,
+			want:  []string{"us1", "kr1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diversifyRelayPage(tc.relays, tc.limit)
+			page := got
+			if len(page) > tc.limit {
+				page = page[:tc.limit]
+			}
+			gotIDs := relayIDs(page)
+			if len(gotIDs) != len(tc.want) {
+				t.Fatalf("page = %v, want %v", gotIDs, tc.want)
+			}
+			for i, id := range tc.want {
+				if gotIDs[i] != id {
+					t.Fatalf("page = %v, want %v", gotIDs, tc.want)
+				}
+			}
+			if len(got) != len(tc.relays) {
+				t.Fatalf("full list length changed: %d, want %d", len(got), len(tc.relays))
+			}
+		})
+	}
+}
+
+func TestDiversifyRelayPageIsDeterministic(t *testing.T) {
+	relays := []relay.Descriptor{
+		geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("kr3", "KR"),
+		geoRelay("kr4", "KR"), geoRelay("kr5", "KR"),
+		geoRelay("de1", "DE"), geoRelay("de2", "DE"),
+	}
+	first := relayIDs(diversifyRelayPage(relays, 5))
+	for i := 0; i < 10; i++ {
+		again := relayIDs(diversifyRelayPage(relays, 5))
+		for j := range first {
+			if again[j] != first[j] {
+				t.Fatalf("run %d produced %v, first run produced %v", i, again, first)
+			}
+		}
+	}
+}
+
+// registerGeoFleet fills a store with count KR relays plus one DE relay
+// carrying the oldest heartbeat. With no telemetry every composite score ties,
+// heartbeat recency breaks the tie in both ranking modes, and the DE relay
+// ranks dead last: the default page head is Korea-only with the EU relay
+// below the fold.
+func registerGeoFleet(t *testing.T, store *Store, count int) {
+	t.Helper()
+	now := time.Now().UTC()
+	for i := 0; i <= count; i++ {
+		req := validRegisterRequest()
+		req.PublicHost = fmt.Sprintf("203.0.113.%d", i+1)
+		desc, err := store.Register(req, now.Add(-time.Duration(i)*time.Minute), time.Hour)
+		if err != nil {
+			t.Fatalf("register relay %d: %v", i, err)
+		}
+		countryCode := "KR"
+		if i == count {
+			countryCode = "DE"
+		}
+		if err := store.UpdateGeo(desc.ID, desc.LeaseToken, relay.GeoLocation{CountryCode: countryCode}); err != nil {
+			t.Fatalf("set relay %d geo: %v", i, err)
+		}
+	}
+}
+
+func listedCountryCodes(t *testing.T, server http.Handler) []string {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/relays", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("list relays: expected 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var listed struct {
+		Relays []relay.Descriptor `json:"relays"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode relay list: %v", err)
+	}
+	codes := make([]string, len(listed.Relays))
+	for i, desc := range listed.Relays {
+		codes[i] = desc.CountryCode
+	}
+	return codes
+}
+
+func TestListRelaysPageDiversitySlots(t *testing.T) {
+	store := NewStore()
+	registerGeoFleet(t, store, 6)
+	server := NewServer(store, Config{SigningSeed: testSigningSeed()})
+
+	codes := listedCountryCodes(t, server)
+	want := []string{"KR", "KR", "KR", "KR", "DE"}
+	if len(codes) != len(want) {
+		t.Fatalf("page countries = %v, want %v", codes, want)
+	}
+	for i := range want {
+		if codes[i] != want[i] {
+			t.Fatalf("page countries = %v, want %v", codes, want)
+		}
+	}
+}
+
+func TestListRelaysPageDiversityDisabledAndLegacyServeGlobalHead(t *testing.T) {
+	tests := []struct {
+		name string
+		mode RankingMode
+		cfg  Config
+	}{
+		{
+			name: "flag disabled",
+			mode: RankingModeGlobal,
+			cfg:  Config{SigningSeed: testSigningSeed(), RelayPageDiversityDisabled: true},
+		},
+		{
+			name: "legacy ranking mode",
+			mode: RankingModeLegacy,
+			cfg:  Config{SigningSeed: testSigningSeed(), RelayRanking: RankingModeLegacy},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewStoreWithRanking(tc.mode)
+			registerGeoFleet(t, store, 6)
+			server := NewServer(store, tc.cfg)
+			for _, code := range listedCountryCodes(t, server) {
+				if code != "KR" {
+					t.Fatalf("page must be the untouched ranking head, found country %q", code)
+				}
+			}
+		})
+	}
+}

--- a/internal/broker/diversity_test.go
+++ b/internal/broker/diversity_test.go
@@ -65,6 +65,41 @@ func TestDiversifyRelayPage(t *testing.T) {
 			want: []string{"us1", "us2", "us3", "de1", "kr1"},
 		},
 		{
+			name: "three missing regions fill only two slots",
+			relays: []relay.Descriptor{
+				geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("kr3", "KR"),
+				geoRelay("kr4", "KR"), geoRelay("kr5", "KR"),
+				geoRelay("au1", "AU"), geoRelay("us1", "US"), geoRelay("de1", "DE"),
+			},
+			limit: 5,
+			// Global order picks which missing regions win the capped slots:
+			// oceania and americas rank above europe, so de1 stays below.
+			want: []string{"kr1", "kr2", "kr3", "us1", "au1"},
+		},
+		{
+			name: "a fill never evicts a region's only representative",
+			relays: []relay.Descriptor{
+				geoRelay("us1", "US"), geoRelay("us2", "US"), geoRelay("us3", "US"),
+				geoRelay("us4", "US"), geoRelay("kr1", "KR"),
+				geoRelay("de1", "DE"),
+			},
+			limit: 5,
+			// kr1 holds the tail slot but is asia's only page relay, so the
+			// europe fill displaces us4 instead.
+			want: []string{"us1", "us2", "us3", "de1", "kr1"},
+		},
+		{
+			name: "no displaceable slot leaves the page unchanged",
+			relays: []relay.Descriptor{
+				geoRelay("us1", "US"), geoRelay("kr1", "KR"), geoRelay("de1", "DE"),
+				geoRelay("au1", "AU"),
+			},
+			limit: 3,
+			// Every tail relay is its region's only representative, so the
+			// oceania fill has no victim and the page stays the global head.
+			want: []string{"us1", "kr1", "de1"},
+		},
+		{
 			name: "fleet smaller than the page is untouched",
 			relays: []relay.Descriptor{
 				geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("de1", "DE"),
@@ -121,6 +156,36 @@ func TestDiversifyRelayPage(t *testing.T) {
 				t.Fatalf("full list length changed: %d, want %d", len(got), len(tc.relays))
 			}
 		})
+	}
+}
+
+// TestDiversityFillSurvivesWSSReservation pins the interplay between the two
+// page-composition passes on the live fleet's shape: a head of WSS-less
+// volunteers, the diversity fill also WSS-less, and the only WSS-capable
+// foundation relay below the fold. The fill must move to the second-to-last
+// slot so the WSS reservation's overwrite of the last slot cannot cancel it.
+func TestDiversityFillSurvivesWSSReservation(t *testing.T) {
+	wssJP := relay.Descriptor{
+		ID: "jp-wss", NodeClass: relay.NodeClassFoundation, Transport: relay.TransportDirect,
+		ExitMode: relay.ExitModeDirect, PublicPort: 443, IdentityPublicKey: "identity",
+		WSSFronts:   []relay.WSSFrontDescriptor{{ID: "front-a", ProtocolVersion: relay.WSSProtocolVersion}},
+		GeoLocation: relay.GeoLocation{CountryCode: "JP"},
+	}
+	relays := []relay.Descriptor{
+		geoRelay("kr1", "KR"), geoRelay("kr2", "KR"), geoRelay("kr3", "KR"),
+		geoRelay("kr4", "KR"), geoRelay("kr5", "KR"),
+		geoRelay("kr6", "KR"), geoRelay("de1", "DE"), wssJP,
+	}
+	page := reserveWSSCandidate(diversifyRelayPage(relays, 5), 5)
+	want := []string{"kr1", "kr2", "kr3", "de1", "jp-wss"}
+	got := relayIDs(page)
+	if len(got) != len(want) {
+		t.Fatalf("page = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("page = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -70,6 +70,15 @@ type Config struct {
 	// can show where relays are located. Nil disables lookups;
 	// descriptors then carry empty geo fields.
 	GeoIP GeoIPResolver
+	// RelayRanking is the directory ordering mode (see ParseRankingMode) and
+	// should carry the same value the relay store was constructed with; the
+	// zero value is the default global mode. Diversity slots apply only to
+	// global ranking — legacy ordering is served untouched.
+	RelayRanking RankingMode
+	// RelayPageDiversityDisabled turns off the geographic diversity slots in
+	// the ranked relay page (OPENRUNG_RELAY_PAGE_DIVERSITY=false), serving the
+	// pure global-order page head — the rollback lever for the diverse page.
+	RelayPageDiversityDisabled bool
 	// SigningSeed is the 32-byte Ed25519 seed that signs every relay-list
 	// response body. Required: cmd/broker validates OPENRUNG_RELAY_SIGNING_KEY
 	// with ParseSigningSeed and refuses to start without it, because serving
@@ -99,6 +108,7 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	relayLedger := newRelayIDLedger(relayLedgerTTL, relayLedgerMaxEntries)
 	seedRelayLedger(relayLedger, store)
 	newIDCap := newNewRelayCap(cfg.MaxNewRelayIDsPerIPPerDay, newRelayCapWindow, cfg.RegistrationCapExemptCIDRs)
+	diversifyPages := !cfg.RelayPageDiversityDisabled && normalizeRankingMode(cfg.RelayRanking) == RankingModeGlobal
 	registerRelay := rateLimited(relayRegistrationLimiter, clientIP, 10, registerHandler(store, cfg, clientIP, relayLedger, newIDCap))
 	heartbeatRelay := rateLimited(relayRegistrationLimiter, clientIP, 10, heartbeatHandler(store, cfg, relayLedger))
 
@@ -119,8 +129,8 @@ func NewServer(store RelayStore, cfg Config) http.Handler {
 	})
 	mux.HandleFunc("POST /api/v1/relays/register", registerRelay)
 	mux.HandleFunc("POST /api/v1/relays/", heartbeatRelay)
-	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen, relaySigner)))
-	mux.HandleFunc("GET /api/v1/relays.mirror", rateLimited(relayListLimiter, clientIP, 10, listRelaysMirrorHandler(store, relaySigner)))
+	mux.HandleFunc("GET /api/v1/relays", rateLimited(relayListLimiter, clientIP, 10, listRelaysHandler(store, cfg.TelemetrySink, clientIP, clientSeen, relaySigner, diversifyPages)))
+	mux.HandleFunc("GET /api/v1/relays.mirror", rateLimited(relayListLimiter, clientIP, 10, listRelaysMirrorHandler(store, relaySigner, diversifyPages)))
 	if wssIssuer != nil {
 		mux.HandleFunc("POST /api/v1/wss/tickets", rateLimitedBy(wssTicketLimiter, wssTicketRateKey(clientIP), 10, wssTicketHandler(store, wssIssuer)))
 	}
@@ -368,7 +378,7 @@ func geoLookupHost(desc *relay.Descriptor) string {
 	return desc.PublicHost
 }
 
-func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *clientIPResolver, clientSeen *clientSeenDeduper, s signer) http.HandlerFunc {
+func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *clientIPResolver, clientSeen *clientSeenDeduper, s signer, diversify bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Relay availability is real-time: shared caches (Cloudflare's edge in
 		// production) must never store a copy, and clients cannot bust an edge
@@ -387,14 +397,19 @@ func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *
 		}
 
 		now := time.Now().UTC()
-		// Ask both stores for the ranked set, then reserve one already-advertised
-		// per-relay WSS-capable Foundation descriptor in a short page. This never
-		// attaches a shared URL or changes ordering when the page already has one.
+		// Ask both stores for the ranked set, apply the geographic diversity
+		// slots to the page head, then reserve one already-advertised per-relay
+		// WSS-capable Foundation descriptor in a short page. Diversity runs
+		// first so the WSS reservation keeps final authority over the last
+		// slot: a page must never lose its WSS fallback to a diversity fill.
 		relays, err := store.List(now, 0)
 		if err != nil {
 			slog.Error("could not list relays", "error", err)
 			writeError(w, http.StatusServiceUnavailable, "could not list relays")
 			return
+		}
+		if diversify {
+			relays = diversifyRelayPage(relays, limit)
 		}
 		relays = reserveWSSCandidate(relays, limit)
 		s.writeSigned(w, relay.ListResponse{
@@ -422,7 +437,7 @@ const mirrorRelayLimit = 20
 // exact body bytes plus the signature header value to static mirrors, which
 // clients try only after every API candidate fails. The body carries no limit
 // field — the mirror is not request-shaped, so there is nothing to echo.
-func listRelaysMirrorHandler(store RelayStore, s signer) http.HandlerFunc {
+func listRelaysMirrorHandler(store RelayStore, s signer, diversify bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Same caching rule as the API list: errors must not be cached either.
 		w.Header().Set("Cache-Control", "no-store")
@@ -432,6 +447,9 @@ func listRelaysMirrorHandler(store RelayStore, s signer) http.HandlerFunc {
 			slog.Error("could not list relays for mirror", "error", err)
 			writeError(w, http.StatusServiceUnavailable, "could not list relays")
 			return
+		}
+		if diversify {
+			relays = diversifyRelayPage(relays, mirrorRelayLimit)
 		}
 		relays = reserveWSSCandidate(relays, mirrorRelayLimit)
 		s.writeSigned(w, relay.ListResponse{

--- a/internal/broker/server.go
+++ b/internal/broker/server.go
@@ -365,6 +365,13 @@ func resolveRelayGeo(ctx context.Context, store RelayStore, resolver GeoIPResolv
 		return
 	}
 	desc.GeoLocation = geo
+	if geo.CountryCode != "" && regionForCountryCode(geo.CountryCode) == "" {
+		// The fleet has outgrown the page-diversity region map: this relay can
+		// neither win nor satisfy a diversity slot until relayRegions learns
+		// its country. Warn here (once per resolution, not per list request)
+		// so the drift is visible.
+		slog.Warn("relay country code is not in the page-diversity region map", "relay_id", desc.ID, "country_code", geo.CountryCode)
+	}
 	slog.Info("relay location resolved", "relay_id", desc.ID, "city", geo.City, "country", geo.Country)
 }
 
@@ -400,8 +407,9 @@ func listRelaysHandler(store RelayStore, telemetrySink TelemetrySink, clientIP *
 		// Ask both stores for the ranked set, apply the geographic diversity
 		// slots to the page head, then reserve one already-advertised per-relay
 		// WSS-capable Foundation descriptor in a short page. Diversity runs
-		// first so the WSS reservation keeps final authority over the last
-		// slot: a page must never lose its WSS fallback to a diversity fill.
+		// first and keeps its fills out of the slot the WSS reservation will
+		// claim, so the page never loses its WSS fallback to a diversity fill
+		// and the reservation never cancels a fill.
 		relays, err := store.List(now, 0)
 		if err != nil {
 			slog.Error("could not list relays", "error", err)


### PR DESCRIPTION
## Mechanism

Iranian clients pile onto the Seoul relays (transfer overage) while the Hetzner EU relays idle at 1–3% of allowance, because the broker's single global ranking can serve a page with no EU relay on it. This PR adds **diversity slots + the already-shipped client latency bucketing = de facto geo steering with zero geo code**: after the global sort, if a coarse region present in the eligible fleet (asia / europe / americas / oceania, from a small static country-code map covering the fleet's deploy-target countries) is missing from the page head, the region's best-ranked below-fold relay swaps with a relay from the page tail — at most 2 slots, never the global #1, deterministic, page size unchanged. Every client already probes the whole served page (`RelayRankMaxProbes = 8` ≥ the default page of 5) and reorders by 30 ms latency bucket, so from Iran an EU relay (~110 ms) decisively beats Seoul (~270 ms) while from China Korea (~60 ms) still wins — each client steers itself, and the broker never learns or guesses where the client is.

## Behavior & invariants

- Runs at page assembly in both list handlers (`/api/v1/relays` and the mirror channel), strictly after the global sort and after `store.List`'s eligibility filtering; the signed envelope, page size, and echoed limit are untouched.
- Global #1 never displaced; at most 2 tail slots repurposed; unknown/unmapped country codes can neither win a slot nor count a region as represented, and `resolveRelayGeo` warns when a relay's country falls outside the region map so the map cannot silently fall behind the fleet.
- If every fleet region is already on the page (or the fleet fits in the page), the served bytes are identical to today's.
- A fill never evicts a region's only page representative — coverage can only grow, never trade one missing region for another.
- Displaced relays swap below the fold, and the diversity pass runs **before** `reserveWSSCandidate` and keeps its fills out of the slot the reservation will claim — the page never loses its WSS fallback to a diversity fill, and the reservation never cancels a fill.
- Applies only to the default `global` ranking mode; `legacy` is served untouched.
- Rollback: `OPENRUNG_RELAY_PAGE_DIVERSITY=false` (default enabled, state logged on the startup line, documented in deploy/broker/README.md and .env.example). The flag fails closed: an unrecognized value refuses to start rather than silently keeping the feature running. No client changes, no GeoIP, no new ranking mode.

## Tests

Table-driven tests in `internal/broker/diversity_test.go`: already-diverse page unchanged, KR-heavy head + below-fold EU relay promoted into the tail with #1 untouched and length unchanged, two missing regions fill exactly two slots, three missing regions capped at two, sole-representative protection, all-slots-protected no-op, fleet smaller than page unchanged, unknown country codes never win a slot, single-slot page never displaces #1, determinism across repeated runs, and `TestDiversityFillSurvivesWSSReservation` composing both page passes on the live fleet's shape; plus handler-level tests through `NewServer` for the default-on behavior, the disabled flag (exactly today's output), and legacy mode, and fail-closed parsing tests for the rollback flag in `cmd/broker`.

## Acceptance after deploy

`connection_succeeded` telemetry already records `brokerIndex` and the client's probe latency, so IR sessions shifting toward EU relays is observable with no new instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
