### PR TITLE
Trim dead and test-only code left by the ADR-001 consolidation

### DIFF
--- a/internal/relay/wss_capability.go
+++ b/internal/relay/wss_capability.go
@@ -24,9 +24,7 @@ const (
 	// relay-local sidecar. A front URL cannot select any other sidecar route.
 	WSSBridgePath = wsscore.BridgePath
 
-	MaxWSSFronts        = wsscore.MaxFronts
-	MaxWSSFrontIDBytes  = wsscore.MaxFrontIDBytes
-	MaxWSSFrontURLBytes = wsscore.MaxFrontURLBytes
+	MaxWSSFronts = wsscore.MaxFronts
 	// Capability and identity expiry are required to match exactly, so keep
 	// their signer TTL and verifier ceiling tied together as well.
 	MaxWSSCapabilityProofWindow = MaxIdentityProofWindow

--- a/internal/relayruntime/engine/probe_pin_test.go
+++ b/internal/relayruntime/engine/probe_pin_test.go
@@ -42,23 +42,23 @@ func TestProbePinnedSelfSignedHubSelectsDirect(t *testing.T) {
 
 	// Matching pin: the HTTPS probe validates, the hub dials the relay's
 	// loopback listener back, and detection reports reachable → direct mode.
-	reachable, host, err := relayruntime.DetectDirectReachable(
+	result := relayruntime.ProbeDirectReachability(
 		context.Background(), ts.URL, "", "::", port, eng.probeClient(Config{HubCertFingerprint: fp}))
-	if err != nil {
-		t.Fatalf("probe under matching pin must not error (it forces tunnel fallback): %v", err)
+	if result.Err != nil {
+		t.Fatalf("probe under matching pin must not error (it forces tunnel fallback): %v", result.Err)
 	}
-	if !reachable {
+	if result.Outcome != relayruntime.DirectProbeReachable {
 		t.Fatal("probe under matching pin must report reachable so auto mode selects direct")
 	}
-	if host != "127.0.0.1" {
-		t.Fatalf("observed host = %q, want 127.0.0.1", host)
+	if result.ObservedHost != "127.0.0.1" {
+		t.Fatalf("observed host = %q, want 127.0.0.1", result.ObservedHost)
 	}
 
 	// Wrong pin: the probe must fail cert validation (→ inconclusive → tunnel),
 	// proving the pin is genuinely enforced and not merely skipping verification.
-	_, _, err = relayruntime.DetectDirectReachable(
+	wrongPin := relayruntime.ProbeDirectReachability(
 		context.Background(), ts.URL, "", "::", freePort(t), eng.probeClient(Config{HubCertFingerprint: strings.Repeat("00", 32)}))
-	if err == nil {
+	if wrongPin.Err == nil {
 		t.Fatal("probe under a wrong pin must fail, not silently succeed")
 	}
 }
@@ -74,9 +74,9 @@ func TestProbeUnpinnedSelfSignedHubFails(t *testing.T) {
 	defer ts.Close()
 
 	eng := New(Config{}, Events{})
-	_, _, err := relayruntime.DetectDirectReachable(
+	unpinned := relayruntime.ProbeDirectReachability(
 		context.Background(), ts.URL, "", "::", freePort(t), eng.probeClient(Config{}))
-	if err == nil {
+	if unpinned.Err == nil {
 		t.Fatal("unpinned probe against a self-signed hub must fail standard verification")
 	}
 }

--- a/internal/relayruntime/probe.go
+++ b/internal/relayruntime/probe.go
@@ -49,20 +49,14 @@ type DirectProbeResult struct {
 	Err          error
 }
 
-// DetectDirectReachable opens a temporary TCP listener on port, asks the hub to
-// dial it back at the relay's observed public IP, and reports whether that
-// inbound connection succeeded. The temporary listener answers each accepted
-// connection with the nonce line so the hub can confirm it reached this
-// relay. reachable=false with err=nil means "probed, not reachable" (→
-// tunnel); a non-nil err means the probe itself could not run (hub HTTP API
-// unreachable), which the caller treats as inconclusive.
-func DetectDirectReachable(ctx context.Context, hubHTTPBase, token, listenHost string, port int, httpClient *http.Client) (reachable bool, observedHost string, err error) {
-	result := ProbeDirectReachability(ctx, hubHTTPBase, token, listenHost, port, httpClient)
-	return result.Outcome == DirectProbeReachable, result.ObservedHost, result.Err
-}
-
-// ProbeDirectReachability is the structured form of DetectDirectReachable.
-// Direct mode is safe to advertise only when Outcome is DirectProbeReachable.
+// ProbeDirectReachability opens a temporary TCP listener on port, asks the hub
+// to dial it back at the relay's observed public IP, and reports the outcome.
+// The temporary listener answers each accepted connection with the nonce line
+// so the hub can confirm it reached this relay. Direct mode is safe to
+// advertise only when Outcome is DirectProbeReachable; any other Outcome with
+// a nil Err means "probed, not reachable" (→ tunnel), and a non-nil Err means
+// the probe itself could not run (hub HTTP API unreachable), which the caller
+// treats as inconclusive.
 func ProbeDirectReachability(ctx context.Context, hubHTTPBase, token, listenHost string, port int, httpClient *http.Client) DirectProbeResult {
 	nonceBytes := make([]byte, 8)
 	if _, err := rand.Read(nonceBytes); err != nil {

--- a/internal/relayruntime/probe_test.go
+++ b/internal/relayruntime/probe_test.go
@@ -31,10 +31,10 @@ func freeTCPPort(t *testing.T) int {
 	return port
 }
 
-// TestDetectDirectReachableReachable wires the real hub prober to the relay
+// TestProbeDirectReachabilityReachable wires the real hub prober to the relay
 // detection client on loopback: the relay opens its temporary listener, the hub
-// dials it back at the observed source IP, and detection reports reachable.
-func TestDetectDirectReachableReachable(t *testing.T) {
+// dials it back at the observed source IP, and the probe reports reachable.
+func TestProbeDirectReachabilityReachable(t *testing.T) {
 	prober := tunnel.NewReachabilityProber("token123", testLogger())
 	mux := http.NewServeMux()
 	prober.Register(mux)
@@ -42,29 +42,29 @@ func TestDetectDirectReachableReachable(t *testing.T) {
 	defer ts.Close()
 
 	port := freeTCPPort(t)
-	reachable, host, err := DetectDirectReachable(context.Background(), ts.URL, "token123", "::", port, ts.Client())
-	if err != nil {
-		t.Fatalf("detect: %v", err)
+	result := ProbeDirectReachability(context.Background(), ts.URL, "token123", "::", port, ts.Client())
+	if result.Err != nil {
+		t.Fatalf("probe: %v", result.Err)
 	}
-	if !reachable {
-		t.Fatal("expected reachable on loopback")
+	if result.Outcome != DirectProbeReachable {
+		t.Fatalf("outcome = %q, want reachable on loopback", result.Outcome)
 	}
-	if host != "127.0.0.1" {
-		t.Fatalf("observed host = %q, want 127.0.0.1", host)
+	if result.ObservedHost != "127.0.0.1" {
+		t.Fatalf("observed host = %q, want 127.0.0.1", result.ObservedHost)
 	}
 }
 
-// TestDetectDirectReachableHubDown returns an inconclusive error (not a false
+// TestProbeDirectReachabilityHubDown returns an inconclusive error (not a false
 // "reachable") when the hub HTTP API cannot be reached.
-func TestDetectDirectReachableHubDown(t *testing.T) {
+func TestProbeDirectReachabilityHubDown(t *testing.T) {
 	// A URL that refuses connections.
 	deadURL := "http://127.0.0.1:1"
 	port := freeTCPPort(t)
-	reachable, _, err := DetectDirectReachable(context.Background(), deadURL, "", "::", port, &http.Client{})
-	if err == nil {
+	result := ProbeDirectReachability(context.Background(), deadURL, "", "::", port, &http.Client{})
+	if result.Err == nil {
 		t.Fatal("expected an error when the hub is unreachable")
 	}
-	if reachable {
+	if result.Outcome == DirectProbeReachable {
 		t.Fatal("must not report reachable when the probe could not run")
 	}
 }

--- a/internal/tunnel/allocator.go
+++ b/internal/tunnel/allocator.go
@@ -66,13 +66,6 @@ func (a *PortAllocator) Release(port int) {
 	delete(a.inUse, port)
 }
 
-// InUse reports how many ports are currently allocated.
-func (a *PortAllocator) InUse() int {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return len(a.inUse)
-}
-
 func portBindable(port int) bool {
 	listener, err := net.Listen("tcp", net.JoinHostPort("", strconv.Itoa(port)))
 	if err != nil {

--- a/internal/tunnel/allocator_test.go
+++ b/internal/tunnel/allocator_test.go
@@ -17,6 +17,14 @@ func freePort(t *testing.T) int {
 	return port
 }
 
+// inUse reports how many ports are currently allocated — test-only
+// observability; production code never inspects the pool size.
+func (a *PortAllocator) allocatedCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.inUse)
+}
+
 func TestPortAllocatorInvalidRange(t *testing.T) {
 	if _, err := NewPortAllocator(0, 10); err == nil {
 		t.Fatal("expected error for start < 1")
@@ -43,8 +51,8 @@ func TestPortAllocatorAllocateReleaseExhaust(t *testing.T) {
 	if got != port {
 		t.Fatalf("Allocate returned %d, want %d", got, port)
 	}
-	if alloc.InUse() != 1 {
-		t.Fatalf("InUse = %d, want 1", alloc.InUse())
+	if alloc.allocatedCount() != 1 {
+		t.Fatalf("InUse = %d, want 1", alloc.allocatedCount())
 	}
 
 	if _, err := alloc.Allocate(); !errors.Is(err, errPortsExhausted) {
@@ -52,8 +60,8 @@ func TestPortAllocatorAllocateReleaseExhaust(t *testing.T) {
 	}
 
 	alloc.Release(port)
-	if alloc.InUse() != 0 {
-		t.Fatalf("InUse after release = %d, want 0", alloc.InUse())
+	if alloc.allocatedCount() != 0 {
+		t.Fatalf("InUse after release = %d, want 0", alloc.allocatedCount())
 	}
 	if _, err := alloc.Allocate(); err != nil {
 		t.Fatalf("Allocate after release: %v", err)

--- a/internal/tunnel/allocator_test.go
+++ b/internal/tunnel/allocator_test.go
@@ -17,8 +17,6 @@ func freePort(t *testing.T) int {
 	return port
 }
 
-// inUse reports how many ports are currently allocated — test-only
-// observability; production code never inspects the pool size.
 func (a *PortAllocator) allocatedCount() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -52,7 +50,7 @@ func TestPortAllocatorAllocateReleaseExhaust(t *testing.T) {
 		t.Fatalf("Allocate returned %d, want %d", got, port)
 	}
 	if alloc.allocatedCount() != 1 {
-		t.Fatalf("InUse = %d, want 1", alloc.allocatedCount())
+		t.Fatalf("allocatedCount = %d, want 1", alloc.allocatedCount())
 	}
 
 	if _, err := alloc.Allocate(); !errors.Is(err, errPortsExhausted) {
@@ -61,7 +59,7 @@ func TestPortAllocatorAllocateReleaseExhaust(t *testing.T) {
 
 	alloc.Release(port)
 	if alloc.allocatedCount() != 0 {
-		t.Fatalf("InUse after release = %d, want 0", alloc.allocatedCount())
+		t.Fatalf("allocatedCount after release = %d, want 0", alloc.allocatedCount())
 	}
 	if _, err := alloc.Allocate(); err != nil {
 		t.Fatalf("Allocate after release: %v", err)

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -267,8 +267,8 @@ func TestHubClientEndToEnd(t *testing.T) {
 
 	// Teardown: cancel the client; the hub should free the allocated port.
 	clientCancel()
-	if !eventually(3*time.Second, func() bool { return alloc.InUse() == 0 }) {
-		t.Fatalf("port not released after teardown, InUse=%d", alloc.InUse())
+	if !eventually(3*time.Second, func() bool { return alloc.allocatedCount() == 0 }) {
+		t.Fatalf("port not released after teardown, InUse=%d", alloc.allocatedCount())
 	}
 }
 
@@ -394,8 +394,8 @@ func TestHubRejectsBadToken(t *testing.T) {
 	if registers, _, _ := registrar.stats(); registers != 0 {
 		t.Fatalf("register called on auth failure: %d", registers)
 	}
-	if alloc.InUse() != 0 {
-		t.Fatalf("port allocated on auth failure: %d", alloc.InUse())
+	if alloc.allocatedCount() != 0 {
+		t.Fatalf("port allocated on auth failure: %d", alloc.allocatedCount())
 	}
 }
 

--- a/internal/tunnel/server_test.go
+++ b/internal/tunnel/server_test.go
@@ -268,7 +268,7 @@ func TestHubClientEndToEnd(t *testing.T) {
 	// Teardown: cancel the client; the hub should free the allocated port.
 	clientCancel()
 	if !eventually(3*time.Second, func() bool { return alloc.allocatedCount() == 0 }) {
-		t.Fatalf("port not released after teardown, InUse=%d", alloc.allocatedCount())
+		t.Fatalf("port not released after teardown, allocatedCount=%d", alloc.allocatedCount())
 	}
 }
 

--- a/internal/wssbridge/replay.go
+++ b/internal/wssbridge/replay.go
@@ -91,48 +91,6 @@ func (i *replayIndex) prune(nowUnixNano int64) int {
 	return removed
 }
 
-// MemoryReplayStore is a bounded single-process replay store. It is useful for
-// tests and embedded callers that explicitly accept process-local durability.
-// The production sidecar command uses DurableReplayStore instead.
-type MemoryReplayStore struct {
-	mu         sync.Mutex
-	index      replayIndex
-	maxEntries int
-	now        func() time.Time
-}
-
-func NewMemoryReplayStore(maxEntries int) *MemoryReplayStore {
-	if maxEntries <= 0 {
-		maxEntries = defaultReplayEntries
-	}
-	return &MemoryReplayStore{index: newReplayIndex(), maxEntries: maxEntries, now: time.Now}
-}
-
-func (s *MemoryReplayStore) Consume(ctx context.Context, jti string, expiresAt time.Time) (bool, error) {
-	if err := validateReplayConsume(ctx, jti, expiresAt); err != nil {
-		return false, err
-	}
-	if s == nil || s.maxEntries <= 0 || s.now == nil {
-		return false, errors.New("replay store is not initialized")
-	}
-	nowUnixNano := s.now().UTC().UnixNano()
-	if expiresAt.UTC().UnixNano() <= nowUnixNano {
-		return false, ErrExpiredTicket
-	}
-	key := newReplayKey(jti)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.index.prune(nowUnixNano)
-	if s.index.contains(key, nowUnixNano) {
-		return false, nil
-	}
-	if len(s.index.entries) >= s.maxEntries {
-		return false, ErrReplayStoreFull
-	}
-	s.index.insert(key, expiresAt.UTC().UnixNano())
-	return true, nil
-}
-
 // DurableReplayStore is a bounded, relay-local append-and-fsync replay
 // journal. Consume returns true only after the hashed JTI is durable. A
 // separate lifetime lock prevents two sidecar processes from sharing the same

--- a/internal/wssbridge/replay_test.go
+++ b/internal/wssbridge/replay_test.go
@@ -13,23 +13,21 @@ import (
 	"time"
 )
 
-// MemoryReplayStore is a bounded single-process replay store, kept as a test
-// double: the production sidecar command always uses DurableReplayStore.
-type MemoryReplayStore struct {
+type memoryReplayStore struct {
 	mu         sync.Mutex
 	index      replayIndex
 	maxEntries int
 	now        func() time.Time
 }
 
-func NewMemoryReplayStore(maxEntries int) *MemoryReplayStore {
+func newMemoryReplayStore(maxEntries int) *memoryReplayStore {
 	if maxEntries <= 0 {
 		maxEntries = defaultReplayEntries
 	}
-	return &MemoryReplayStore{index: newReplayIndex(), maxEntries: maxEntries, now: time.Now}
+	return &memoryReplayStore{index: newReplayIndex(), maxEntries: maxEntries, now: time.Now}
 }
 
-func (s *MemoryReplayStore) Consume(ctx context.Context, jti string, expiresAt time.Time) (bool, error) {
+func (s *memoryReplayStore) Consume(ctx context.Context, jti string, expiresAt time.Time) (bool, error) {
 	if err := validateReplayConsume(ctx, jti, expiresAt); err != nil {
 		return false, err
 	}
@@ -56,7 +54,7 @@ func (s *MemoryReplayStore) Consume(ctx context.Context, jti string, expiresAt t
 
 func TestMemoryReplayStoreSingleUseBoundAndExpiryCleanup(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0).UTC()
-	store := NewMemoryReplayStore(1)
+	store := newMemoryReplayStore(1)
 	store.now = func() time.Time { return now }
 	if consumed, err := store.Consume(context.Background(), "ticket-jti-00000001", now.Add(time.Minute)); err != nil || !consumed {
 		t.Fatalf("first consume = %t, %v", consumed, err)

--- a/internal/wssbridge/replay_test.go
+++ b/internal/wssbridge/replay_test.go
@@ -13,6 +13,47 @@ import (
 	"time"
 )
 
+// MemoryReplayStore is a bounded single-process replay store, kept as a test
+// double: the production sidecar command always uses DurableReplayStore.
+type MemoryReplayStore struct {
+	mu         sync.Mutex
+	index      replayIndex
+	maxEntries int
+	now        func() time.Time
+}
+
+func NewMemoryReplayStore(maxEntries int) *MemoryReplayStore {
+	if maxEntries <= 0 {
+		maxEntries = defaultReplayEntries
+	}
+	return &MemoryReplayStore{index: newReplayIndex(), maxEntries: maxEntries, now: time.Now}
+}
+
+func (s *MemoryReplayStore) Consume(ctx context.Context, jti string, expiresAt time.Time) (bool, error) {
+	if err := validateReplayConsume(ctx, jti, expiresAt); err != nil {
+		return false, err
+	}
+	if s == nil || s.maxEntries <= 0 || s.now == nil {
+		return false, errors.New("replay store is not initialized")
+	}
+	nowUnixNano := s.now().UTC().UnixNano()
+	if expiresAt.UTC().UnixNano() <= nowUnixNano {
+		return false, ErrExpiredTicket
+	}
+	key := newReplayKey(jti)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.index.prune(nowUnixNano)
+	if s.index.contains(key, nowUnixNano) {
+		return false, nil
+	}
+	if len(s.index.entries) >= s.maxEntries {
+		return false, ErrReplayStoreFull
+	}
+	s.index.insert(key, expiresAt.UTC().UnixNano())
+	return true, nil
+}
+
 func TestMemoryReplayStoreSingleUseBoundAndExpiryCleanup(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0).UTC()
 	store := NewMemoryReplayStore(1)

--- a/internal/wssbridge/sidecar_test.go
+++ b/internal/wssbridge/sidecar_test.go
@@ -67,7 +67,7 @@ func newSidecarFixture(t *testing.T, mutate func(*SidecarOptions)) *sidecarFixtu
 	stats := &SidecarStats{}
 	opts := SidecarOptions{
 		RelayID: "relay-a", Verifier: verifier, Stats: stats,
-		ReplayStore: NewMemoryReplayStore(100_000),
+		ReplayStore: newMemoryReplayStore(100_000),
 		FrontOriginTokens: map[string][]string{
 			"front-a": {testOriginOld, testOriginNew},
 			"front-b": {testOriginB},

--- a/wsscore/README.md
+++ b/wsscore/README.md
@@ -194,7 +194,7 @@ mappings testable on the Linux-only CI, which the earlier build-tagged split
 pins needed a Windows test run CI does not provide. A range check now catches a
 reversion to the portable names on any host, a source-parsing registry test
 keeps `WinsockErrnos()` in lockstep with the constant block, and the exported
-table is also consumed by `openrung/internal/clienttelemetry`, whose divergence
+table is also consumed by the `connectcore` module's `clienttelemetry` package, whose divergence
 test pins where its client taxonomy deliberately disagrees with this one
 (WSAECONNABORTED, the timeout split, WSAEACCES).
 


### PR DESCRIPTION
## What

Removes verified-dead and test-only production code surfaced by a post-ADR-001 sweep (staticcheck + `x/tools/cmd/deadcode` across GOOS darwin/linux/windows; every exported candidate cross-checked against the mobile repo's punchbridge imports before deletion):

- `internal/relay`: two orphaned wsscore alias constants.
- `internal/relayruntime`: `DetectDirectReachable` (unreachable wrapper) deleted; its semantics doc folded into `ProbeDirectReachability`, and the probe + engine pin tests rewired to the structured form — coverage unchanged.
- `internal/tunnel`: `PortAllocator.InUse` → unexported `allocatedCount()` helper in the test files.
- `internal/wssbridge`: `MemoryReplayStore` (self-described test store) → `replay_test.go`.
- `wsscore/README.md`: stale `internal/clienttelemetry` reference repointed at connectcore (README-only, so no wsscore VERSION bump per the module rules).

## Deliberately NOT touched

- **connectcore/** entirely — the in-flight geo-regression fix bumps it to 0.1.1; its dead code (`SplitTunnelSupportedCountries`, the brokerapi pass-through shims, `markConnected`, and the geoip decision) is batched for the follow-up shim-collapse PR to share one VERSION bump.
- `ListenAddressesForHost` — it's the *subject* of the engine's automatic-wildcard bind-strategy pin test, not a helper.
- `broker.NewStore` / the two `NewInDir`s — documented test seams (one consumed across module boundaries).
- The taxonomy introspection surface (`wsscore.Reasons`, `WinsockErrnos`, `wssReasonExcluded`) — test-consumed by design as contract machinery.

## Verification

`gofmt` clean; `go build ./... && go test ./...` green in the root module, `desktop/`, and `desktop-volunteer/` (the latter two with the usual local `frontend/dist` placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)