### PR TITLE
Make the Go sing-box config builder the superset of mobile's generators

### DIFF
--- a/internal/client/singbox_config.go
+++ b/internal/client/singbox_config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 
 	"openrung/internal/relay"
@@ -608,19 +609,22 @@ func localRuleSetObject(directory, tag string) map[string]any {
 // route rule. A datagram addressed to a public resolver (1.1.1.1) is NOT
 // tagged, matches no rule, and dies on the TCP-only proxy outbound, so
 // mobile's fresh-DNS probe must target this address.
+//
+// sing-tun only performs that derivation when the successor stays inside the
+// TUN prefix (HasNextAddress: prefix.Contains(addr.Next())); otherwise it
+// hijacks no IPv4 address at all. A tunnel address whose successor escapes the
+// prefix is therefore rejected here — returning it would hand probes an
+// address sing-box never hijacks and fail them on a healthy tunnel.
 func TunnelDNSAddress(tunnelIPv4Address string) (string, error) {
-	address, _, found := strings.Cut(tunnelIPv4Address, "/")
-	if !found {
-		return "", fmt.Errorf("tunnel address has no prefix length: %s", tunnelIPv4Address)
+	prefix, err := netip.ParsePrefix(tunnelIPv4Address)
+	if err != nil || !prefix.Addr().Is4() {
+		return "", fmt.Errorf("tunnel address is not an IPv4 prefix: %s", tunnelIPv4Address)
 	}
-	ip := net.ParseIP(address)
-	if ip == nil || ip.To4() == nil {
-		return "", fmt.Errorf("tunnel address is not IPv4: %s", tunnelIPv4Address)
+	next := prefix.Addr().Next()
+	if !prefix.Contains(next) {
+		return "", fmt.Errorf("tunnel address %s has no successor inside its prefix for sing-tun to hijack", tunnelIPv4Address)
 	}
-	ip = ip.To4()
-	value := uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
-	next := value + 1
-	return net.IPv4(byte(next>>24), byte(next>>16), byte(next>>8), byte(next)).String(), nil
+	return next.String(), nil
 }
 
 func validateRelayForConfig(candidate relay.Descriptor) error {

--- a/internal/client/singbox_config.go
+++ b/internal/client/singbox_config.go
@@ -75,6 +75,26 @@ var dohTLSServerNames = map[string]string{
 	"8.8.8.8": "dns.google",
 }
 
+// validateDoHDNSServers rejects proxied resolvers the DoH failover emission
+// cannot represent safely. A hostname server would be self-referential: its
+// address could only be resolved by route.default_domain_resolver = "dns-0",
+// which is the very chain it belongs to, and we emit no bootstrap resolver. An
+// IP literal without a dohTLSServerNames entry would be emitted with no tls
+// block, verifying the bare IP against the certificate — the IP-SAN fragility
+// that map exists to prevent. Only DNSShapeDoHFailover validates: the TCP
+// shape's byte-identical legacy emission keeps tolerating anything.
+func validateDoHDNSServers(dnsServers []string) error {
+	for _, server := range dnsServers {
+		if net.ParseIP(server) == nil {
+			return fmt.Errorf("DoH failover DNS server %q is not an IP literal; a hostname server has no bootstrap resolver", server)
+		}
+		if _, ok := dohTLSServerNames[server]; !ok {
+			return fmt.Errorf("DoH failover DNS server %q has no pinned TLS server name; add it to dohTLSServerNames first", server)
+		}
+	}
+	return nil
+}
+
 // Per-evaluate budget before the next resolver runs, and the terminal/global
 // budget (DNSShapeDoHFailover only).
 const (
@@ -158,6 +178,11 @@ func BuildSingBoxConfig(input SingBoxConfigInput) ([]byte, error) {
 	dnsServers := input.DNSServers
 	if len(dnsServers) == 0 {
 		dnsServers = []string{"1.1.1.1", "8.8.8.8"}
+	}
+	if input.DNSShape == DNSShapeDoHFailover {
+		if err := validateDoHDNSServers(dnsServers); err != nil {
+			return nil, err
+		}
 	}
 	mtu := input.MTU
 	if mtu == 0 {
@@ -354,23 +379,22 @@ func buildDNSConfig(input SingBoxConfigInput, dnsServers, probeSuffixes []string
 	for i, server := range dnsServers {
 		// DoH over 443 via the proxy: relays answer 443 on every transport,
 		// while TCP/53 gets no replies under WSS. IP-literal servers need no
-		// bootstrap resolver (defaults: port 443, path /dns-query).
-		object := map[string]any{
+		// bootstrap resolver (defaults: port 443, path /dns-query);
+		// validateDoHDNSServers has already rejected anything else, and
+		// guarantees the dohTLSServerNames lookup below succeeds. TLS
+		// authenticates the provider hostname while the dial stays on the IP
+		// literal, so a provider dropping IP SANs from its certificate cannot
+		// break resolution.
+		servers = append(servers, map[string]any{
 			"tag":    fmt.Sprintf("dns-%d", i),
 			"type":   "https",
 			"server": server,
 			"detour": "proxy",
-		}
-		// TLS authenticates the provider hostname while the dial stays on the
-		// IP literal, so a provider dropping IP SANs from its certificate
-		// cannot break resolution.
-		if serverName, ok := dohTLSServerNames[server]; ok {
-			object["tls"] = map[string]any{
+			"tls": map[string]any{
 				"enabled":     true,
-				"server_name": serverName,
-			}
-		}
-		servers = append(servers, object)
+				"server_name": dohTLSServerNames[server],
+			},
+		})
 	}
 	for _, country := range bypassCountries {
 		resolver := splitTunnelDirectResolvers[country]

--- a/internal/client/singbox_config.go
+++ b/internal/client/singbox_config.go
@@ -25,6 +25,24 @@ const (
 	ModeProxy
 )
 
+// DNSShape selects the DNS block's emission. The zero value is
+// DNSShapeTCPProxied, so existing callers keep producing byte-identical
+// configs.
+type DNSShape int
+
+const (
+	// DNSShapeTCPProxied is the original desktop/CLI shape: plain TCP/53
+	// resolvers detoured through the proxy, final pinned to dns-0, no DNS
+	// rules. Unchanged behavior.
+	DNSShapeTCPProxied DNSShape = iota
+	// DNSShapeDoHFailover is mobile's shape: DoH over 443 through the proxy
+	// (relays answer 443 on every transport, while TCP/53 gets no replies
+	// under WSS), an uncached probe-priority rule chain, per-country direct
+	// resolvers for split tunneling, and a real primary-to-fallback failover
+	// chain — a static final would never consult a second resolver.
+	DNSShapeDoHFailover
+)
+
 const (
 	// DefaultTunnelIPv4Address and DefaultTunnelIPv6Address are the TUN
 	// inbound's addresses when the caller does not override them. They are
@@ -33,6 +51,35 @@ const (
 	// interface (connectcore.tunInterfaceReady).
 	DefaultTunnelIPv4Address = "172.19.0.1/30"
 	DefaultTunnelIPv6Address = "fdfe:dcba:9876::1/126"
+
+	// DefaultTunnelDNSAddress is TunnelDNSAddress(DefaultTunnelIPv4Address):
+	// the only in-TUN address whose port-53 traffic sing-box hijacks (see
+	// TunnelDNSAddress), and therefore the address mobile's fresh-DNS probes
+	// must target.
+	DefaultTunnelDNSAddress = "172.19.0.2"
+)
+
+// DefaultProbeDomainSuffixes are the through-tunnel connectivity-probe
+// hostnames the DoH failover shape pins through the proxy with its
+// highest-priority DNS and route rules, so a country-bypass rule set that
+// happens to contain a probe hostname (geosite-cn ships www.gstatic.com) can
+// never route a probe onto the direct path and prove nothing about the
+// tunnel. Mirrors mobile's ProbeTargets.
+var DefaultProbeDomainSuffixes = []string{"probe.openrung.org", "cp.cloudflare.com"}
+
+// dohTLSServerNames are the hostnames the DoH TLS handshakes authenticate
+// while the dial stays on the IP literal, so a provider dropping IP SANs from
+// its certificate cannot break resolution.
+var dohTLSServerNames = map[string]string{
+	"1.1.1.1": "cloudflare-dns.com",
+	"8.8.8.8": "dns.google",
+}
+
+// Per-evaluate budget before the next resolver runs, and the terminal/global
+// budget (DNSShapeDoHFailover only).
+const (
+	dnsPrimaryTimeout  = "2s"
+	dnsFallbackTimeout = "3s"
 )
 
 type SingBoxConfigInput struct {
@@ -59,10 +106,44 @@ type SingBoxConfigInput struct {
 	// and loop back into the tunnel (deadlock). The loopback bridge address needs
 	// no exclusion; this peer IP does.
 	PunchPeerExcludeAddress string
+	// BridgeOwnsOuterSocket marks the bridge's outer socket as protected by
+	// the platform outside the TUN (Android VpnService.protect / iOS's
+	// tunnel-exempt provider socket), the mobile posture. While a bridge is
+	// active it suppresses every route_exclude_address: the exclusions exist
+	// only to keep an unprotected transport socket out of its own TUN, and a
+	// peer /32 exclusion on a protected transport would instead leak unrelated
+	// apps' traffic to that IP. Without an active bridge it changes nothing.
+	BridgeOwnsOuterSocket bool
+	// LogLevel overrides sing-box's log level; empty keeps the original
+	// "info". Mobile release builds pass "warn" — "info" logs every flow and
+	// DNS query, too hot for the per-connection path inside the mobile engine.
+	LogLevel string
+	// DNSShape selects the DNS block (see DNSShape). The zero value keeps the
+	// existing TCP-through-proxy emission byte-identical.
+	DNSShape DNSShape
+	// ProbeDomainSuffixes overrides DefaultProbeDomainSuffixes for the DoH
+	// failover shape's probe-priority pins. Ignored by DNSShapeTCPProxied.
+	ProbeDomainSuffixes []string
+	// SplitTunnel enables mobile's split tunneling when non-nil: LAN bypass,
+	// per-country .srs rule-set bypass with in-country direct resolvers, and
+	// Android per-app exclusion. Bypass countries require DNSShapeDoHFailover
+	// (see validateSplitTunnel). Nil emits a byte-identical no-split config.
+	SplitTunnel *SplitTunnelRules
+	// RouteFindProcess emits route.find_process, the Android emission's
+	// process-matching switch; iOS and desktop leave it off.
+	RouteFindProcess bool
+	// ClashAPI emits an empty experimental.clash_api block. No
+	// external_controller is set, so nothing listens; it just turns on
+	// sing-box's traffic accounting, which feeds the cumulative
+	// bytes_sent/bytes_received counters mobile reports with session telemetry.
+	ClashAPI bool
 }
 
 func BuildSingBoxConfig(input SingBoxConfigInput) ([]byte, error) {
 	if err := validateRelayForConfig(input.Relay); err != nil {
+		return nil, err
+	}
+	if err := validateSplitTunnel(input); err != nil {
 		return nil, err
 	}
 
@@ -98,15 +179,21 @@ func BuildSingBoxConfig(input SingBoxConfigInput) ([]byte, error) {
 		serverPort = input.BridgePort
 	}
 
+	logLevel := input.LogLevel
+	if logLevel == "" {
+		logLevel = "info"
+	}
+	probeSuffixes := input.ProbeDomainSuffixes
+	if len(probeSuffixes) == 0 {
+		probeSuffixes = DefaultProbeDomainSuffixes
+	}
+
 	cfg := map[string]any{
 		"log": map[string]any{
-			"level":     "info",
+			"level":     logLevel,
 			"timestamp": true,
 		},
-		"dns": map[string]any{
-			"servers": dnsServerObjects(dnsServers),
-			"final":   "dns-0",
-		},
+		"dns": buildDNSConfig(input, dnsServers, probeSuffixes),
 		"inbounds": []any{
 			inbound,
 		},
@@ -143,17 +230,15 @@ func BuildSingBoxConfig(input SingBoxConfigInput) ([]byte, error) {
 				"tag":  "block",
 			},
 		},
-		"route": map[string]any{
-			"auto_detect_interface":   true,
-			"default_domain_resolver": "dns-0",
-			"rules": []any{
-				map[string]any{
-					"protocol": "dns",
-					"action":   "hijack-dns",
-				},
-			},
-			"final": "proxy",
-		},
+		"route": buildRouteConfig(input, probeSuffixes),
+	}
+	if input.ClashAPI {
+		// No external_controller is set, so nothing listens; an empty
+		// clash_api block just turns on sing-box's traffic accounting (see
+		// SingBoxConfigInput.ClashAPI).
+		cfg["experimental"] = map[string]any{
+			"clash_api": map[string]any{},
+		}
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")
@@ -195,6 +280,19 @@ func buildInbound(input SingBoxConfigInput, tunnelIPv4Address, tunnelIPv6Address
 		"dns_mode":                 "hijack",
 		"endpoint_independent_nat": true,
 	}
+	if input.SplitTunnel != nil && len(input.SplitTunnel.ExcludedPackages) > 0 {
+		// Excluded apps leave the VPN at the OS level (Android). NEVER emit
+		// include_package alongside this: Android forbids mixing the two, and
+		// we only ever exclude.
+		tunInbound["exclude_package"] = input.SplitTunnel.ExcludedPackages
+	}
+	if input.BridgeOwnsOuterSocket && input.BridgeHost != "" && input.BridgePort > 0 {
+		// A platform-protected bridge owns its outer socket, so nothing here
+		// needs excluding from the TUN — and a peer /32 exclusion would leak
+		// unrelated apps' traffic to that IP (mobile's leak-precedent
+		// regression). The inner bridge endpoint must stay on loopback.
+		return tunInbound, nil
+	}
 	// Exclude the real transport peers from the TUN so their traffic is not
 	// captured by auto_route/strict_route. On the direct path that is the relay's
 	// public IP; on the punch path it is additionally the relay's reflexive
@@ -234,6 +332,271 @@ func dnsServerObjects(servers []string) []any {
 		})
 	}
 	return out
+}
+
+// buildDNSConfig emits the DNS block for the selected shape. The TCP shape is
+// the original desktop/CLI emission, byte-identical; the DoH failover shape is
+// mobile's (see DNSShapeDoHFailover).
+func buildDNSConfig(input SingBoxConfigInput, dnsServers, probeSuffixes []string) map[string]any {
+	if input.DNSShape != DNSShapeDoHFailover {
+		return map[string]any{
+			"servers": dnsServerObjects(dnsServers),
+			"final":   "dns-0",
+		}
+	}
+
+	var bypassCountries []string
+	if input.SplitTunnel != nil {
+		bypassCountries = input.SplitTunnel.BypassCountries
+	}
+
+	servers := make([]any, 0, len(dnsServers)+len(bypassCountries))
+	for i, server := range dnsServers {
+		// DoH over 443 via the proxy: relays answer 443 on every transport,
+		// while TCP/53 gets no replies under WSS. IP-literal servers need no
+		// bootstrap resolver (defaults: port 443, path /dns-query).
+		object := map[string]any{
+			"tag":    fmt.Sprintf("dns-%d", i),
+			"type":   "https",
+			"server": server,
+			"detour": "proxy",
+		}
+		// TLS authenticates the provider hostname while the dial stays on the
+		// IP literal, so a provider dropping IP SANs from its certificate
+		// cannot break resolution.
+		if serverName, ok := dohTLSServerNames[server]; ok {
+			object["tls"] = map[string]any{
+				"enabled":     true,
+				"server_name": serverName,
+			}
+		}
+		servers = append(servers, object)
+	}
+	for _, country := range bypassCountries {
+		resolver := splitTunnelDirectResolvers[country]
+		if resolver == nil {
+			continue
+		}
+		// DoH over 443 on the direct path: encrypted, and 443 survives the
+		// middleboxes that a bare 853 often does not. A DNS server with no
+		// detour builds its own direct dialer, which is exactly what a bypass
+		// resolver needs — detouring to our otherwise-empty tagged direct
+		// outbound is rejected during sing-box's Start stage.
+		servers = append(servers, map[string]any{
+			"tag":    "dns-direct-" + country,
+			"type":   "https",
+			"server": resolver.server,
+			"tls": map[string]any{
+				"enabled":     true,
+				"server_name": resolver.tlsServerName,
+			},
+		})
+	}
+
+	// Highest priority: probe lookups must reach the proxied DoH resolvers
+	// even when a country rule would divert them (geosite-cn contains
+	// gstatic-class hosts), and must never be answered from any cache — a
+	// cached answer proves nothing about the tunnel right now. The chain is
+	// terminal for probe domains (its trailing route rule always fires), so a
+	// future geosite refresh can never capture a probe lookup.
+	rules := dnsFailoverRules(dnsServers, probeSuffixes, true)
+	for _, country := range bypassCountries {
+		rules = append(rules, countryDNSRules(country)...)
+	}
+	// Real failover for everything else: a static final would never consult a
+	// second resolver. evaluate is non-terminal on a transport error, timeout,
+	// SERVFAIL or REFUSED in the pinned engine — a usable answer (NOERROR, or
+	// an authoritative NXDOMAIN) is returned by respond, anything else falls
+	// through to the next resolver's terminal route rule.
+	rules = append(rules, dnsFailoverRules(dnsServers, nil, false)...)
+
+	return map[string]any{
+		"servers": servers,
+		"rules":   rules,
+		"final":   fmt.Sprintf("dns-%d", len(dnsServers)-1),
+		"timeout": dnsFallbackTimeout,
+	}
+}
+
+// dnsFailoverRules emits an ordered primary-to-fallback resolver chain from
+// sing-box 1.14 DNS rule actions: for every resolver but the last, evaluate
+// exchanges the query (non-terminal on error) and respond returns its answer
+// when the RCODE is NOERROR or NXDOMAIN — both are real answers, and probe
+// nonce queries are expected to draw NXDOMAIN. Everything else (timeout,
+// transport error, SERVFAIL, REFUSED) falls through until the last resolver's
+// terminal route rule. With domainSuffixes the whole chain applies only to
+// those domains and is guaranteed terminal for them; with nil it applies to
+// every remaining query.
+func dnsFailoverRules(dnsServers, domainSuffixes []string, disableCache bool) []any {
+	scopeAndCache := func(rule map[string]any) map[string]any {
+		if len(domainSuffixes) > 0 {
+			rule["domain_suffix"] = domainSuffixes
+		}
+		if disableCache {
+			rule["disable_cache"] = true
+			rule["disable_optimistic_cache"] = true
+		}
+		return rule
+	}
+	var rules []any
+	for i := range dnsServers[:len(dnsServers)-1] {
+		rules = append(rules, scopeAndCache(map[string]any{
+			"action":  "evaluate",
+			"server":  fmt.Sprintf("dns-%d", i),
+			"timeout": dnsPrimaryTimeout,
+		}))
+		for _, rcode := range []string{"NOERROR", "NXDOMAIN"} {
+			respond := map[string]any{
+				"match_response": true,
+				"response_rcode": rcode,
+				"action":         "respond",
+			}
+			if len(domainSuffixes) > 0 {
+				respond["domain_suffix"] = domainSuffixes
+			}
+			rules = append(rules, respond)
+		}
+	}
+	return append(rules, scopeAndCache(map[string]any{
+		"server":  fmt.Sprintf("dns-%d", len(dnsServers)-1),
+		"timeout": dnsFallbackTimeout,
+	}))
+}
+
+// countryDNSRules is the per-country lookup chain for the domains that country
+// bypasses: ask the in-country DoH resolver, and return its answer when it is
+// a real one (NOERROR, or an authoritative NXDOMAIN). Nothing else is
+// terminal, so a resolver that is unreachable, times out, or has let its
+// certificate lapse falls through to the proxied global chain below instead of
+// failing the lookup outright — the same fail-open posture as the rest of the
+// feature, and the reason moving off plaintext UDP cannot cost anyone
+// reachability.
+//
+// rule_set matches against the queried domain in both the query and the
+// response pass, so the response rules stay scoped to this country's domains.
+//
+// Empty for a country with no usable in-country resolver: with nothing to
+// evaluate, its lookups simply reach the global chain, which is where they
+// would end up anyway.
+func countryDNSRules(country string) []any {
+	if splitTunnelDirectResolvers[country] == nil {
+		return nil
+	}
+	ruleSet := []string{"geosite-" + country}
+	rules := []any{
+		map[string]any{
+			"rule_set": ruleSet,
+			"action":   "evaluate",
+			"server":   "dns-direct-" + country,
+			"timeout":  dnsPrimaryTimeout,
+		},
+	}
+	for _, rcode := range []string{"NOERROR", "NXDOMAIN"} {
+		rules = append(rules, map[string]any{
+			"rule_set":       ruleSet,
+			"match_response": true,
+			"response_rcode": rcode,
+			"action":         "respond",
+		})
+	}
+	return rules
+}
+
+// buildRouteConfig emits the route block. Without split tunneling it is the
+// original emission (a single hijack-dns rule and final proxy), byte-identical
+// for existing callers.
+func buildRouteConfig(input SingBoxConfigInput, probeSuffixes []string) map[string]any {
+	var bypassCountries []string
+	bypassLAN := false
+	if input.SplitTunnel != nil {
+		bypassCountries = input.SplitTunnel.BypassCountries
+		bypassLAN = input.SplitTunnel.BypassLAN
+	}
+
+	rules := []any{
+		map[string]any{
+			"protocol": "dns",
+			"action":   "hijack-dns",
+		},
+	}
+	if len(bypassCountries) > 0 {
+		// Route rules need a sniffed domain before geosite matching can work.
+		rules = append(rules, map[string]any{
+			"action": "sniff",
+		})
+		// Probe traffic must reach the proxy even when a bypass rule would
+		// send it direct; a probe that escapes onto the direct path can report
+		// CONNECTED over a dead tunnel. Must precede every bypass rule.
+		rules = append(rules, map[string]any{
+			"domain_suffix": probeSuffixes,
+			"outbound":      "proxy",
+		})
+	}
+	if bypassLAN {
+		rules = append(rules, map[string]any{
+			"ip_is_private": true,
+			"outbound":      "direct",
+		})
+	}
+	for _, country := range bypassCountries {
+		rules = append(rules, map[string]any{
+			"rule_set": []string{"geosite-" + country, "geoip-" + country},
+			"outbound": "direct",
+		})
+	}
+
+	route := map[string]any{
+		"auto_detect_interface":   true,
+		"default_domain_resolver": "dns-0",
+		"rules":                   rules,
+		"final":                   "proxy",
+	}
+	if input.RouteFindProcess {
+		route["find_process"] = true
+	}
+	if len(bypassCountries) > 0 {
+		ruleSets := make([]any, 0, 2*len(bypassCountries))
+		for _, country := range bypassCountries {
+			ruleSets = append(ruleSets,
+				localRuleSetObject(input.SplitTunnel.RuleSetDirectory, "geosite-"+country),
+				localRuleSetObject(input.SplitTunnel.RuleSetDirectory, "geoip-"+country))
+		}
+		route["rule_set"] = ruleSets
+	}
+	return route
+}
+
+func localRuleSetObject(directory, tag string) map[string]any {
+	return map[string]any{
+		"type":   "local",
+		"tag":    tag,
+		"format": "binary",
+		"path":   directory + "/" + tag + ".srs",
+	}
+}
+
+// TunnelDNSAddress returns the next IPv4 address after tunnelIPv4Address,
+// mirroring sing-tun's derivation of the DNS hijack address. When the tun
+// inbound carries no explicit dns_address (we emit none), sing-tun derives the
+// hijack address as the next address after the TUN's own IPv4 address, and the
+// tun inbound tags a packet Protocol=DNS only when its destination equals that
+// address — after which the router hijacks it into the DNS module ahead of any
+// route rule. A datagram addressed to a public resolver (1.1.1.1) is NOT
+// tagged, matches no rule, and dies on the TCP-only proxy outbound, so
+// mobile's fresh-DNS probe must target this address.
+func TunnelDNSAddress(tunnelIPv4Address string) (string, error) {
+	address, _, found := strings.Cut(tunnelIPv4Address, "/")
+	if !found {
+		return "", fmt.Errorf("tunnel address has no prefix length: %s", tunnelIPv4Address)
+	}
+	ip := net.ParseIP(address)
+	if ip == nil || ip.To4() == nil {
+		return "", fmt.Errorf("tunnel address is not IPv4: %s", tunnelIPv4Address)
+	}
+	ip = ip.To4()
+	value := uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
+	next := value + 1
+	return net.IPv4(byte(next>>24), byte(next>>16), byte(next>>8), byte(next)).String(), nil
 }
 
 func validateRelayForConfig(candidate relay.Descriptor) error {

--- a/internal/client/singbox_config_golden_test.go
+++ b/internal/client/singbox_config_golden_test.go
@@ -68,6 +68,109 @@ func goldenCases() []goldenCase {
 				BridgePort:         54321,
 			},
 		},
+
+		// The mobile-shaped cases below mirror the emissions
+		// SingBoxConfiguration.kt / SingBoxConfiguration.swift produce (release
+		// log level, MTU 1400, DoH failover DNS, traffic accounting), so the
+		// mobile-parity structural tests and these goldens together pin the
+		// superset against the mobile generators' own test expectations.
+		{
+			// Full-device Android TUN on the direct relay path.
+			name: "mobile-tun-android",
+			input: SingBoxConfigInput{
+				Relay:            ipRelay,
+				MTU:              1400,
+				LogLevel:         "warn",
+				DNSShape:         DNSShapeDoHFailover,
+				RouteFindProcess: true,
+				ClashAPI:         true,
+			},
+		},
+		{
+			// iOS never emits find_process (nor exclude_package).
+			name: "mobile-tun-ios",
+			input: SingBoxConfigInput{
+				Relay:    ipRelay,
+				MTU:      1400,
+				LogLevel: "warn",
+				DNSShape: DNSShapeDoHFailover,
+				ClashAPI: true,
+			},
+		},
+		{
+			// Mobile's punched AND WSS shape — both hand sing-box the same
+			// loopback bridge, and the platform-protected outer socket means
+			// no route_exclude_address may appear (VpnService.protect exempts
+			// only the Go socket; a peer /32 would leak other apps' traffic).
+			name: "mobile-bridge-android",
+			input: SingBoxConfigInput{
+				Relay:                 ipRelay,
+				MTU:                   1400,
+				LogLevel:              "warn",
+				DNSShape:              DNSShapeDoHFailover,
+				RouteFindProcess:      true,
+				ClashAPI:              true,
+				BridgeHost:            "127.0.0.1",
+				BridgePort:            54321,
+				BridgeOwnsOuterSocket: true,
+			},
+		},
+		{
+			// Iran split tunneling: route bypass + LAN bypass + per-app
+			// exclusion, but NO dns-direct-ir server or country DNS rules —
+			// Iran has no verifiable encrypted in-country resolver today.
+			name: "mobile-split-ir-android",
+			input: SingBoxConfigInput{
+				Relay:            ipRelay,
+				MTU:              1400,
+				LogLevel:         "warn",
+				DNSShape:         DNSShapeDoHFailover,
+				RouteFindProcess: true,
+				ClashAPI:         true,
+				SplitTunnel: &SplitTunnelRules{
+					BypassLAN:        true,
+					BypassCountries:  []string{SplitTunnelCountryIR},
+					ExcludedPackages: []string{"com.tencent.mm", "org.telegram.messenger"},
+					RuleSetDirectory: "/data/user/0/rulesets",
+				},
+			},
+		},
+		{
+			// China split tunneling on iOS: AliDNS direct resolver plus the
+			// probe pins that keep geosite-cn from capturing probe lookups.
+			name: "mobile-split-cn-ios",
+			input: SingBoxConfigInput{
+				Relay:    ipRelay,
+				MTU:      1400,
+				LogLevel: "warn",
+				DNSShape: DNSShapeDoHFailover,
+				ClashAPI: true,
+				SplitTunnel: &SplitTunnelRules{
+					BypassLAN:        true,
+					BypassCountries:  []string{SplitTunnelCountryCN},
+					RuleSetDirectory: "/var/mobile/rulesets",
+				},
+			},
+		},
+		{
+			// Both countries in canonical order, matching the Kotlin
+			// "both countries plus lan keep the full canonical rule order"
+			// expectation.
+			name: "mobile-split-ir-cn-android",
+			input: SingBoxConfigInput{
+				Relay:            ipRelay,
+				MTU:              1400,
+				LogLevel:         "warn",
+				DNSShape:         DNSShapeDoHFailover,
+				RouteFindProcess: true,
+				ClashAPI:         true,
+				SplitTunnel: &SplitTunnelRules{
+					BypassLAN:        true,
+					BypassCountries:  []string{SplitTunnelCountryIR, SplitTunnelCountryCN},
+					RuleSetDirectory: "/data/user/0/rulesets",
+				},
+			},
+		},
 	}
 }
 

--- a/internal/client/singbox_config_golden_test.go
+++ b/internal/client/singbox_config_golden_test.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// goldenCases is the full matrix of builder inputs whose emitted JSON is frozen
+// under testdata/singbox/. The first five entries are the pre-existing
+// desktop/CLI combinations (TUN, TUN with an IP-literal relay, the punched TUN
+// bridge, proxy mode, and the WSS loopback bridge in proxy mode); their goldens
+// were generated before the mobile superset options existed and freezing them
+// is what proves those options are strictly additive — any byte drift on an
+// existing combination is a regression, not a formatting choice.
+type goldenCase struct {
+	name  string
+	input SingBoxConfigInput
+}
+
+func goldenCases() []goldenCase {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	hostRelay := validRelay(now)
+	ipRelay := validRelay(now)
+	ipRelay.PublicHost = "203.0.113.10"
+
+	return []goldenCase{
+		{
+			name:  "tun-default",
+			input: SingBoxConfigInput{Relay: hostRelay},
+		},
+		{
+			name:  "tun-ip-relay",
+			input: SingBoxConfigInput{Relay: ipRelay},
+		},
+		{
+			// The desktop punched path: outbound redirected to the loopback
+			// bridge, relay endpoint and reflexive peer both excluded from the
+			// TUN route (no socket protection exists outside mobile).
+			name: "tun-punched",
+			input: SingBoxConfigInput{
+				Relay:                   ipRelay,
+				BridgeHost:              "127.0.0.1",
+				BridgePort:              54321,
+				PunchPeerExcludeAddress: "198.51.100.7",
+			},
+		},
+		{
+			name: "proxy",
+			input: SingBoxConfigInput{
+				Relay:           hostRelay,
+				Mode:            ModeProxy,
+				ProxyListenPort: 7890,
+			},
+		},
+		{
+			// cmd/wssmatrix's WSS probe shape: a mixed loopback inbound whose
+			// VLESS outbound dials the local WSS bridge.
+			name: "proxy-wss-bridge",
+			input: SingBoxConfigInput{
+				Relay:              hostRelay,
+				Mode:               ModeProxy,
+				ProxyListenAddress: "127.0.0.1",
+				ProxyListenPort:    7890,
+				BridgeHost:         "127.0.0.1",
+				BridgePort:         54321,
+			},
+		},
+	}
+}
+
+// TestBuildSingBoxConfigGolden compares every case against its frozen file.
+// Regenerate deliberately with:
+//
+//	UPDATE_SINGBOX_GOLDEN=1 go test ./internal/client -run TestBuildSingBoxConfigGolden
+func TestBuildSingBoxConfigGolden(t *testing.T) {
+	for _, tc := range goldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildSingBoxConfig(tc.input)
+			if err != nil {
+				t.Fatalf("build sing-box config: %v", err)
+			}
+			path := filepath.Join("testdata", "singbox", tc.name+".golden.json")
+			if os.Getenv("UPDATE_SINGBOX_GOLDEN") != "" {
+				if err := os.WriteFile(path, got, 0o644); err != nil {
+					t.Fatalf("update golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden (run with UPDATE_SINGBOX_GOLDEN=1 to create): %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("config drifted from %s:\n--- want\n%s\n--- got\n%s", path, want, got)
+			}
+		})
+	}
+}

--- a/internal/client/singbox_config_mobile_test.go
+++ b/internal/client/singbox_config_mobile_test.go
@@ -1,0 +1,419 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"openrung/internal/relay"
+)
+
+// The tests below mirror the assertions in mobile's own generator tests
+// (SingBoxConfigurationDnsTest, SingBoxConfigurationSplitTunnelTest,
+// SingBoxConfigurationPunchTest), so the Go builder provably reproduces the
+// emissions mobile expects before it is bound in.
+
+func mobileRelay(t *testing.T) relay.Descriptor {
+	t.Helper()
+	r := validRelay(time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC))
+	r.PublicHost = "203.0.113.10"
+	return r
+}
+
+func mobileInput(r relay.Descriptor) SingBoxConfigInput {
+	return SingBoxConfigInput{
+		Relay:    r,
+		MTU:      1400,
+		LogLevel: "warn",
+		DNSShape: DNSShapeDoHFailover,
+		ClashAPI: true,
+	}
+}
+
+func buildDecoded(t *testing.T, input SingBoxConfigInput) map[string]any {
+	t.Helper()
+	cfg, err := BuildSingBoxConfig(input)
+	if err != nil {
+		t.Fatalf("build sing-box config: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(cfg, &decoded); err != nil {
+		t.Fatalf("config should be valid JSON: %v", err)
+	}
+	return decoded
+}
+
+func dnsRulesOf(decoded map[string]any) []map[string]any {
+	raw := decoded["dns"].(map[string]any)["rules"].([]any)
+	rules := make([]map[string]any, len(raw))
+	for i, r := range raw {
+		rules[i] = r.(map[string]any)
+	}
+	return rules
+}
+
+func routeRulesOf(decoded map[string]any) []map[string]any {
+	raw := decoded["route"].(map[string]any)["rules"].([]any)
+	rules := make([]map[string]any, len(raw))
+	for i, r := range raw {
+		rules[i] = r.(map[string]any)
+	}
+	return rules
+}
+
+func TestMobileNilAndEmptySplitTunnelEmitIdenticalBytes(t *testing.T) {
+	base := mobileInput(mobileRelay(t))
+	baseline, err := BuildSingBoxConfig(base)
+	if err != nil {
+		t.Fatalf("build baseline: %v", err)
+	}
+	withEmpty := base
+	withEmpty.SplitTunnel = &SplitTunnelRules{}
+	emptied, err := BuildSingBoxConfig(withEmpty)
+	if err != nil {
+		t.Fatalf("build with empty split rules: %v", err)
+	}
+	if !bytes.Equal(baseline, emptied) {
+		t.Fatal("all-empty split rules must emit the exact no-split configuration")
+	}
+}
+
+func TestMobileDoHServersAreEncryptedAndProxied(t *testing.T) {
+	input := mobileInput(mobileRelay(t))
+	input.SplitTunnel = &SplitTunnelRules{
+		BypassCountries:  []string{SplitTunnelCountryIR, SplitTunnelCountryCN},
+		RuleSetDirectory: "/data/user/0/rulesets",
+	}
+	decoded := buildDecoded(t, input)
+
+	servers := decoded["dns"].(map[string]any)["servers"].([]any)
+	tags := make([]string, 0, len(servers))
+	for _, s := range servers {
+		server := s.(map[string]any)
+		tag := server["tag"].(string)
+		tags = append(tags, tag)
+		// Proxied resolvers need DoH because TCP/53 gets no replies under WSS;
+		// the direct bypass resolvers need it so a cleartext, forgeable domain
+		// list never leaves the device on the user's real IP. Neither may ever
+		// regress to udp/tcp.
+		if server["type"] != "https" {
+			t.Fatalf("dns server %s is not DoH: %+v", tag, server)
+		}
+		if server["tls"].(map[string]any)["server_name"] == "" {
+			t.Fatalf("dns server %s does not authenticate a hostname", tag)
+		}
+		if strings.HasPrefix(tag, "dns-direct-") {
+			// A direct resolver with a detour to the empty tagged direct
+			// outbound is rejected during sing-box's Start stage.
+			if _, ok := server["detour"]; ok {
+				t.Fatalf("direct resolver %s must build its own dialer: %+v", tag, server)
+			}
+		} else if server["detour"] != "proxy" {
+			t.Fatalf("proxied resolver %s must detour through the proxy: %+v", tag, server)
+		}
+		for _, key := range []string{"server_port", "path", "domain_resolver"} {
+			if _, ok := server[key]; ok {
+				t.Fatalf("dns server %s must keep the %s default: %+v", tag, key, server)
+			}
+		}
+	}
+	// Iran contributes no resolver (no verifiable encrypted endpoint today);
+	// only China does.
+	if !reflect.DeepEqual(tags, []string{"dns-0", "dns-1", "dns-direct-cn"}) {
+		t.Fatalf("unexpected dns server tags: %v", tags)
+	}
+
+	dns := decoded["dns"].(map[string]any)
+	if dns["final"] != "dns-1" || dns["timeout"] != "3s" {
+		t.Fatalf("expected terminal fallback final and 3s timeout, got final=%v timeout=%v", dns["final"], dns["timeout"])
+	}
+	if decoded["route"].(map[string]any)["default_domain_resolver"] != "dns-0" {
+		t.Fatal("default domain resolver must stay on the primary")
+	}
+}
+
+func TestMobileProbeDNSChainIsFirstUncachedAndTerminal(t *testing.T) {
+	baseline := mobileInput(mobileRelay(t))
+	china := mobileInput(mobileRelay(t))
+	china.SplitTunnel = &SplitTunnelRules{
+		BypassCountries:  []string{SplitTunnelCountryCN},
+		RuleSetDirectory: "/data/user/0/rulesets",
+	}
+
+	for _, input := range []SingBoxConfigInput{baseline, china} {
+		rules := dnsRulesOf(buildDecoded(t, input))
+		probeChain := rules[:4]
+		for _, rule := range probeChain {
+			suffixes := rule["domain_suffix"].([]any)
+			if len(suffixes) != 2 || suffixes[0] != "probe.openrung.org" || suffixes[1] != "cp.cloudflare.com" {
+				t.Fatalf("probe rule not scoped to the probe domains: %+v", rule)
+			}
+			if rule["match_response"] != true {
+				// A cached answer proves nothing about the tunnel right now.
+				if rule["disable_cache"] != true || rule["disable_optimistic_cache"] != true {
+					t.Fatalf("probe rule must disable caching: %+v", rule)
+				}
+			}
+		}
+		if probeChain[0]["action"] != "evaluate" || probeChain[0]["server"] != "dns-0" {
+			t.Fatalf("probe chain must start by evaluating the primary: %+v", probeChain[0])
+		}
+		// Nonce probes legitimately draw NXDOMAIN; the primary answering one
+		// must respond.
+		if probeChain[2]["response_rcode"] != "NXDOMAIN" {
+			t.Fatalf("probe chain must respond to NXDOMAIN: %+v", probeChain[2])
+		}
+		// The trailing route rule is terminal (no action key), so a probe
+		// lookup can never leak past it into a country rule.
+		if _, ok := probeChain[3]["action"]; ok {
+			t.Fatalf("probe chain terminus must be a route rule: %+v", probeChain[3])
+		}
+		if probeChain[3]["server"] != "dns-1" {
+			t.Fatalf("probe chain terminus must name the fallback: %+v", probeChain[3])
+		}
+	}
+}
+
+func TestMobileChinaBypassNeverOutranksProbePins(t *testing.T) {
+	input := mobileInput(mobileRelay(t))
+	input.SplitTunnel = &SplitTunnelRules{
+		BypassCountries:  []string{SplitTunnelCountryCN},
+		RuleSetDirectory: "/data/user/0/rulesets",
+	}
+	decoded := buildDecoded(t, input)
+
+	// The confirmed regression this guards: geosite-cn contains
+	// www.gstatic.com, so without the pins a dead proxy still produced a
+	// passing probe over the direct path and the app published CONNECTED.
+	dnsRules := dnsRulesOf(decoded)
+	countryIndex := -1
+	for i, rule := range dnsRules {
+		if _, ok := rule["rule_set"]; ok {
+			countryIndex = i
+			break
+		}
+	}
+	if countryIndex != 4 {
+		t.Fatalf("country dns rule must follow the 4-rule probe chain, got index %d", countryIndex)
+	}
+
+	routeRules := routeRulesOf(decoded)
+	probeIndex, bypassIndex := -1, -1
+	for i, rule := range routeRules {
+		if _, ok := rule["domain_suffix"]; ok && rule["outbound"] == "proxy" && probeIndex < 0 {
+			probeIndex = i
+		}
+		if rule["outbound"] == "direct" && bypassIndex < 0 {
+			bypassIndex = i
+		}
+	}
+	if probeIndex < 0 || bypassIndex < probeIndex {
+		t.Fatalf("probe route pin must exist and precede every direct-bypass rule: probe=%d bypass=%d", probeIndex, bypassIndex)
+	}
+	// Route rules need a sniffed domain before geosite matching can work.
+	if routeRules[1]["action"] != "sniff" {
+		t.Fatalf("sniff must precede the probe pin: %+v", routeRules[1])
+	}
+}
+
+func TestMobileSplitRuleOrderWithBothCountriesAndLAN(t *testing.T) {
+	input := mobileInput(mobileRelay(t))
+	input.SplitTunnel = &SplitTunnelRules{
+		BypassLAN:        true,
+		BypassCountries:  []string{SplitTunnelCountryIR, SplitTunnelCountryCN},
+		RuleSetDirectory: "/data/user/0/rulesets",
+	}
+	decoded := buildDecoded(t, input)
+
+	rules := routeRulesOf(decoded)
+	if len(rules) != 6 {
+		t.Fatalf("expected the 6-rule canonical order, got %d: %+v", len(rules), rules)
+	}
+	if rules[0]["action"] != "hijack-dns" || rules[1]["action"] != "sniff" ||
+		rules[2]["outbound"] != "proxy" || rules[3]["ip_is_private"] != true {
+		t.Fatalf("canonical rule order broken: %+v", rules)
+	}
+	for i, want := range map[int]string{4: "geosite-ir", 5: "geosite-cn"} {
+		ruleSet := rules[i]["rule_set"].([]any)
+		if ruleSet[0] != want || rules[i]["outbound"] != "direct" {
+			t.Fatalf("country rule %d unexpected: %+v", i, rules[i])
+		}
+	}
+
+	ruleSets := decoded["route"].(map[string]any)["rule_set"].([]any)
+	var tags []string
+	for _, rs := range ruleSets {
+		object := rs.(map[string]any)
+		tags = append(tags, object["tag"].(string))
+		if object["type"] != "local" || object["format"] != "binary" {
+			t.Fatalf("rule set must be a local binary .srs: %+v", object)
+		}
+		if object["path"] != "/data/user/0/rulesets/"+object["tag"].(string)+".srs" {
+			t.Fatalf("rule set path unexpected: %+v", object)
+		}
+	}
+	if !reflect.DeepEqual(tags, []string{"geosite-ir", "geoip-ir", "geosite-cn", "geoip-cn"}) {
+		t.Fatalf("unexpected rule set tags: %v", tags)
+	}
+}
+
+func TestMobileExcludedPackagesLandOnTUNOnly(t *testing.T) {
+	input := mobileInput(mobileRelay(t))
+	input.SplitTunnel = &SplitTunnelRules{
+		ExcludedPackages: []string{"com.tencent.mm", "org.telegram.messenger"},
+	}
+	decoded := buildDecoded(t, input)
+
+	tun := decoded["inbounds"].([]any)[0].(map[string]any)
+	excluded := tun["exclude_package"].([]any)
+	if len(excluded) != 2 || excluded[0] != "com.tencent.mm" {
+		t.Fatalf("unexpected exclude_package: %+v", excluded)
+	}
+	// Android forbids mixing the two, and we only ever exclude.
+	if _, ok := tun["include_package"]; ok {
+		t.Fatalf("include_package must never be emitted: %+v", tun)
+	}
+}
+
+func TestMobileBridgeOmitsRouteExclusionsButKeepsSplitRules(t *testing.T) {
+	splitTunnel := &SplitTunnelRules{
+		BypassLAN:        true,
+		BypassCountries:  []string{SplitTunnelCountryIR, SplitTunnelCountryCN},
+		RuleSetDirectory: "/data/user/0/rulesets",
+	}
+	direct := mobileInput(mobileRelay(t))
+	direct.SplitTunnel = splitTunnel
+	bridged := direct
+	bridged.BridgeHost = "127.0.0.1"
+	bridged.BridgePort = 54321
+	bridged.BridgeOwnsOuterSocket = true
+
+	directDecoded := buildDecoded(t, direct)
+	bridgedDecoded := buildDecoded(t, bridged)
+
+	// DNS and route blocks are identical across the direct and bridged shapes.
+	if !reflect.DeepEqual(directDecoded["dns"], bridgedDecoded["dns"]) {
+		t.Fatal("dns block must be identical across direct and bridged shapes")
+	}
+	if !reflect.DeepEqual(directDecoded["route"], bridgedDecoded["route"]) {
+		t.Fatal("route block must be identical across direct and bridged shapes")
+	}
+
+	// Leak-precedent regression guard: the punch/WSS loopback adapter must
+	// never regain a peer /32 exclusion because split tunneling is on —
+	// VpnService.protect(fd) exempts only the transport's own socket, so an
+	// exclusion would leak unrelated apps' traffic to that IP.
+	bridgedTUN := bridgedDecoded["inbounds"].([]any)[0].(map[string]any)
+	if _, ok := bridgedTUN["route_exclude_address"]; ok {
+		t.Fatalf("protected bridge must not emit route exclusions: %+v", bridgedTUN)
+	}
+	directTUN := directDecoded["inbounds"].([]any)[0].(map[string]any)
+	if _, ok := directTUN["route_exclude_address"]; !ok {
+		t.Fatalf("ordinary relay path must keep its endpoint route exclusion: %+v", directTUN)
+	}
+
+	// The bridge changes only the transport endpoint; the Reality identity
+	// still targets the real relay.
+	outbound := bridgedDecoded["outbounds"].([]any)[0].(map[string]any)
+	if outbound["server"] != "127.0.0.1" || outbound["server_port"].(float64) != 54321 {
+		t.Fatalf("outbound not pointed at the bridge: %+v", outbound)
+	}
+	if outbound["tls"].(map[string]any)["server_name"] != "www.cloudflare.com" {
+		t.Fatalf("reality identity changed on the bridge path: %+v", outbound)
+	}
+}
+
+func TestMobileIranContributesNoDNSServerOrRules(t *testing.T) {
+	baseline := mobileInput(mobileRelay(t))
+	iran := mobileInput(mobileRelay(t))
+	iran.SplitTunnel = &SplitTunnelRules{
+		BypassCountries:  []string{SplitTunnelCountryIR},
+		RuleSetDirectory: "/data/user/0/rulesets",
+	}
+	baselineDecoded := buildDecoded(t, baseline)
+	iranDecoded := buildDecoded(t, iran)
+
+	// Iran's ROUTE bypass is untouched, but with no verifiable encrypted
+	// in-country resolver it contributes no dns server and no dns rules — a
+	// dead primary would burn the full evaluate timeout on every bypassed
+	// lookup for an answer it can never receive.
+	if !reflect.DeepEqual(baselineDecoded["dns"], iranDecoded["dns"]) {
+		t.Fatal("an IR bypass must leave the dns block untouched")
+	}
+	rules := routeRulesOf(iranDecoded)
+	last := rules[len(rules)-1]
+	ruleSet := last["rule_set"].([]any)
+	if ruleSet[0] != "geosite-ir" || last["outbound"] != "direct" {
+		t.Fatalf("IR route bypass missing: %+v", last)
+	}
+}
+
+func TestSplitTunnelValidation(t *testing.T) {
+	base := mobileInput(mobileRelay(t))
+	for name, mutate := range map[string]func(*SingBoxConfigInput){
+		"unknown country": func(input *SingBoxConfigInput) {
+			input.SplitTunnel = &SplitTunnelRules{
+				BypassCountries:  []string{"us"},
+				RuleSetDirectory: "/rulesets",
+			}
+		},
+		"duplicate country": func(input *SingBoxConfigInput) {
+			input.SplitTunnel = &SplitTunnelRules{
+				BypassCountries:  []string{"cn", "cn"},
+				RuleSetDirectory: "/rulesets",
+			}
+		},
+		"missing rule set directory": func(input *SingBoxConfigInput) {
+			input.SplitTunnel = &SplitTunnelRules{BypassCountries: []string{"cn"}}
+		},
+		"bypass countries without the DoH shape": func(input *SingBoxConfigInput) {
+			input.DNSShape = DNSShapeTCPProxied
+			input.SplitTunnel = &SplitTunnelRules{
+				BypassCountries:  []string{"cn"},
+				RuleSetDirectory: "/rulesets",
+			}
+		},
+	} {
+		input := base
+		mutate(&input)
+		if _, err := BuildSingBoxConfig(input); err == nil {
+			t.Fatalf("%s: expected an error", name)
+		}
+	}
+}
+
+func TestTunnelDNSAddress(t *testing.T) {
+	got, err := TunnelDNSAddress(DefaultTunnelIPv4Address)
+	if err != nil {
+		t.Fatalf("derive default tunnel DNS address: %v", err)
+	}
+	if got != DefaultTunnelDNSAddress {
+		t.Fatalf("expected %s, got %s", DefaultTunnelDNSAddress, got)
+	}
+	if DefaultTunnelDNSAddress != "172.19.0.2" {
+		t.Fatalf("DefaultTunnelDNSAddress drifted: %s", DefaultTunnelDNSAddress)
+	}
+	// Octet carry, so a future tunnel address change cannot silently derive a
+	// wrong hijack address.
+	if got, err := TunnelDNSAddress("10.0.0.255/30"); err != nil || got != "10.0.1.0" {
+		t.Fatalf("expected 10.0.1.0, got %s (%v)", got, err)
+	}
+	for _, invalid := range []string{"172.19.0.1", "fdfe:dcba:9876::1/126", "bogus/30"} {
+		if _, err := TunnelDNSAddress(invalid); err == nil {
+			t.Fatalf("expected %q to be rejected", invalid)
+		}
+	}
+}
+
+func TestMobileTUNNeverPinsItsOwnDNSAddress(t *testing.T) {
+	// An explicit dns_address on the tun inbound would replace sing-tun's
+	// derived hijack address and silently invalidate the probe target above.
+	decoded := buildDecoded(t, mobileInput(mobileRelay(t)))
+	tun := decoded["inbounds"].([]any)[0].(map[string]any)
+	if _, ok := tun["dns_address"]; ok {
+		t.Fatalf("tun inbound must not pin dns_address: %+v", tun)
+	}
+}

--- a/internal/client/singbox_config_mobile_test.go
+++ b/internal/client/singbox_config_mobile_test.go
@@ -376,11 +376,44 @@ func TestSplitTunnelValidation(t *testing.T) {
 				RuleSetDirectory: "/rulesets",
 			}
 		},
+		"excluded packages in proxy mode": func(input *SingBoxConfigInput) {
+			// exclude_package is a TUN inbound field; in ModeProxy it would be
+			// a silent no-op and the excluded apps' traffic would still be
+			// carried through the proxy.
+			input.Mode = ModeProxy
+			input.ProxyListenPort = 2080
+			input.SplitTunnel = &SplitTunnelRules{
+				ExcludedPackages: []string{"com.tencent.mm"},
+			}
+		},
 	} {
 		input := base
 		mutate(&input)
 		if _, err := BuildSingBoxConfig(input); err == nil {
 			t.Fatalf("%s: expected an error", name)
+		}
+	}
+}
+
+func TestDoHFailoverRejectsUnrepresentableDNSServers(t *testing.T) {
+	// A hostname server would be self-referential (nothing can bootstrap its
+	// own resolver chain), and an unknown IP would be emitted with no
+	// tls.server_name, reintroducing the IP-SAN fragility dohTLSServerNames
+	// exists to prevent.
+	for name, servers := range map[string][]string{
+		"hostname server": {"dns.google"},
+		"unpinned IP":     {"1.1.1.1", "9.9.9.9"},
+	} {
+		input := mobileInput(mobileRelay(t))
+		input.DNSServers = servers
+		if _, err := BuildSingBoxConfig(input); err == nil {
+			t.Fatalf("%s: expected an error", name)
+		}
+		// The TCP shape's legacy emission keeps tolerating the same servers.
+		input.DNSShape = DNSShapeTCPProxied
+		input.ClashAPI = false
+		if _, err := BuildSingBoxConfig(input); err != nil {
+			t.Fatalf("%s: the TCP shape must stay tolerant: %v", name, err)
 		}
 	}
 }

--- a/internal/client/singbox_config_mobile_test.go
+++ b/internal/client/singbox_config_mobile_test.go
@@ -430,11 +430,15 @@ func TestTunnelDNSAddress(t *testing.T) {
 		t.Fatalf("DefaultTunnelDNSAddress drifted: %s", DefaultTunnelDNSAddress)
 	}
 	// Octet carry, so a future tunnel address change cannot silently derive a
-	// wrong hijack address.
-	if got, err := TunnelDNSAddress("10.0.0.255/30"); err != nil || got != "10.0.1.0" {
+	// wrong hijack address. The /23 keeps the successor inside the prefix.
+	if got, err := TunnelDNSAddress("10.0.0.255/23"); err != nil || got != "10.0.1.0" {
 		t.Fatalf("expected 10.0.1.0, got %s (%v)", got, err)
 	}
-	for _, invalid := range []string{"172.19.0.1", "fdfe:dcba:9876::1/126", "bogus/30"} {
+	// sing-tun refuses to derive a hijack address whose successor escapes the
+	// TUN prefix (HasNextAddress), so returning one here would fail every
+	// probe on a healthy tunnel: the last address of a prefix must be
+	// rejected, exactly like a non-IPv4 input.
+	for _, invalid := range []string{"172.19.0.1", "fdfe:dcba:9876::1/126", "bogus/30", "10.0.0.255/30", "172.19.0.3/30"} {
 		if _, err := TunnelDNSAddress(invalid); err == nil {
 			t.Fatalf("expected %q to be rejected", invalid)
 		}

--- a/internal/client/singbox_split_tunnel.go
+++ b/internal/client/singbox_split_tunnel.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+)
+
+// SplitTunnelRules is the validated split-tunneling emission input (mobile's
+// split-tunnel spec §2) — the Go twin of the Kotlin/Swift SplitTunnelRules.
+// This is NOT the persisted mobile preference payload: the caller has already
+// decided policy and verified that BOTH .srs files exist under
+// RuleSetDirectory for every entry in BypassCountries. A nil
+// SingBoxConfigInput.SplitTunnel means split tunneling is disabled and the
+// emitted config is byte-identical to one built without the feature.
+type SplitTunnelRules struct {
+	// BypassLAN routes private-range destinations (ip_is_private) direct.
+	BypassLAN bool
+	// BypassCountries are entries of SplitTunnelSupportedCountries, already
+	// normalized by the caller to that canonical order. Unknown or duplicate
+	// codes are a build error: a duplicate rule-set tag fails sing-box's Start
+	// stage anyway, and failing here names the actual mistake.
+	BypassCountries []string
+	// ExcludedPackages leave the VPN at the OS level via the TUN inbound's
+	// exclude_package. Android-only — iOS has no OS-level per-app exclusion
+	// and its callers leave this empty.
+	ExcludedPackages []string
+	// RuleSetDirectory is the absolute directory containing
+	// geosite-<cc>.srs / geoip-<cc>.srs for every bypass country.
+	RuleSetDirectory string
+}
+
+const (
+	SplitTunnelCountryIR = "ir"
+	SplitTunnelCountryCN = "cn"
+)
+
+// SplitTunnelSupportedCountries are the countries with bundled rule sets, in
+// the canonical emission order.
+var SplitTunnelSupportedCountries = []string{SplitTunnelCountryIR, SplitTunnelCountryCN}
+
+// splitTunnelDirectResolver is an in-country public resolver reached over the
+// DIRECT path, so bypassed domains resolve to in-country CDN nodes instead of
+// the relay exit's view of them.
+//
+// DoH over 443, never plaintext UDP/53: these queries leave the device on the
+// user's real IP while the tunnel is up, so the local network, the ISP and
+// anything else on the path must not get a cleartext list of the domains being
+// bypassed (nor the chance to forge the answers). server stays an IP literal
+// so no bootstrap lookup is needed, and TLS authenticates tlsServerName — the
+// same shape the proxied DoH resolvers use.
+type splitTunnelDirectResolver struct {
+	server        string
+	tlsServerName string
+}
+
+// splitTunnelDirectResolvers maps every supported country to its direct-path
+// resolver. A nil entry means the country has no encrypted public resolver we
+// can currently stand behind: its bypass then keeps its ROUTE rules — the
+// traffic still takes the direct path — and only its lookups fall to the
+// proxied DoH chain, resolving through the relay exit's view. That costs
+// in-country CDN affinity and nothing else.
+//
+// A resolver goes in here only while its certificate actually validates.
+// Anything else is worse than omitting it: sing-box would spend the full
+// evaluate timeout failing the TLS handshake on EVERY bypassed lookup before
+// the fallback runs, so users would pay latency for an in-country answer they
+// can never receive. Never restore one on the strength of its documentation —
+// verify the live endpoint first.
+var splitTunnelDirectResolvers = map[string]*splitTunnelDirectResolver{
+	// Shecan is Iran's usual public resolver, but every endpoint it publishes
+	// (178.22.122.100, 185.51.200.2, dns.shecan.ir) served an expired Let's
+	// Encrypt certificate as of 2026-08-12 (notAfter Jul 10 2026), on both 443
+	// and 853. Electro (78.157.42.100) refuses both ports and Begzar's DoH host
+	// no longer resolves, so Iran has no verifiable encrypted resolver to point
+	// at right now.
+	SplitTunnelCountryIR: nil,
+	// AliDNS (Chinese public resolver); https://223.5.5.5/dns-query is a
+	// published endpoint and its certificate covers the IP literal.
+	SplitTunnelCountryCN: {server: "223.5.5.5", tlsServerName: "dns.alidns.com"},
+}
+
+// validateSplitTunnel rejects split-tunnel inputs the emission below cannot
+// represent safely. Bypass countries require the DoH failover DNS shape: the
+// probe-priority pins that keep a country rule set (geosite-cn ships
+// gstatic-class hosts) from capturing probe lookups only exist in that shape,
+// and shipping country ROUTE rules without them recreates the confirmed
+// CONNECTED-over-a-dead-tunnel regression mobile's tests guard against.
+func validateSplitTunnel(input SingBoxConfigInput) error {
+	rules := input.SplitTunnel
+	if rules == nil || len(rules.BypassCountries) == 0 {
+		return nil
+	}
+	if input.DNSShape != DNSShapeDoHFailover {
+		return errors.New("split-tunnel bypass countries require DNSShapeDoHFailover")
+	}
+	if rules.RuleSetDirectory == "" {
+		return errors.New("split-tunnel bypass countries require a rule set directory")
+	}
+	seen := make(map[string]bool, len(rules.BypassCountries))
+	for _, country := range rules.BypassCountries {
+		if _, supported := splitTunnelDirectResolvers[country]; !supported {
+			return fmt.Errorf("unsupported split-tunnel country: %q", country)
+		}
+		if seen[country] {
+			return fmt.Errorf("duplicate split-tunnel country: %q", country)
+		}
+		seen[country] = true
+	}
+	return nil
+}

--- a/internal/client/singbox_split_tunnel.go
+++ b/internal/client/singbox_split_tunnel.go
@@ -80,14 +80,23 @@ var splitTunnelDirectResolvers = map[string]*splitTunnelDirectResolver{
 }
 
 // validateSplitTunnel rejects split-tunnel inputs the emission below cannot
-// represent safely. Bypass countries require the DoH failover DNS shape: the
-// probe-priority pins that keep a country rule set (geosite-cn ships
-// gstatic-class hosts) from capturing probe lookups only exist in that shape,
-// and shipping country ROUTE rules without them recreates the confirmed
+// represent safely. Excluded packages require the TUN inbound:
+// exclude_package is a TUN field, so in ModeProxy the setting would be a
+// silent no-op and apps the caller believes leave the VPN would still be
+// carried through the proxy. Bypass countries require the DoH failover DNS
+// shape: the probe-priority pins that keep a country rule set (geosite-cn
+// ships gstatic-class hosts) from capturing probe lookups only exist in that
+// shape, and shipping country ROUTE rules without them recreates the confirmed
 // CONNECTED-over-a-dead-tunnel regression mobile's tests guard against.
 func validateSplitTunnel(input SingBoxConfigInput) error {
 	rules := input.SplitTunnel
-	if rules == nil || len(rules.BypassCountries) == 0 {
+	if rules == nil {
+		return nil
+	}
+	if len(rules.ExcludedPackages) > 0 && input.Mode == ModeProxy {
+		return errors.New("split-tunnel excluded packages require ModeTUN: exclude_package is a TUN inbound field")
+	}
+	if len(rules.BypassCountries) == 0 {
 		return nil
 	}
 	if input.DNSShape != DNSShapeDoHFailover {

--- a/internal/client/testdata/singbox/mobile-bridge-android.golden.json
+++ b/internal/client/testdata/singbox/mobile-bridge-android.golden.json
@@ -1,0 +1,156 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/mobile-split-cn-ios.golden.json
+++ b/internal/client/testdata/singbox/mobile-split-cn-ios.golden.json
@@ -1,0 +1,226 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/mobile-split-ir-android.golden.json
+++ b/internal/client/testdata/singbox/mobile-split-ir-android.golden.json
@@ -1,0 +1,198 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "exclude_package": [
+        "com.tencent.mm",
+        "org.telegram.messenger"
+      ],
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/mobile-split-ir-cn-android.golden.json
+++ b/internal/client/testdata/singbox/mobile-split-ir-cn-android.golden.json
@@ -1,0 +1,246 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/mobile-tun-android.golden.json
+++ b/internal/client/testdata/singbox/mobile-tun-android.golden.json
@@ -1,0 +1,159 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/mobile-tun-ios.golden.json
+++ b/internal/client/testdata/singbox/mobile-tun-ios.golden.json
@@ -1,0 +1,158 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/proxy-wss-bridge.golden.json
+++ b/internal/client/testdata/singbox/proxy-wss-bridge.golden.json
@@ -1,0 +1,75 @@
+{
+  "dns": {
+    "final": "dns-0",
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "type": "tcp"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "type": "tcp"
+      }
+    ]
+  },
+  "inbounds": [
+    {
+      "listen": "127.0.0.1",
+      "listen_port": 7890,
+      "tag": "mixed-in",
+      "type": "mixed"
+    }
+  ],
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/proxy.golden.json
+++ b/internal/client/testdata/singbox/proxy.golden.json
@@ -1,0 +1,75 @@
+{
+  "dns": {
+    "final": "dns-0",
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "type": "tcp"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "type": "tcp"
+      }
+    ]
+  },
+  "inbounds": [
+    {
+      "listen": "127.0.0.1",
+      "listen_port": 7890,
+      "tag": "mixed-in",
+      "type": "mixed"
+    }
+  ],
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "relay.example.com",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/tun-default.golden.json
+++ b/internal/client/testdata/singbox/tun-default.golden.json
@@ -1,0 +1,83 @@
+{
+  "dns": {
+    "final": "dns-0",
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "type": "tcp"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "type": "tcp"
+      }
+    ]
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1500,
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "relay.example.com",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/tun-ip-relay.golden.json
+++ b/internal/client/testdata/singbox/tun-ip-relay.golden.json
@@ -1,0 +1,86 @@
+{
+  "dns": {
+    "final": "dns-0",
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "type": "tcp"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "type": "tcp"
+      }
+    ]
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1500,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/internal/client/testdata/singbox/tun-punched.golden.json
+++ b/internal/client/testdata/singbox/tun-punched.golden.json
@@ -1,0 +1,87 @@
+{
+  "dns": {
+    "final": "dns-0",
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "type": "tcp"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "type": "tcp"
+      }
+    ]
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1500,
+      "route_exclude_address": [
+        "203.0.113.10/32",
+        "198.51.100.7/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "public-key",
+          "short_id": "5f7a8d9c01ab23cd"
+        },
+        "server_name": "www.cloudflare.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "2c08df10-4ef4-4ab9-95c6-cb1e94cdb2ff"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Mobile's `SingBoxConfiguration.kt` (~485 lines) and `SingBoxConfiguration.swift` (~407) diverged ahead of `internal/client/singbox_config.go`. This PR upstreams those capabilities into `BuildSingBoxConfig` so the Go builder becomes the single superset, in preparation for binding it into mobile (D-track).

Two commits, in the order the prompt requires:

1. **Freeze today's output** — golden-file test (`testdata/singbox/*.golden.json`) over the five pre-existing combinations (TUN hostname relay, TUN IP relay, punched TUN bridge, proxy mode, wssmatrix proxy+WSS bridge), generated from the **unmodified** builder.
2. **The superset** — new option fields on `SingBoxConfigInput` (all zero values reproduce the frozen bytes exactly; the commit-1 goldens pass unchanged), plus six mobile-shaped goldens and structural tests mirroring mobile's own generator-test assertions (`SingBoxConfigurationDnsTest`, `SingBoxConfigurationSplitTunnelTest`, `SingBoxConfigurationPunchTest`).

## Mobile feature → Go option

| Mobile feature | Go option |
|---|---|
| Split tunneling (`.srs` local rule sets, LAN bypass) | `SingBoxConfigInput.SplitTunnel *SplitTunnelRules` (`BypassLAN`, `BypassCountries`, `RuleSetDirectory`) |
| IR/CN in-country direct DoH resolvers (`dns-direct-<cc>` + country evaluate/respond chains) | `SplitTunnelRules.BypassCountries` + the `splitTunnelDirectResolvers` table (IR deliberately nil — no verifiable encrypted resolver as of 2026-08-12; CN = AliDNS `223.5.5.5` / `dns.alidns.com`) |
| Platform DNS shape: DoH-over-443 via the proxy, pinned TLS hostnames, uncached terminal probe chain, global evaluate/respond failover, `final` on the terminal fallback, `timeout: 3s` | `DNSShape: DNSShapeDoHFailover` (zero value `DNSShapeTCPProxied` keeps today's TCP/53 emission byte-identical); probe hostnames overridable via `ProbeDomainSuffixes` (default `probe.openrung.org`, `cp.cloudflare.com`) |
| Punch / WSS loopback-bridge outbound wiring | existing `BridgeHost`/`BridgePort` (unchanged) |
| Protected-socket posture: bridged mobile transport emits **no** `route_exclude_address` (a peer /32 would leak other apps' traffic; `VpnService.protect` exempts only the transport's socket) | `BridgeOwnsOuterSocket bool` |
| Android `route.find_process` | `RouteFindProcess bool` |
| Android per-app exclusion (`exclude_package`, never `include_package`) | `SplitTunnelRules.ExcludedPackages` |
| Traffic accounting (`experimental.clash_api {}`) | `ClashAPI bool` |
| Release log level (`warn`) | `LogLevel string` (empty keeps `info`) |
| TUN DNS hijack-address derivation (`tunnelDnsAddress`, probe target) | `TunnelDNSAddress()` + `DefaultTunnelDNSAddress` |
| MTU 1400 | existing `MTU` field (Go default stays 1500; mobile passes 1400) |

## Golden coverage

Frozen pre-change: `tun-default`, `tun-ip-relay`, `tun-punched`, `proxy`, `proxy-wss-bridge`.
Mobile-shaped: `mobile-tun-android`, `mobile-tun-ios`, `mobile-bridge-android` (mobile punch and WSS hand sing-box the same bridge shape), `mobile-split-ir-android`, `mobile-split-cn-ios`, `mobile-split-ir-cn-android`.
Regenerate deliberately with `UPDATE_SINGBOX_GOLDEN=1 go test ./internal/client -run TestBuildSingBoxConfigGolden`.

Structural tests additionally pin mobile's load-bearing invariants: probe DNS chain first/uncached/terminal, country DNS rule at index 4, probe route pin preceding every direct-bypass rule, sniff before the pins, bridge+split keeping dns/route identical to direct+split while omitting all route exclusions, IR contributing no DNS server or rules, no plaintext DNS server anywhere in the DoH shape, and `exclude_package` never accompanied by `include_package`.

## Resolved divergences

- **Byte-for-byte scope**: neither mobile serializer can match Go byte-for-byte at the encoder level — Kotlin `kotlinx` pretty-print keeps insertion order with 4-space indent, and Swift `JSONSerialization` escapes `/` as `\/`. Go's `MarshalIndent` over maps (sorted keys, 2-space indent) matches Swift's `.sortedKeys` output modulo that escaping. Parity with mobile is therefore exact at the JSON-value level (all arrays ordered identically); the goldens freeze Go's serialization.
- **Bridged relay route exclusion**: mobile omits `route_exclude_address` whenever a bridge is set; desktop's punched path today emits the relay *and* peer exclusions (no fd protection exists there). Kept desktop's behavior for existing combinations and gated the mobile posture behind `BridgeOwnsOuterSocket` instead of keying off the bridge alone.
- **Partial bridge**: mobile throws on host-without-port; Go's existing behavior (silently ignore a partial bridge) is frozen and kept.
- **Country validation**: Kotlin throws on an unsupported country, Swift silently drops it. Go fails closed with an error on unknown or duplicate codes and requires `RuleSetDirectory`; bypass countries also require `DNSShapeDoHFailover`, because the probe-priority pins that stop geosite-cn from capturing probe lookups only exist in that shape (mobile only ever has that shape, so this constrains nothing mobile does).
- **Defaults kept**: Go's `MTU` default stays 1500 and log level stays `info` (mobile passes 1400 / `warn` explicitly), preserving existing CLI/desktop output.
- **DoH resolver allowlist** (added in the review-fix commit 9991e51): mobile emits a DoH server with no `tls` block when it has no pinned hostname — a dead branch there, since its resolver list is hardcoded. Go's `DNSServers` is caller-supplied, so `DNSShapeDoHFailover` now rejects hostname servers (self-referential: nothing can bootstrap the resolver chain that resolves them) and IP literals absent from `dohTLSServerNames` (an un-authenticated hostname would reintroduce the IP-SAN fragility the map exists to prevent). The TCP shape keeps tolerating arbitrary servers, byte-identically. Constrains nothing mobile emits.
- **Excluded packages outside TUN** (same commit): `exclude_package` is a TUN inbound field, so mobile's Android-only setting would be a silent no-op in `ModeProxy` — apps the caller believes leave the VPN would still ride the proxy. The combination is now a build error. Mobile has no proxy mode, so this too constrains nothing mobile does.
- **DNS successor outside the TUN prefix** (commit d9c20b3, Codex finding): the pinned sing-tun derives the DNS hijack address as `Addr().Next()` **only when the successor stays inside the TUN prefix** (`HasNextAddress` = `prefix.Contains(addr.Next())`); otherwise it hijacks no IPv4 address. Mobile's `tunnelDnsAddress` helpers are prefix-blind and would return such an escaping successor (harmless for the shipping `172.19.0.1/30`, whose successor is contained); Go's `TunnelDNSAddress` now parses the full prefix and rejects an escaping successor instead of returning an address sing-box never hijacks. Mobile's helpers deserve the same fix as a follow-up in that repo.

## Verification

- `go build ./... && go vet ./... && go test ./...` — root module green.
- `go build ./... && go test ./...` in `desktop/` and `desktop-volunteer/` — green (with the usual untracked `frontend/dist` placeholder).
- `gofmt` clean; no wire behavior touched (registration/heartbeat/directory/telemetry unchanged); no nested-module changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

