### PR TITLE
Show the client version in the TUI header and accept -v

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -49,7 +49,7 @@ func run(args []string) error {
 	// re-execs this binary into it (internal/singboxruntime).
 	case singboxruntime.Subcommand:
 		return singboxruntime.RunSubcommand(args[1:])
-	case "-version", "--version", "version":
+	case "-v", "-version", "--version", "version":
 		fmt.Println(versionInfo())
 		return nil
 	case "-h", "--help", "help":
@@ -166,7 +166,7 @@ Commands:
   run      Internal: run the bundled sing-box with -c <config>. The connect
            engine invokes it on this binary; it also works standalone in
            place of "sing-box run -c <config>".
-  version  Print the client and bundled sing-box versions and exit.
+  version  Print the client and bundled sing-box versions and exit (-v).
 
 Keys (interactive):
   c connect  d disconnect  r refresh relays  1-4/tab switch view  q quit

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -95,7 +95,7 @@ func fitLines(body string, n int) string {
 func (m tuiModel) headerView() string {
 	tr := m.tr()
 	tabs := make([]string, 0, len(tr.tabs)+2)
-	tabs = append(tabs, titleStyle.Render(" OpenRung "))
+	tabs = append(tabs, titleStyle.Render(" OpenRung v"+strings.TrimSpace(baseVersion)+" "))
 	for i, name := range tr.tabs {
 		style := tabStyle
 		if viewID(i) == m.view {


### PR DESCRIPTION
## Summary
- The TUI header title now renders **`OpenRung v0.5.0`** instead of `OpenRung`, built from the embedded `cmd/client/VERSION` file so it tracks releases automatically.
- `./openrung -v` is now an alias for `version` — previously it fell through to the unknown-command path (usage text, exit 1). Usage text mentions the alias.

## Testing
- `go build ./cmd/client && go test ./cmd/client/` pass.
- Ran the built binary: `./client -v` prints the client/sing-box version lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)