### PR TITLE
TUI: old-terminal green-on-black theme, corner brand mark, and slimmer chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,16 @@ openrung-telemetry.jsonl
 # Claude Code local worktrees (may contain absolute paths / local branch content)
 .claude/agents/
 .claude/worktrees/
-/relay
+
+# `go build ./cmd/<name>` drops the binary in the repo root under the package
+# name. Ignore every cmd/ package's binary: a Go binary embeds the builder's
+# GOMODCACHE paths (/Users/<name>/go/pkg/mod/...), so committing one leaks the
+# local username into public history.
 /broker
+/client
+/frontcheck
+/relay
+/relayhub
+/wssmatrix
+/wsssidecar
 /openrung-*

--- a/cmd/client/headless.go
+++ b/cmd/client/headless.go
@@ -31,12 +31,13 @@ const (
 )
 
 type commonConfig struct {
-	BrokerURL  string
-	Limit      int
-	MTU        int
-	Family     string
-	RelayID    string
-	RelayLabel string
+	BrokerURL    string
+	Limit        int
+	MTU          int
+	Family       string
+	RelayID      string
+	RelayLabel   string
+	RelayCountry string
 }
 
 func parseCommonFlags(name string, args []string) (commonConfig, error) {
@@ -56,10 +57,14 @@ func addCommonFlags(fs *flag.FlagSet, cfg *commonConfig) {
 	fs.StringVar(&cfg.Family, "relay-family", defaultRelayFamily, "relay address family: auto, ipv4, or ipv6 (check/config)")
 	fs.StringVar(&cfg.RelayID, "relay-id", "", "connect only to the relay with this exact broker relay id (e.g. relay_abc...)")
 	fs.StringVar(&cfg.RelayLabel, "relay-label", "", "connect only to the relay(s) with this label")
+	// A country target keeps the engine's mid-session failover WITHIN the
+	// country (an exact relay id has nothing to fail over to) — for networks
+	// where only one country's relays are usable at all.
+	fs.StringVar(&cfg.RelayCountry, "relay-country", "", "connect only to relays in this 2-letter country code (e.g. kr); failover stays within it")
 }
 
 func (cfg commonConfig) target() connectcore.RelayTarget {
-	return connectcore.RelayTarget{RelayID: cfg.RelayID, Label: cfg.RelayLabel}
+	return connectcore.RelayTarget{RelayID: cfg.RelayID, Label: cfg.RelayLabel, Country: cfg.RelayCountry}
 }
 
 func runCheck(args []string) error {

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -9,7 +9,7 @@ import (
 )
 
 // The TUI ships English, Chinese, and Russian. There is no settings entry for
-// this: the . key cycles the language directly, and the footer help token that
+// this: the 0 key cycles the language directly, and the footer help token that
 // advertises it stays in all three languages at once (languageKeyHelp) so a
 // reader can always find their way back regardless of the current language.
 //
@@ -28,18 +28,18 @@ const (
 
 // languageKeyHelp is identical in every language on purpose: the switch must
 // be recognizable before the current language is readable, so every footer
-// carries this same trilingual token. The key is punctuation for the matching
-// reason — see the "." case in handleKey.
-const languageKeyHelp = ". lang/语言/язык"
+// carries this same trilingual token. The key is a digit for the matching
+// reason — see the "0" case in handleKey.
+const languageKeyHelp = "0 lang/语言/язык"
 
 type translation struct {
 	tabs [viewCount]string
 
 	helpGlobal string
 	helpRelays string
-	helpLogs   string
-	// No helpSettings: moving with ↑/↓ and acting with enter is the same
-	// convention every view uses, so Settings adds nothing to the global help.
+	// No helpLogs or helpSettings: scrolling a pager, moving with ↑/↓, and
+	// acting with enter are conventions the reader already has, so neither view
+	// adds anything to the global help.
 	helpSettingsEdit string
 
 	labelStatus    string
@@ -119,7 +119,6 @@ var translations = [languageCount]*translation{
 
 		helpGlobal:       "c connect · d disconnect · r refresh · " + languageKeyHelp + " · q quit",
 		helpRelays:       "x clear target · ",
-		helpLogs:         "pgup/pgdn scroll · ",
 		helpSettingsEdit: "esc cancel",
 
 		labelStatus:    "Status",
@@ -207,7 +206,6 @@ var translations = [languageCount]*translation{
 
 		helpGlobal:       "c 连接 · d 断开 · r 刷新 · " + languageKeyHelp + " · q 退出",
 		helpRelays:       "x 清除目标 · ",
-		helpLogs:         "pgup/pgdn 滚动 · ",
 		helpSettingsEdit: "esc 取消",
 
 		labelStatus:    "状态",
@@ -295,7 +293,6 @@ var translations = [languageCount]*translation{
 
 		helpGlobal:       "c подключить · d отключить · r обновить · " + languageKeyHelp + " · q выход",
 		helpRelays:       "x сбросить цель · ",
-		helpLogs:         "pgup/pgdn прокрутка · ",
 		helpSettingsEdit: "esc отмена",
 
 		labelStatus:    "Статус",

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -35,10 +35,11 @@ const languageKeyHelp = ". lang/语言/язык"
 type translation struct {
 	tabs [viewCount]string
 
-	helpGlobal       string
-	helpRelays       string
-	helpLogs         string
-	helpSettings     string
+	helpGlobal string
+	helpRelays string
+	helpLogs   string
+	// No helpSettings: moving with ↑/↓ and acting with enter is the same
+	// convention every view uses, so Settings adds nothing to the global help.
 	helpSettingsEdit string
 
 	labelStatus    string
@@ -117,10 +118,9 @@ var translations = [languageCount]*translation{
 		tabs: [viewCount]string{"1 Status", "2 Relays", "3 Logs", "4 Settings"},
 
 		helpGlobal:       "c connect · d disconnect · r refresh · " + languageKeyHelp + " · q quit",
-		helpRelays:       "↑/↓ select · enter connect to selection · x clear target · ",
-		helpLogs:         "↑/↓/pgup/pgdn scroll · ",
-		helpSettings:     "↑/↓ field · enter edit · ",
-		helpSettingsEdit: "enter apply · esc cancel",
+		helpRelays:       "x clear target · ",
+		helpLogs:         "pgup/pgdn scroll · ",
+		helpSettingsEdit: "esc cancel",
 
 		labelStatus:    "Status",
 		labelRelay:     "Relay",
@@ -206,10 +206,9 @@ var translations = [languageCount]*translation{
 		tabs: [viewCount]string{"1 状态", "2 中继", "3 日志", "4 设置"},
 
 		helpGlobal:       "c 连接 · d 断开 · r 刷新 · " + languageKeyHelp + " · q 退出",
-		helpRelays:       "↑/↓ 选择 · enter 连接所选 · x 清除目标 · ",
-		helpLogs:         "↑/↓/pgup/pgdn 滚动 · ",
-		helpSettings:     "↑/↓ 字段 · enter 编辑 · ",
-		helpSettingsEdit: "enter 应用 · esc 取消",
+		helpRelays:       "x 清除目标 · ",
+		helpLogs:         "pgup/pgdn 滚动 · ",
+		helpSettingsEdit: "esc 取消",
 
 		labelStatus:    "状态",
 		labelRelay:     "中继",
@@ -295,10 +294,9 @@ var translations = [languageCount]*translation{
 		tabs: [viewCount]string{"1 Статус", "2 Узлы", "3 Журнал", "4 Настройки"},
 
 		helpGlobal:       "c подключить · d отключить · r обновить · " + languageKeyHelp + " · q выход",
-		helpRelays:       "↑/↓ выбор · enter подключиться к выбранному · x сбросить цель · ",
-		helpLogs:         "↑/↓/pgup/pgdn прокрутка · ",
-		helpSettings:     "↑/↓ поле · enter изменить · ",
-		helpSettingsEdit: "enter применить · esc отмена",
+		helpRelays:       "x сбросить цель · ",
+		helpLogs:         "pgup/pgdn прокрутка · ",
+		helpSettingsEdit: "esc отмена",
 
 		labelStatus:    "Статус",
 		labelRelay:     "Узел",

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -34,10 +34,10 @@ type translation struct {
 	tabs [viewCount]string
 
 	helpGlobal string
-	helpRelays string
-	// No helpLogs or helpSettings: scrolling a pager, moving with ↑/↓, and
-	// acting with enter are conventions the reader already has, so neither view
-	// adds anything to the global help.
+	// No per-view help: scrolling a pager, moving with ↑/↓, and connecting with
+	// enter on the highlighted row are conventions the list itself teaches, so
+	// every view shows the global help alone. Only the settings editor keeps
+	// its own line, for the esc that leaves it.
 	helpSettingsEdit string
 
 	// The status bar's scrolling detail carries only fields the bar does not
@@ -77,6 +77,9 @@ type translation struct {
 	targetCountry   string // fmt: country
 	targetAutomatic string
 
+	// autoSelect is the Relays list's first row: enter there connects with no
+	// target pinned, letting the broker's ranking pick.
+	autoSelect          string
 	refreshingDirectory string
 	directoryErrPrefix  string
 	noRelaysYet         string
@@ -112,8 +115,7 @@ var translations = [languageCount]*translation{
 	langEnglish: {
 		tabs: [viewCount]string{"1 Relays", "2 Logs", "3 Settings"},
 
-		helpGlobal:       "c connect · d disconnect · r refresh · " + languageKeyHelp + " · q quit",
-		helpRelays:       "x clear target · ",
+		helpGlobal:       "d disconnect · r refresh · " + languageKeyHelp + " · q quit",
 		helpSettingsEdit: "esc cancel",
 
 		labelTransport: "Transport",
@@ -150,6 +152,7 @@ var translations = [languageCount]*translation{
 		targetCountry:   "country %s",
 		targetAutomatic: "automatic (ranked)",
 
+		autoSelect:          "Auto select (ranked)",
 		refreshingDirectory: "refreshing relay directory…",
 		directoryErrPrefix:  "directory: ",
 		noRelaysYet:         "no relays yet — press r to refresh",
@@ -186,8 +189,7 @@ var translations = [languageCount]*translation{
 	langChinese: {
 		tabs: [viewCount]string{"1 中继", "2 日志", "3 设置"},
 
-		helpGlobal:       "c 连接 · d 断开 · r 刷新 · " + languageKeyHelp + " · q 退出",
-		helpRelays:       "x 清除目标 · ",
+		helpGlobal:       "d 断开 · r 刷新 · " + languageKeyHelp + " · q 退出",
 		helpSettingsEdit: "esc 取消",
 
 		labelTransport: "传输",
@@ -224,6 +226,7 @@ var translations = [languageCount]*translation{
 		targetCountry:   "国家 %s",
 		targetAutomatic: "自动（按排名）",
 
+		autoSelect:          "自动选择（按排名）",
 		refreshingDirectory: "正在刷新中继目录…",
 		directoryErrPrefix:  "目录：",
 		noRelaysYet:         "暂无中继 — 按 r 刷新",
@@ -260,8 +263,7 @@ var translations = [languageCount]*translation{
 	langRussian: {
 		tabs: [viewCount]string{"1 Узлы", "2 Журнал", "3 Настройки"},
 
-		helpGlobal:       "c подключить · d отключить · r обновить · " + languageKeyHelp + " · q выход",
-		helpRelays:       "x сбросить цель · ",
+		helpGlobal:       "d отключить · r обновить · " + languageKeyHelp + " · q выход",
 		helpSettingsEdit: "esc отмена",
 
 		labelTransport: "Транспорт",
@@ -298,6 +300,7 @@ var translations = [languageCount]*translation{
 		targetCountry:   "страна %s",
 		targetAutomatic: "автоматически (по рейтингу)",
 
+		autoSelect:          "Автовыбор (по рейтингу)",
 		refreshingDirectory: "обновление каталога узлов…",
 		directoryErrPrefix:  "каталог: ",
 		noRelaysYet:         "узлов пока нет — нажмите r для обновления",

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -9,7 +9,7 @@ import (
 )
 
 // The TUI ships English, Chinese, and Russian. There is no settings entry for
-// this: the l key cycles the language directly, and the footer help token that
+// this: the . key cycles the language directly, and the footer help token that
 // advertises it stays in all three languages at once (languageKeyHelp) so a
 // reader can always find their way back regardless of the current language.
 //
@@ -28,8 +28,9 @@ const (
 
 // languageKeyHelp is identical in every language on purpose: the switch must
 // be recognizable before the current language is readable, so every footer
-// carries this same trilingual token.
-const languageKeyHelp = "l lang/语言/язык"
+// carries this same trilingual token. The key is punctuation for the matching
+// reason — see the "." case in handleKey.
+const languageKeyHelp = ". lang/语言/язык"
 
 type translation struct {
 	tabs [viewCount]string

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/openrung/openrung/connectcore"
 )
 
 // The TUI ships English, Chinese, and Russian. There is no settings entry for
@@ -50,6 +52,11 @@ type translation struct {
 	labelProxy     string
 	labelBroker    string
 	labelError     string
+
+	// statusNames word the connection state for terminals with no color: the
+	// state is normally the status bar's background alone, which the Ascii
+	// profile (NO_COLOR, dumb terminals) cannot render.
+	statusNames map[connectcore.Status]string
 
 	captureTUN     string
 	captureProxy   string
@@ -119,6 +126,15 @@ var translations = [languageCount]*translation{
 		labelBroker:    "Broker",
 		labelError:     "Error",
 
+		statusNames: map[connectcore.Status]string{
+			connectcore.StatusDisconnected:  "disconnected",
+			connectcore.StatusPreparing:     "preparing",
+			connectcore.StatusConnecting:    "connecting",
+			connectcore.StatusConnected:     "connected",
+			connectcore.StatusDisconnecting: "disconnecting",
+			connectcore.StatusFailed:        "failed",
+		},
+
 		captureTUN:     "TUN — whole device",
 		captureProxy:   "proxy — applications configured for the endpoint below",
 		proxyResolving: "resolving…",
@@ -185,6 +201,15 @@ var translations = [languageCount]*translation{
 		labelProxy:     "代理",
 		labelBroker:    "调度服务器",
 		labelError:     "错误",
+
+		statusNames: map[connectcore.Status]string{
+			connectcore.StatusDisconnected:  "未连接",
+			connectcore.StatusPreparing:     "准备中",
+			connectcore.StatusConnecting:    "连接中",
+			connectcore.StatusConnected:     "已连接",
+			connectcore.StatusDisconnecting: "断开中",
+			connectcore.StatusFailed:        "失败",
+		},
 
 		captureTUN:     "TUN — 全设备接管",
 		captureProxy:   "代理 — 应用需配置为下方端点",
@@ -253,6 +278,15 @@ var translations = [languageCount]*translation{
 		labelBroker:    "Брокер",
 		labelError:     "Ошибка",
 
+		statusNames: map[connectcore.Status]string{
+			connectcore.StatusDisconnected:  "не подключено",
+			connectcore.StatusPreparing:     "подготовка",
+			connectcore.StatusConnecting:    "подключение",
+			connectcore.StatusConnected:     "подключено",
+			connectcore.StatusDisconnecting: "отключение",
+			connectcore.StatusFailed:        "сбой",
+		},
+
 		captureTUN:     "TUN — всё устройство",
 		captureProxy:   "прокси — приложения настраиваются на адрес ниже",
 		proxyResolving: "определение…",
@@ -314,6 +348,13 @@ func (m tuiModel) tr() *translation {
 		return translations[langEnglish]
 	}
 	return translations[m.lang]
+}
+
+func (tr *translation) statusName(status connectcore.Status) string {
+	if name, ok := tr.statusNames[status]; ok {
+		return name
+	}
+	return string(status)
 }
 
 // padCell pads to display width, not byte count: fmt's %-8s would leave CJK

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -9,8 +9,8 @@ import (
 )
 
 // The TUI ships English, Chinese, and Russian. There is no settings entry for
-// this: the 5 key cycles the language directly, and the header slot that
-// advertises it stays in all three languages at once (languageTabLabel) so a
+// this: the l key cycles the language directly, and the footer help token that
+// advertises it stays in all three languages at once (languageKeyHelp) so a
 // reader can always find their way back regardless of the current language.
 //
 // The platform TUN copy (tunModeSummary/tunModeAdvice) and everything the
@@ -26,9 +26,12 @@ const (
 	languageCount
 )
 
-// languageTabLabel is identical in every language on purpose: the switch must
-// be recognizable before the current language is readable.
-const languageTabLabel = "5 languages/中文/языки"
+// languageKeyHelp is identical in every language on purpose: the switch must
+// be recognizable before the current language is readable, so every footer
+// carries this same trilingual token — and it LEADS helpGlobal, because the
+// footer sheds help from the right and the escape hatch must be the last
+// thing to go.
+const languageKeyHelp = "l lang/语言/язык"
 
 type translation struct {
 	tabs [viewCount]string
@@ -116,7 +119,7 @@ var translations = [languageCount]*translation{
 	langEnglish: {
 		tabs: [viewCount]string{"1 Status", "2 Relays", "3 Logs", "4 Settings"},
 
-		helpGlobal:       "c connect · d disconnect · r refresh · 1-4/tab views · 5 language · q quit",
+		helpGlobal:       languageKeyHelp + " · c connect · d disconnect · r refresh · 1-4/tab views · q quit",
 		helpRelays:       "↑/↓ select · enter connect to selection · x clear target · ",
 		helpLogs:         "↑/↓/pgup/pgdn scroll · ",
 		helpSettings:     "↑/↓ field · enter edit · ",
@@ -207,7 +210,7 @@ var translations = [languageCount]*translation{
 	langChinese: {
 		tabs: [viewCount]string{"1 状态", "2 中继", "3 日志", "4 设置"},
 
-		helpGlobal:       "c 连接 · d 断开 · r 刷新 · 1-4/tab 视图 · 5 语言 · q 退出",
+		helpGlobal:       languageKeyHelp + " · c 连接 · d 断开 · r 刷新 · 1-4/tab 视图 · q 退出",
 		helpRelays:       "↑/↓ 选择 · enter 连接所选 · x 清除目标 · ",
 		helpLogs:         "↑/↓/pgup/pgdn 滚动 · ",
 		helpSettings:     "↑/↓ 字段 · enter 编辑 · ",
@@ -298,7 +301,7 @@ var translations = [languageCount]*translation{
 	langRussian: {
 		tabs: [viewCount]string{"1 Статус", "2 Узлы", "3 Журнал", "4 Настройки"},
 
-		helpGlobal:       "c подключить · d отключить · r обновить · 1-4/tab вкладки · 5 язык · q выход",
+		helpGlobal:       languageKeyHelp + " · c подключить · d отключить · r обновить · 1-4/tab вкладки · q выход",
 		helpRelays:       "↑/↓ выбор · enter подключиться к выбранному · x сбросить цель · ",
 		helpLogs:         "↑/↓/pgup/pgdn прокрутка · ",
 		helpSettings:     "↑/↓ поле · enter изменить · ",

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-
-	"github.com/openrung/openrung/connectcore"
 )
 
 // The TUI ships English, Chinese, and Russian. There is no settings entry for
@@ -42,11 +40,10 @@ type translation struct {
 	// adds anything to the global help.
 	helpSettingsEdit string
 
-	labelStatus    string
-	labelRelay     string
-	labelCountry   string
+	// The status bar's scrolling detail carries only fields the bar does not
+	// state another way — no Status (the bar's color), no Relay/Country/Session
+	// (the pinned right edge).
 	labelTransport string
-	labelSession   string
 	labelHealth    string
 	labelActivity  string
 	labelCapture   string
@@ -54,8 +51,6 @@ type translation struct {
 	labelBroker    string
 	labelTarget    string
 	labelError     string
-
-	statusNames map[connectcore.Status]string
 
 	captureTUN     string
 	captureProxy   string
@@ -121,11 +116,7 @@ var translations = [languageCount]*translation{
 		helpRelays:       "x clear target · ",
 		helpSettingsEdit: "esc cancel",
 
-		labelStatus:    "Status",
-		labelRelay:     "Relay",
-		labelCountry:   "Country",
 		labelTransport: "Transport",
-		labelSession:   "Session",
 		labelHealth:    "Health",
 		labelActivity:  "Activity",
 		labelCapture:   "Capture",
@@ -133,15 +124,6 @@ var translations = [languageCount]*translation{
 		labelBroker:    "Broker",
 		labelTarget:    "Target",
 		labelError:     "Error",
-
-		statusNames: map[connectcore.Status]string{
-			connectcore.StatusDisconnected:  "disconnected",
-			connectcore.StatusPreparing:     "preparing",
-			connectcore.StatusConnecting:    "connecting",
-			connectcore.StatusConnected:     "connected",
-			connectcore.StatusDisconnecting: "disconnecting",
-			connectcore.StatusFailed:        "failed",
-		},
 
 		captureTUN:     "TUN — whole device",
 		captureProxy:   "proxy — applications configured for the endpoint below",
@@ -208,11 +190,7 @@ var translations = [languageCount]*translation{
 		helpRelays:       "x 清除目标 · ",
 		helpSettingsEdit: "esc 取消",
 
-		labelStatus:    "状态",
-		labelRelay:     "中继",
-		labelCountry:   "国家",
 		labelTransport: "传输",
-		labelSession:   "会话",
 		labelHealth:    "健康",
 		labelActivity:  "活动",
 		labelCapture:   "捕获",
@@ -220,15 +198,6 @@ var translations = [languageCount]*translation{
 		labelBroker:    "调度服务器",
 		labelTarget:    "目标",
 		labelError:     "错误",
-
-		statusNames: map[connectcore.Status]string{
-			connectcore.StatusDisconnected:  "未连接",
-			connectcore.StatusPreparing:     "准备中",
-			connectcore.StatusConnecting:    "连接中",
-			connectcore.StatusConnected:     "已连接",
-			connectcore.StatusDisconnecting: "断开中",
-			connectcore.StatusFailed:        "失败",
-		},
 
 		captureTUN:     "TUN — 全设备接管",
 		captureProxy:   "代理 — 应用需配置为下方端点",
@@ -295,11 +264,7 @@ var translations = [languageCount]*translation{
 		helpRelays:       "x сбросить цель · ",
 		helpSettingsEdit: "esc отмена",
 
-		labelStatus:    "Статус",
-		labelRelay:     "Узел",
-		labelCountry:   "Страна",
 		labelTransport: "Транспорт",
-		labelSession:   "Сессия",
 		labelHealth:    "Проверка",
 		labelActivity:  "События",
 		labelCapture:   "Захват",
@@ -307,15 +272,6 @@ var translations = [languageCount]*translation{
 		labelBroker:    "Брокер",
 		labelTarget:    "Цель",
 		labelError:     "Ошибка",
-
-		statusNames: map[connectcore.Status]string{
-			connectcore.StatusDisconnected:  "не подключено",
-			connectcore.StatusPreparing:     "подготовка",
-			connectcore.StatusConnecting:    "подключение",
-			connectcore.StatusConnected:     "подключено",
-			connectcore.StatusDisconnecting: "отключение",
-			connectcore.StatusFailed:        "сбой",
-		},
 
 		captureTUN:     "TUN — всё устройство",
 		captureProxy:   "прокси — приложения настраиваются на адрес ниже",
@@ -383,13 +339,6 @@ func (m tuiModel) tr() *translation {
 		return translations[langEnglish]
 	}
 	return translations[m.lang]
-}
-
-func (tr *translation) statusName(status connectcore.Status) string {
-	if name, ok := tr.statusNames[status]; ok {
-		return name
-	}
-	return string(status)
 }
 
 // padCell pads to display width, not byte count: fmt's %-8s would leave CJK

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -115,7 +115,7 @@ type translation struct {
 
 var translations = [languageCount]*translation{
 	langEnglish: {
-		tabs: [viewCount]string{"1 Status", "2 Relays", "3 Logs", "4 Settings"},
+		tabs: [viewCount]string{"1 Relays", "2 Logs", "3 Settings"},
 
 		helpGlobal:       "c connect · d disconnect · r refresh · " + languageKeyHelp + " · q quit",
 		helpRelays:       "x clear target · ",
@@ -202,7 +202,7 @@ var translations = [languageCount]*translation{
 	},
 
 	langChinese: {
-		tabs: [viewCount]string{"1 状态", "2 中继", "3 日志", "4 设置"},
+		tabs: [viewCount]string{"1 中继", "2 日志", "3 设置"},
 
 		helpGlobal:       "c 连接 · d 断开 · r 刷新 · " + languageKeyHelp + " · q 退出",
 		helpRelays:       "x 清除目标 · ",
@@ -289,7 +289,7 @@ var translations = [languageCount]*translation{
 	},
 
 	langRussian: {
-		tabs: [viewCount]string{"1 Статус", "2 Узлы", "3 Журнал", "4 Настройки"},
+		tabs: [viewCount]string{"1 Узлы", "2 Журнал", "3 Настройки"},
 
 		helpGlobal:       "c подключить · d отключить · r обновить · " + languageKeyHelp + " · q выход",
 		helpRelays:       "x сбросить цель · ",

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -49,7 +49,6 @@ type translation struct {
 	labelCapture   string
 	labelProxy     string
 	labelBroker    string
-	labelTarget    string
 	labelError     string
 
 	captureTUN     string
@@ -72,11 +71,6 @@ type translation struct {
 	noticeTicketRetry       string // fmt: front id, wait
 	noticePunch             string // fmt: relay id, reason
 
-	targetRelay     string // fmt: relay id
-	targetLabel     string // fmt: label
-	targetCountry   string // fmt: country
-	targetAutomatic string
-
 	// autoSelect is the Relays list's first row: enter there connects with no
 	// target pinned, letting the broker's ranking pick.
 	autoSelect          string
@@ -87,7 +81,6 @@ type translation struct {
 	colCountry          string
 	colLatency          string
 	colClass            string
-	targetMarker        string
 	badgeFoundation     string
 	badgeVolunteer      string
 
@@ -124,7 +117,6 @@ var translations = [languageCount]*translation{
 		labelCapture:   "Capture",
 		labelProxy:     "Proxy",
 		labelBroker:    "Broker",
-		labelTarget:    "Target",
 		labelError:     "Error",
 
 		captureTUN:     "TUN — whole device",
@@ -147,11 +139,6 @@ var translations = [languageCount]*translation{
 		noticeTicketRetry:       "WSS tickets rate-limited; retrying front %s in %s",
 		noticePunch:             "punch %s: %s",
 
-		targetRelay:     "relay %s",
-		targetLabel:     "label %s",
-		targetCountry:   "country %s",
-		targetAutomatic: "automatic (ranked)",
-
 		autoSelect:          "Auto select (ranked)",
 		refreshingDirectory: "refreshing relay directory…",
 		directoryErrPrefix:  "directory: ",
@@ -160,7 +147,6 @@ var translations = [languageCount]*translation{
 		colCountry:          "COUNTRY",
 		colLatency:          "LATENCY",
 		colClass:            "CLASS",
-		targetMarker:        "← target",
 		badgeFoundation:     "[foundation]",
 		badgeVolunteer:      "[volunteer]",
 
@@ -198,7 +184,6 @@ var translations = [languageCount]*translation{
 		labelCapture:   "捕获",
 		labelProxy:     "代理",
 		labelBroker:    "调度服务器",
-		labelTarget:    "目标",
 		labelError:     "错误",
 
 		captureTUN:     "TUN — 全设备接管",
@@ -221,11 +206,6 @@ var translations = [languageCount]*translation{
 		noticeTicketRetry:       "WSS 票据被限流；将在 %[2]s 后重试前置 %[1]s",
 		noticePunch:             "打洞 %s：%s",
 
-		targetRelay:     "中继 %s",
-		targetLabel:     "标签 %s",
-		targetCountry:   "国家 %s",
-		targetAutomatic: "自动（按排名）",
-
 		autoSelect:          "自动选择（按排名）",
 		refreshingDirectory: "正在刷新中继目录…",
 		directoryErrPrefix:  "目录：",
@@ -234,7 +214,6 @@ var translations = [languageCount]*translation{
 		colCountry:          "国家",
 		colLatency:          "延迟",
 		colClass:            "类型",
-		targetMarker:        "← 目标",
 		badgeFoundation:     "[官方]",
 		badgeVolunteer:      "[志愿]",
 
@@ -272,7 +251,6 @@ var translations = [languageCount]*translation{
 		labelCapture:   "Захват",
 		labelProxy:     "Прокси",
 		labelBroker:    "Брокер",
-		labelTarget:    "Цель",
 		labelError:     "Ошибка",
 
 		captureTUN:     "TUN — всё устройство",
@@ -295,11 +273,6 @@ var translations = [languageCount]*translation{
 		noticeTicketRetry:       "билеты WSS ограничены; повтор фронта %s через %s",
 		noticePunch:             "пробивка %s: %s",
 
-		targetRelay:     "узел %s",
-		targetLabel:     "метка %s",
-		targetCountry:   "страна %s",
-		targetAutomatic: "автоматически (по рейтингу)",
-
 		autoSelect:          "Автовыбор (по рейтингу)",
 		refreshingDirectory: "обновление каталога узлов…",
 		directoryErrPrefix:  "каталог: ",
@@ -308,7 +281,6 @@ var translations = [languageCount]*translation{
 		colCountry:          "СТРАНА",
 		colLatency:          "ЗАДЕРЖКА",
 		colClass:            "КЛАСС",
-		targetMarker:        "← цель",
 		badgeFoundation:     "[фонд]",
 		badgeVolunteer:      "[волонтёр]",
 

--- a/cmd/client/i18n.go
+++ b/cmd/client/i18n.go
@@ -28,9 +28,7 @@ const (
 
 // languageKeyHelp is identical in every language on purpose: the switch must
 // be recognizable before the current language is readable, so every footer
-// carries this same trilingual token — and it LEADS helpGlobal, because the
-// footer sheds help from the right and the escape hatch must be the last
-// thing to go.
+// carries this same trilingual token.
 const languageKeyHelp = "l lang/语言/язык"
 
 type translation struct {
@@ -82,7 +80,6 @@ type translation struct {
 	targetCountry   string // fmt: country
 	targetAutomatic string
 
-	recentsLabel        string
 	refreshingDirectory string
 	directoryErrPrefix  string
 	noRelaysYet         string
@@ -97,7 +94,6 @@ type translation struct {
 	noLogOutput string
 
 	fieldNames              [settingsFieldCount]string
-	unset                   string
 	enableInShell           string
 	restoreShell            string
 	restoreAdvice           string
@@ -119,7 +115,7 @@ var translations = [languageCount]*translation{
 	langEnglish: {
 		tabs: [viewCount]string{"1 Status", "2 Relays", "3 Logs", "4 Settings"},
 
-		helpGlobal:       languageKeyHelp + " · c connect · d disconnect · r refresh · 1-4/tab views · q quit",
+		helpGlobal:       "c connect · d disconnect · r refresh · " + languageKeyHelp + " · q quit",
 		helpRelays:       "↑/↓ select · enter connect to selection · x clear target · ",
 		helpLogs:         "↑/↓/pgup/pgdn scroll · ",
 		helpSettings:     "↑/↓ field · enter edit · ",
@@ -172,7 +168,6 @@ var translations = [languageCount]*translation{
 		targetCountry:   "country %s",
 		targetAutomatic: "automatic (ranked)",
 
-		recentsLabel:        "recents ",
 		refreshingDirectory: "refreshing relay directory…",
 		directoryErrPrefix:  "directory: ",
 		noRelaysYet:         "no relays yet — press r to refresh",
@@ -187,9 +182,8 @@ var translations = [languageCount]*translation{
 		noLogOutput: "no log output yet",
 
 		fieldNames: [settingsFieldCount]string{
-			"Broker URL", "Mode", "Target relay id", "Target label", "Target country", "Shell proxy",
+			"Broker URL", "Mode", "Shell proxy",
 		},
-		unset:                   "(unset)",
 		enableInShell:           "Enable in a shell",
 		restoreShell:            "Restore that shell",
 		restoreAdvice:           "run the restore command after disconnect, failure, quit, or crash",
@@ -210,7 +204,7 @@ var translations = [languageCount]*translation{
 	langChinese: {
 		tabs: [viewCount]string{"1 状态", "2 中继", "3 日志", "4 设置"},
 
-		helpGlobal:       languageKeyHelp + " · c 连接 · d 断开 · r 刷新 · 1-4/tab 视图 · q 退出",
+		helpGlobal:       "c 连接 · d 断开 · r 刷新 · " + languageKeyHelp + " · q 退出",
 		helpRelays:       "↑/↓ 选择 · enter 连接所选 · x 清除目标 · ",
 		helpLogs:         "↑/↓/pgup/pgdn 滚动 · ",
 		helpSettings:     "↑/↓ 字段 · enter 编辑 · ",
@@ -263,7 +257,6 @@ var translations = [languageCount]*translation{
 		targetCountry:   "国家 %s",
 		targetAutomatic: "自动（按排名）",
 
-		recentsLabel:        "最近 ",
 		refreshingDirectory: "正在刷新中继目录…",
 		directoryErrPrefix:  "目录：",
 		noRelaysYet:         "暂无中继 — 按 r 刷新",
@@ -278,9 +271,8 @@ var translations = [languageCount]*translation{
 		noLogOutput: "暂无日志输出",
 
 		fieldNames: [settingsFieldCount]string{
-			"Broker 地址", "模式", "目标中继 ID", "目标标签", "目标国家", "Shell 代理",
+			"Broker 地址", "模式", "Shell 代理",
 		},
-		unset:                   "（未设置）",
 		enableInShell:           "在 shell 中启用",
 		restoreShell:            "恢复该 shell",
 		restoreAdvice:           "断开、失败、退出或崩溃后，请运行恢复命令",
@@ -301,7 +293,7 @@ var translations = [languageCount]*translation{
 	langRussian: {
 		tabs: [viewCount]string{"1 Статус", "2 Узлы", "3 Журнал", "4 Настройки"},
 
-		helpGlobal:       languageKeyHelp + " · c подключить · d отключить · r обновить · 1-4/tab вкладки · q выход",
+		helpGlobal:       "c подключить · d отключить · r обновить · " + languageKeyHelp + " · q выход",
 		helpRelays:       "↑/↓ выбор · enter подключиться к выбранному · x сбросить цель · ",
 		helpLogs:         "↑/↓/pgup/pgdn прокрутка · ",
 		helpSettings:     "↑/↓ поле · enter изменить · ",
@@ -354,7 +346,6 @@ var translations = [languageCount]*translation{
 		targetCountry:   "страна %s",
 		targetAutomatic: "автоматически (по рейтингу)",
 
-		recentsLabel:        "недавние ",
 		refreshingDirectory: "обновление каталога узлов…",
 		directoryErrPrefix:  "каталог: ",
 		noRelaysYet:         "узлов пока нет — нажмите r для обновления",
@@ -369,9 +360,8 @@ var translations = [languageCount]*translation{
 		noLogOutput: "журнал пока пуст",
 
 		fieldNames: [settingsFieldCount]string{
-			"URL брокера", "Режим", "ID целевого узла", "Целевая метка", "Целевая страна", "Прокси для shell",
+			"URL брокера", "Режим", "Прокси для shell",
 		},
-		unset:                   "(не задано)",
 		enableInShell:           "Включить в shell",
 		restoreShell:            "Восстановить shell",
 		restoreAdvice:           "выполните команду восстановления после отключения, сбоя, выхода или падения",

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -111,15 +111,16 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 	}
 }
 
-// The language switch must be findable in every language, so every footer
-// carries the same trilingual token — and the header, now views-only, no
-// longer holds a language slot.
-func TestFooterAlwaysShowsTheTrilingualLanguageHelp(t *testing.T) {
+// The language switch must be findable in every language, so every footer-help
+// track carries the same trilingual token — and the header, now views-only, no
+// longer holds a language slot. Overflow behavior is covered by the marquee
+// tests in views_test.go.
+func TestEveryLanguageIncludesTheTrilingualLanguageHelp(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	for lang := language(0); lang < languageCount; lang++ {
 		m.lang = lang
-		if footer := m.footerView(); !strings.Contains(footer, languageKeyHelp) {
-			t.Fatalf("lang %d footer lost the language help: %q", lang, footer)
+		if help := m.tr().helpGlobal; !strings.Contains(help, languageKeyHelp) {
+			t.Fatalf("lang %d footer track lost the language help: %q", lang, help)
 		}
 		if header := m.headerView(); strings.Contains(header, "язык") {
 			t.Fatalf("lang %d header still carries a language slot: %q", lang, header)

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -15,7 +15,7 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 		t.Fatal("default view is not English")
 	}
 
-	m, _ = update(t, m, keyMsg("l"))
+	m, _ = update(t, m, keyMsg("."))
 	if m.view != viewStatus {
 		t.Fatalf("language key changed the view to %d", m.view)
 	}
@@ -24,13 +24,13 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 		t.Fatalf("first cycle is not Chinese:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("l"))
+	m, _ = update(t, m, keyMsg("."))
 	view = m.View()
 	if !strings.Contains(view, "2 Узлы") || !strings.Contains(view, "Статус") {
 		t.Fatalf("second cycle is not Russian:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("l"))
+	m, _ = update(t, m, keyMsg("."))
 	if view = m.View(); !strings.Contains(view, "2 Relays") {
 		t.Fatalf("third cycle did not wrap back to English:\n%s", view)
 	}
@@ -41,10 +41,42 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 	if view = m.View(); !strings.Contains(view, "2 Relays") || m.view != viewStatus {
 		t.Fatalf("5 still does something:\n%s", view)
 	}
+
+	// A CJK IME in full-width punctuation mode delivers 。 for the same key,
+	// so it cycles too — the reader who needs the escape hatch most is the
+	// one typing through an IME.
+	m, _ = update(t, m, keyMsg("。"))
+	if view = m.View(); !strings.Contains(view, "2 中继") {
+		t.Fatalf("the full-width period did not cycle the language:\n%s", view)
+	}
+}
+
+// The language key is a period, and broker URLs are full of periods: an
+// editor with focus must swallow it as text rather than cycling the UI out
+// from under the value being typed.
+func TestPeriodIsTextWhileEditingSettings(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.view = viewSettings // cursor starts on the broker field
+
+	m, _ = update(t, m, keyMsg("enter"))
+	if !m.settings.editing {
+		t.Fatal("enter did not begin editing")
+	}
+	before, seeded := m.lang, m.settings.input.Value()
+	for _, r := range "a.b" {
+		m, _ = update(t, m, keyMsg(string(r)))
+	}
+	if m.lang != before {
+		t.Fatalf("typing a period cycled the language to %d", m.lang)
+	}
+	// The editor opens pre-filled with the current value, so the keys append.
+	if got := m.settings.input.Value(); got != seeded+"a.b" {
+		t.Fatalf("editor value = %q, want %q with the typed periods retained", got, seeded+"a.b")
+	}
 }
 
 // Settings notices are stored as kinds and worded at draw time, so a note
-// set under one language follows an l-key cycle into the next — stored
+// set under one language follows a language cycle into the next — stored
 // rendered text would leave mixed-language UI for exactly the reader the
 // trilingual escape hatch serves.
 func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
@@ -57,7 +89,7 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 		t.Fatalf("Chinese mode note missing:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("l")) // 中文 → русский
+	m, _ = update(t, m, keyMsg(".")) // 中文 → русский
 	view := m.View()
 	if !strings.Contains(view, "режим TUN: следующее подключение захватит все приложения") {
 		t.Fatalf("note did not follow the language cycle:\n%s", view)
@@ -73,7 +105,7 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 	if !strings.Contains(m.View(), "интеграция с shell недоступна") {
 		t.Fatalf("Russian shell-unavailable notice missing:\n%s", m.View())
 	}
-	m, _ = update(t, m, keyMsg("l")) // русский → English
+	m, _ = update(t, m, keyMsg(".")) // русский → English
 	if !strings.Contains(m.View(), "shell integration is unavailable in this build") {
 		t.Fatalf("shell notice did not follow the cycle:\n%s", m.View())
 	}

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -11,27 +11,27 @@ import (
 func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 
-	if !strings.Contains(m.View(), "2 Relays") {
+	if !strings.Contains(m.View(), "1 Relays") {
 		t.Fatal("default view is not English")
 	}
 
 	m, _ = update(t, m, keyMsg("0"))
-	if m.view != viewStatus {
+	if m.view != viewRelays {
 		t.Fatalf("language key changed the view to %d", m.view)
 	}
 	view := m.View()
-	if !strings.Contains(view, "2 中继") || !strings.Contains(view, "状态") {
+	if !strings.Contains(view, "1 中继") || !strings.Contains(view, "状态") {
 		t.Fatalf("first cycle is not Chinese:\n%s", view)
 	}
 
 	m, _ = update(t, m, keyMsg("0"))
 	view = m.View()
-	if !strings.Contains(view, "2 Узлы") || !strings.Contains(view, "Статус") {
+	if !strings.Contains(view, "1 Узлы") || !strings.Contains(view, "Статус") {
 		t.Fatalf("second cycle is not Russian:\n%s", view)
 	}
 
 	m, _ = update(t, m, keyMsg("0"))
-	if view = m.View(); !strings.Contains(view, "2 Relays") {
+	if view = m.View(); !strings.Contains(view, "1 Relays") {
 		t.Fatalf("third cycle did not wrap back to English:\n%s", view)
 	}
 
@@ -39,7 +39,7 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 	// memory or doc cannot silently half-work.
 	for _, stale := range []string{"5", ".", "l"} {
 		m, _ = update(t, m, keyMsg(stale))
-		if view = m.View(); !strings.Contains(view, "2 Relays") || m.view != viewStatus {
+		if view = m.View(); !strings.Contains(view, "1 Relays") || m.view != viewRelays {
 			t.Fatalf("%q still cycles the language or moves the view:\n%s", stale, view)
 		}
 	}

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -23,13 +23,13 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 	// header: the status bar's own labels scroll, so they are not dependable
 	// here (TestSettingsNotesFollowLanguageCycles covers body text).
 	view := m.View()
-	if !strings.Contains(view, "1 中继") || !strings.Contains(view, "c 连接") {
+	if !strings.Contains(view, "1 中继") || !strings.Contains(view, "d 断开") {
 		t.Fatalf("first cycle is not Chinese:\n%s", view)
 	}
 
 	m, _ = update(t, m, keyMsg("0"))
 	view = m.View()
-	if !strings.Contains(view, "1 Узлы") || !strings.Contains(view, "c подключить") {
+	if !strings.Contains(view, "1 Узлы") || !strings.Contains(view, "d отключить") {
 		t.Fatalf("second cycle is not Russian:\n%s", view)
 	}
 

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -111,16 +111,23 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 	}
 }
 
-// The language switch must be findable in every language, so every footer-help
-// track carries the same trilingual token — and the header, now views-only, no
-// longer holds a language slot. Overflow behavior is covered by the marquee
-// tests in views_test.go.
-func TestEveryLanguageIncludesTheTrilingualLanguageHelp(t *testing.T) {
+// The language switch must be findable in every language, so the RENDERED
+// footer carries the trilingual token whenever it fits — and the header, now
+// views-only, no longer holds a language slot. Asserting on tr().helpGlobal
+// instead would be a tautology: helpGlobal is built by concatenating
+// languageKeyHelp at init, so such a check passes however the footer renders.
+// Narrow terminals, where the token has to scroll into view, are covered by
+// TestFooterMarqueeRevealsLanguageToken.
+func TestRenderedFooterShowsTheTrilingualLanguageHelp(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
+	m.width = 120 // wide enough that no view's help needs the marquee
 	for lang := language(0); lang < languageCount; lang++ {
 		m.lang = lang
-		if help := m.tr().helpGlobal; !strings.Contains(help, languageKeyHelp) {
-			t.Fatalf("lang %d footer track lost the language help: %q", lang, help)
+		for v := viewID(0); v < viewCount; v++ {
+			m.view = v
+			if footer := m.footerView(); !strings.Contains(footer, languageKeyHelp) {
+				t.Errorf("lang %d view %d footer lost the language help: %q", lang, v, footer)
+			}
 		}
 		if header := m.headerView(); strings.Contains(header, "язык") {
 			t.Fatalf("lang %d header still carries a language slot: %q", lang, header)

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -19,14 +19,17 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 	if m.view != viewRelays {
 		t.Fatalf("language key changed the view to %d", m.view)
 	}
+	// Evidence from both a tab and the key help, so this covers more than the
+	// header: the status bar's own labels scroll, so they are not dependable
+	// here (TestSettingsNotesFollowLanguageCycles covers body text).
 	view := m.View()
-	if !strings.Contains(view, "1 中继") || !strings.Contains(view, "状态") {
+	if !strings.Contains(view, "1 中继") || !strings.Contains(view, "c 连接") {
 		t.Fatalf("first cycle is not Chinese:\n%s", view)
 	}
 
 	m, _ = update(t, m, keyMsg("0"))
 	view = m.View()
-	if !strings.Contains(view, "1 Узлы") || !strings.Contains(view, "Статус") {
+	if !strings.Contains(view, "1 Узлы") || !strings.Contains(view, "c подключить") {
 		t.Fatalf("second cycle is not Russian:\n%s", view)
 	}
 

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -15,7 +15,7 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 		t.Fatal("default view is not English")
 	}
 
-	m, _ = update(t, m, keyMsg("5"))
+	m, _ = update(t, m, keyMsg("l"))
 	if m.view != viewStatus {
 		t.Fatalf("language key changed the view to %d", m.view)
 	}
@@ -24,20 +24,27 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 		t.Fatalf("first cycle is not Chinese:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("5"))
+	m, _ = update(t, m, keyMsg("l"))
 	view = m.View()
 	if !strings.Contains(view, "2 Узлы") || !strings.Contains(view, "Статус") {
 		t.Fatalf("second cycle is not Russian:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("5"))
+	m, _ = update(t, m, keyMsg("l"))
 	if view = m.View(); !strings.Contains(view, "2 Relays") {
 		t.Fatalf("third cycle did not wrap back to English:\n%s", view)
+	}
+
+	// The old 5 binding is gone: it must neither cycle the language nor
+	// change the view.
+	m, _ = update(t, m, keyMsg("5"))
+	if view = m.View(); !strings.Contains(view, "2 Relays") || m.view != viewStatus {
+		t.Fatalf("5 still does something:\n%s", view)
 	}
 }
 
 // Settings notices are stored as kinds and worded at draw time, so a note
-// set under one language follows a 5-key cycle into the next — stored
+// set under one language follows an l-key cycle into the next — stored
 // rendered text would leave mixed-language UI for exactly the reader the
 // trilingual escape hatch serves.
 func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
@@ -50,7 +57,7 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 		t.Fatalf("Chinese mode note missing:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("5")) // 中文 → русский
+	m, _ = update(t, m, keyMsg("l")) // 中文 → русский
 	view := m.View()
 	if !strings.Contains(view, "режим TUN: следующее подключение захватит все приложения") {
 		t.Fatalf("note did not follow the language cycle:\n%s", view)
@@ -66,20 +73,24 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 	if !strings.Contains(m.View(), "интеграция с shell недоступна") {
 		t.Fatalf("Russian shell-unavailable notice missing:\n%s", m.View())
 	}
-	m, _ = update(t, m, keyMsg("5")) // русский → English
+	m, _ = update(t, m, keyMsg("l")) // русский → English
 	if !strings.Contains(m.View(), "shell integration is unavailable in this build") {
 		t.Fatalf("shell notice did not follow the cycle:\n%s", m.View())
 	}
 }
 
-// The language slot must be readable in every language, so it is the same
-// trilingual label in all of them.
-func TestHeaderAlwaysShowsTheTrilingualLanguageLabel(t *testing.T) {
+// The language switch must be findable in every language, so every footer
+// carries the same trilingual token — and the header, now views-only, no
+// longer holds a language slot.
+func TestFooterAlwaysShowsTheTrilingualLanguageHelp(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	for lang := language(0); lang < languageCount; lang++ {
 		m.lang = lang
-		if header := m.headerView(); !strings.Contains(header, languageTabLabel) {
-			t.Fatalf("lang %d header lost the language label: %q", lang, header)
+		if footer := m.footerView(); !strings.Contains(footer, languageKeyHelp) {
+			t.Fatalf("lang %d footer lost the language help: %q", lang, footer)
+		}
+		if header := m.headerView(); strings.Contains(header, "язык") {
+			t.Fatalf("lang %d header still carries a language slot: %q", lang, header)
 		}
 	}
 }

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -137,11 +137,6 @@ func TestRenderedFooterShowsTheTrilingualLanguageHelp(t *testing.T) {
 // render a bare "%!s(MISSING)" only for those users.
 func TestTranslationTablesAreCompleteAndFormatCompatible(t *testing.T) {
 	english := reflect.ValueOf(*translations[langEnglish])
-	statuses := []connectcore.Status{
-		connectcore.StatusDisconnected, connectcore.StatusPreparing,
-		connectcore.StatusConnecting, connectcore.StatusConnected,
-		connectcore.StatusDisconnecting, connectcore.StatusFailed,
-	}
 
 	for lang := language(0); lang < languageCount; lang++ {
 		tr := translations[lang]
@@ -166,12 +161,8 @@ func TestTranslationTablesAreCompleteAndFormatCompatible(t *testing.T) {
 						t.Errorf("lang %d: %s[%d] is empty", lang, name, j)
 					}
 				}
-			case reflect.Map:
-				for _, status := range statuses {
-					if strings.TrimSpace(tr.statusName(status)) == "" || tr.statusName(status) == string(status) && lang != langEnglish {
-						t.Errorf("lang %d: status %q is untranslated", lang, status)
-					}
-				}
+			default:
+				t.Errorf("lang %d: %s is a %s the completeness sweep does not check", lang, name, field.Kind())
 			}
 		}
 	}

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -15,7 +15,7 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 		t.Fatal("default view is not English")
 	}
 
-	m, _ = update(t, m, keyMsg("."))
+	m, _ = update(t, m, keyMsg("0"))
 	if m.view != viewStatus {
 		t.Fatalf("language key changed the view to %d", m.view)
 	}
@@ -24,37 +24,31 @@ func TestLanguageKeyCyclesWithoutEnteringSettings(t *testing.T) {
 		t.Fatalf("first cycle is not Chinese:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("."))
+	m, _ = update(t, m, keyMsg("0"))
 	view = m.View()
 	if !strings.Contains(view, "2 Узлы") || !strings.Contains(view, "Статус") {
 		t.Fatalf("second cycle is not Russian:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg("."))
+	m, _ = update(t, m, keyMsg("0"))
 	if view = m.View(); !strings.Contains(view, "2 Relays") {
 		t.Fatalf("third cycle did not wrap back to English:\n%s", view)
 	}
 
-	// The old 5 binding is gone: it must neither cycle the language nor
-	// change the view.
-	m, _ = update(t, m, keyMsg("5"))
-	if view = m.View(); !strings.Contains(view, "2 Relays") || m.view != viewStatus {
-		t.Fatalf("5 still does something:\n%s", view)
-	}
-
-	// A CJK IME in full-width punctuation mode delivers 。 for the same key,
-	// so it cycles too — the reader who needs the escape hatch most is the
-	// one typing through an IME.
-	m, _ = update(t, m, keyMsg("。"))
-	if view = m.View(); !strings.Contains(view, "2 中继") {
-		t.Fatalf("the full-width period did not cycle the language:\n%s", view)
+	// Keys this control used to live on must be inert, so a stale muscle
+	// memory or doc cannot silently half-work.
+	for _, stale := range []string{"5", ".", "l"} {
+		m, _ = update(t, m, keyMsg(stale))
+		if view = m.View(); !strings.Contains(view, "2 Relays") || m.view != viewStatus {
+			t.Fatalf("%q still cycles the language or moves the view:\n%s", stale, view)
+		}
 	}
 }
 
-// The language key is a period, and broker URLs are full of periods: an
+// The language key is a digit, and broker URLs carry digits (ports): an
 // editor with focus must swallow it as text rather than cycling the UI out
 // from under the value being typed.
-func TestPeriodIsTextWhileEditingSettings(t *testing.T) {
+func TestLanguageKeyIsTextWhileEditingSettings(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.view = viewSettings // cursor starts on the broker field
 
@@ -63,15 +57,15 @@ func TestPeriodIsTextWhileEditingSettings(t *testing.T) {
 		t.Fatal("enter did not begin editing")
 	}
 	before, seeded := m.lang, m.settings.input.Value()
-	for _, r := range "a.b" {
+	for _, r := range ":8080" {
 		m, _ = update(t, m, keyMsg(string(r)))
 	}
 	if m.lang != before {
-		t.Fatalf("typing a period cycled the language to %d", m.lang)
+		t.Fatalf("typing a digit cycled the language to %d", m.lang)
 	}
 	// The editor opens pre-filled with the current value, so the keys append.
-	if got := m.settings.input.Value(); got != seeded+"a.b" {
-		t.Fatalf("editor value = %q, want %q with the typed periods retained", got, seeded+"a.b")
+	if got := m.settings.input.Value(); got != seeded+":8080" {
+		t.Fatalf("editor value = %q, want %q with the typed digits retained", got, seeded+":8080")
 	}
 }
 
@@ -89,7 +83,7 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 		t.Fatalf("Chinese mode note missing:\n%s", view)
 	}
 
-	m, _ = update(t, m, keyMsg(".")) // 中文 → русский
+	m, _ = update(t, m, keyMsg("0")) // 中文 → русский
 	view := m.View()
 	if !strings.Contains(view, "режим TUN: следующее подключение захватит все приложения") {
 		t.Fatalf("note did not follow the language cycle:\n%s", view)
@@ -105,7 +99,7 @@ func TestSettingsNotesFollowLanguageCycles(t *testing.T) {
 	if !strings.Contains(m.View(), "интеграция с shell недоступна") {
 		t.Fatalf("Russian shell-unavailable notice missing:\n%s", m.View())
 	}
-	m, _ = update(t, m, keyMsg(".")) // русский → English
+	m, _ = update(t, m, keyMsg("0")) // русский → English
 	if !strings.Contains(m.View(), "shell integration is unavailable in this build") {
 		t.Fatalf("shell notice did not follow the cycle:\n%s", m.View())
 	}

--- a/cmd/client/i18n_test.go
+++ b/cmd/client/i18n_test.go
@@ -137,6 +137,11 @@ func TestRenderedFooterShowsTheTrilingualLanguageHelp(t *testing.T) {
 // render a bare "%!s(MISSING)" only for those users.
 func TestTranslationTablesAreCompleteAndFormatCompatible(t *testing.T) {
 	english := reflect.ValueOf(*translations[langEnglish])
+	statuses := []connectcore.Status{
+		connectcore.StatusDisconnected, connectcore.StatusPreparing,
+		connectcore.StatusConnecting, connectcore.StatusConnected,
+		connectcore.StatusDisconnecting, connectcore.StatusFailed,
+	}
 
 	for lang := language(0); lang < languageCount; lang++ {
 		tr := translations[lang]
@@ -159,6 +164,12 @@ func TestTranslationTablesAreCompleteAndFormatCompatible(t *testing.T) {
 				for j := 0; j < field.Len(); j++ {
 					if strings.TrimSpace(field.Index(j).String()) == "" {
 						t.Errorf("lang %d: %s[%d] is empty", lang, name, j)
+					}
+				}
+			case reflect.Map:
+				for _, status := range statuses {
+					if strings.TrimSpace(tr.statusName(status)) == "" || tr.statusName(status) == string(status) && lang != langEnglish {
+						t.Errorf("lang %d: status %q is untranslated", lang, status)
 					}
 				}
 			default:

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -186,7 +186,8 @@ Commands:
   version  Print the client and bundled sing-box versions and exit (-v).
 
 Keys (interactive):
-  c connect  d disconnect  r refresh relays  1-3/tab switch view
+  enter connect to the highlighted relay (Auto select = ranked)  d disconnect
+  r refresh relays  1-3/tab switch view
   0 language (English/中文/русский)  q quit
 
 Connect flags:

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -175,7 +175,7 @@ func printUsage() {
   %[1]s config  -broker http://localhost:8080 -out openrung-sing-box.json
 
 Commands:
-  connect  Interactive TUI by default: Status, Relays, Logs, and Settings views
+  connect  Interactive TUI by default: Relays, Logs, and Settings views
            over the shared connection engine. With -headless, connect and
            stream logs until interrupted.
   check    Fetch relay candidates and print the selected usable relay.
@@ -207,6 +207,9 @@ Common flags:
                   check, and config; the interactive client selects from
                   the Relays list instead).
   -relay-label    Connect only to relay(s) with this label (same commands).
+  -relay-country  Connect only to relays in this 2-letter country code
+                  (e.g. kr); mid-session failover stays within the country
+                  (same commands).
   -mtu            Override the TUN MTU (connect --tun, and the config
                   subcommand).
   -relay-family   Select relay family for check/config: auto, ipv4, or ipv6.

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -186,7 +186,8 @@ Commands:
   version  Print the client and bundled sing-box versions and exit (-v).
 
 Keys (interactive):
-  c connect  d disconnect  r refresh relays  1-4/tab switch view  q quit
+  c connect  d disconnect  r refresh relays  1-3/tab switch view
+  0 language (English/中文/русский)  q quit
 
 Connect flags:
   --tun           Capture the whole device through a TUN interface (%[2]s).

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -203,8 +203,10 @@ Common flags:
   -broker         Broker base URL override (e.g. http://localhost:8080 for a
                   local broker). Empty (the default) races the built-in HTTPS
                   broker fronts and uses the first that answers.
-  -relay-id       Pin the connect target to this exact broker relay id.
-  -relay-label    Pin the connect target to relay(s) with this label.
+  -relay-id       Connect only to this exact broker relay id (-headless,
+                  check, and config; the interactive client selects from
+                  the Relays list instead).
+  -relay-label    Connect only to relay(s) with this label (same commands).
   -mtu            Override the TUN MTU (connect --tun, and the config
                   subcommand).
   -relay-family   Select relay family for check/config: auto, ipv4, or ipv6.

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -185,8 +185,9 @@ const (
 type settingsFieldID int
 
 // The target relay is not a settings field: it is pinned from the Relays view
-// (enter targets the highlighted relay, x clears) or by CLI flags, and the
-// Status view's Target row shows what is pinned.
+// (enter connects to the highlighted relay; the Auto select row clears the
+// pin) or by CLI flags, and the status bar's Target field shows what is
+// pinned.
 const (
 	fieldBroker settingsFieldID = iota
 	fieldMode
@@ -489,8 +490,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.relayErr = ""
 		m.relays = msg.relays
-		if m.relayCursor >= len(m.relays) {
-			m.relayCursor = max(0, len(m.relays)-1)
+		// Index 0 is the Auto select row, so the list is one longer than the
+		// directory and the cursor is valid at len(relays) — and on the Auto
+		// row even when the directory is empty.
+		if m.relayCursor > len(m.relays) {
+			m.relayCursor = len(m.relays)
 		}
 		return m, nil
 
@@ -553,8 +557,6 @@ func (m tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "shift+tab":
 		m.view = (m.view + viewCount - 1) % viewCount
 		return m, nil
-	case "c":
-		return m, m.connectCmd()
 	case "d":
 		return m, m.disconnectCmd()
 	case "r":
@@ -585,18 +587,23 @@ func (m tuiModel) handleRelaysKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.relayCursor--
 		}
 	case "down", "j":
-		if m.relayCursor < len(m.relays)-1 {
+		if m.relayCursor < len(m.relays) {
 			m.relayCursor++
 		}
 	case "enter":
-		// Manual relay selection, like the desktop map's targeting: pin the
-		// highlighted relay and connect to it.
-		if m.relayCursor < len(m.relays) {
-			m.settings.target = connectcore.RelayTarget{RelayID: m.relays[m.relayCursor].Relay.ID}
-			return m, m.connectCmd()
+		// The list is the connect control — there is no separate connect key.
+		// Row 0 is Auto select: it clears any pinned or CLI-seeded target and
+		// lets the broker's ranking pick, which is also the only way to unpin.
+		// Every row below pins the highlighted relay and connects to it, like
+		// the desktop map's targeting.
+		if m.relayCursor == 0 {
+			m.settings.target = connectcore.RelayTarget{}
+		} else if m.relayCursor <= len(m.relays) {
+			m.settings.target = connectcore.RelayTarget{RelayID: m.relays[m.relayCursor-1].Relay.ID}
+		} else {
+			return m, nil
 		}
-	case "x":
-		m.settings.target = connectcore.RelayTarget{}
+		return m, m.connectCmd()
 	}
 	return m, nil
 }

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -109,7 +109,7 @@ func runTUI(cfg connectConfig) error {
 	// interactive client holds no target state at all, so a passed one would
 	// otherwise go silently dead.
 	if cfg.target().Targeted() {
-		ring.push(stampLog(time.Now(), "warning: -relay-id/-relay-label are ignored by the interactive client — pick a relay in the Relays list (they still work with -headless, check, and config)"))
+		ring.push(stampLog(time.Now(), "warning: -relay-id/-relay-label/-relay-country are ignored by the interactive client — pick a relay in the Relays list (they still work with -headless, check, and config)"))
 	}
 
 	// Crash recovery and persisted recents; runs before the event loop exists,
@@ -603,10 +603,23 @@ func (m tuiModel) handleRelaysKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Row 0 is Auto select: the zero target, the broker's ranking picks.
 		// Every row below connects to exactly that relay. The target is built
 		// here and handed straight to the engine; nothing is stored.
+		switch m.state.Status {
+		case connectcore.StatusPreparing, connectcore.StatusConnecting, connectcore.StatusDisconnecting:
+			// A connect or teardown is already in flight. Every ConnectTarget
+			// tears the ladder down and restarts it, so mashing enter on a slow
+			// connect must not keep it from ever converging.
+			return m, nil
+		}
 		if m.relayCursor == 0 {
 			return m, m.connectCmd(connectcore.RelayTarget{})
 		}
 		if m.relayCursor <= len(m.relays) {
+			// Enter on the relay the session is already on would drop the live
+			// session just to rebuild it; only a different row reconnects.
+			if m.state.Status == connectcore.StatusConnected && m.infoOK &&
+				m.relays[m.relayCursor-1].Relay.ID == m.info.Relay.ID {
+				return m, nil
+			}
 			return m, m.connectCmd(connectcore.RelayTarget{RelayID: m.relays[m.relayCursor-1].Relay.ID})
 		}
 	}

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -281,6 +281,15 @@ type tuiModel struct {
 	relayCursor int
 	refreshing  bool
 
+	// connectPending covers the window between dispatching a connect and the
+	// engine's first state event for it: the enter guard reads only the last
+	// PUBLISHED state, so queued presses in that window would otherwise each
+	// tear down and restart the ladder. lastConnectAt backs it with a
+	// one-connect-per-second throttle (against m.now, the tick clock), since
+	// key repeats can outrun the pending flag's clearing.
+	connectPending bool
+	lastConnectAt  time.Time
+
 	settings settingsState
 }
 
@@ -414,6 +423,10 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case engineStateMsg:
+		// The engine has published state for the dispatched connect (or for
+		// whatever else happened); from here the enter guard's status check is
+		// current again.
+		m.connectPending = false
 		m.state = connectcore.State(msg)
 		switch m.state.Status {
 		case connectcore.StatusPreparing:
@@ -512,6 +525,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case connectIssuedMsg:
 		if msg.err != nil {
+			// The engine refused synchronously, so no state event will follow
+			// to clear the pending flag.
+			m.connectPending = false
 			m.ring.push(stampLog(time.Now(), "connect failed to start: "+msg.err.Error()))
 		}
 		return m, nil
@@ -603,25 +619,39 @@ func (m tuiModel) handleRelaysKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Row 0 is Auto select: the zero target, the broker's ranking picks.
 		// Every row below connects to exactly that relay. The target is built
 		// here and handed straight to the engine; nothing is stored.
-		switch m.state.Status {
-		case connectcore.StatusPreparing, connectcore.StatusConnecting, connectcore.StatusDisconnecting:
-			// A connect or teardown is already in flight. Every ConnectTarget
-			// tears the ladder down and restarts it, so mashing enter on a slow
-			// connect must not keep it from ever converging.
+		//
+		// Three guards, because every ConnectTarget tears the ladder down and
+		// restarts it: a dispatched connect the engine has not published state
+		// for yet (connectPending), a hard one-per-second throttle for key
+		// repeats, and the published in-flight states themselves.
+		if m.connectPending {
 			return m, nil
 		}
-		if m.relayCursor == 0 {
-			return m, m.connectCmd(connectcore.RelayTarget{})
+		if !m.lastConnectAt.IsZero() && m.now.Sub(m.lastConnectAt) < time.Second {
+			return m, nil
 		}
-		if m.relayCursor <= len(m.relays) {
+		switch m.state.Status {
+		case connectcore.StatusPreparing, connectcore.StatusConnecting, connectcore.StatusDisconnecting:
+			// A connect or teardown is already in flight; mashing enter on a
+			// slow connect must not keep it from ever converging.
+			return m, nil
+		}
+		var target connectcore.RelayTarget
+		if m.relayCursor > 0 {
+			if m.relayCursor > len(m.relays) {
+				return m, nil
+			}
 			// Enter on the relay the session is already on would drop the live
 			// session just to rebuild it; only a different row reconnects.
 			if m.state.Status == connectcore.StatusConnected && m.infoOK &&
 				m.relays[m.relayCursor-1].Relay.ID == m.info.Relay.ID {
 				return m, nil
 			}
-			return m, m.connectCmd(connectcore.RelayTarget{RelayID: m.relays[m.relayCursor-1].Relay.ID})
+			target = connectcore.RelayTarget{RelayID: m.relays[m.relayCursor-1].Relay.ID}
 		}
+		m.connectPending = true
+		m.lastConnectAt = m.now
+		return m, m.connectCmd(target)
 	}
 	return m, nil
 }

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -533,20 +533,19 @@ func (m tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "4":
 		m.view = viewSettings
 		return m, nil
-	case ".", "。":
+	case "0":
 		// Cycle the UI language in place — no settings entry, so a user who
 		// cannot read the current language never has to navigate one. The
 		// footer advertises the key trilingually (languageKeyHelp) for the
 		// same reason.
 		//
-		// Punctuation, not a letter, because this key must be TYPEABLE in the
-		// same situation it must be readable. A Cyrillic (ЙЦУКЕН) or Greek
-		// layout carries no Latin letters at all, so a letter binding is
-		// unreachable without switching the OS layout first — for exactly the
-		// reader who cannot read the UI telling them which key to press. A
-		// period exists on essentially every layout (unshifted on ЙЦУКЕН and
-		// QWERTZ, shifted on AZERTY — all deliver "."). 。 is the same key
-		// under a CJK IME in full-width punctuation mode.
+		// A digit, not a letter, because this key must be TYPEABLE in the same
+		// situation it must be readable. A Cyrillic (ЙЦУКЕН) or Greek layout
+		// carries no Latin letters at all, so a letter binding is unreachable
+		// without switching the OS layout first — for exactly the reader who
+		// cannot read the UI telling them which key to press. Digits sit on
+		// every layout, the same property that makes the 1-4 view keys work,
+		// and 0 reads as their neighbour.
 		m.lang = (m.lang + 1) % languageCount
 		return m, nil
 	case "tab":

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -193,7 +193,7 @@ const (
 )
 
 // A settings notice is stored as a kind and rendered through the active
-// language at draw time: storing translated text would survive a 5-key
+// language at draw time: storing translated text would survive an l-key
 // language cycle and leave mixed-language UI.
 type noteKind int
 
@@ -530,9 +530,11 @@ func (m tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "4":
 		m.view = viewSettings
 		return m, nil
-	case "5":
+	case "l":
 		// Cycle the UI language in place — no settings entry, so a user who
-		// cannot read the current language never has to navigate one.
+		// cannot read the current language never has to navigate one. The
+		// footer advertises the key trilingually (languageKeyHelp) for the
+		// same reason.
 		m.lang = (m.lang + 1) % languageCount
 		return m, nil
 	case "tab":

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -196,7 +196,7 @@ const (
 
 // A settings notice is stored as a kind and rendered through the active
 // language at draw time: storing translated text would survive a language
-// language cycle and leave mixed-language UI.
+// cycle and leave mixed-language UI.
 type noteKind int
 
 const (

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -105,6 +105,12 @@ func runTUI(cfg connectConfig) error {
 	for _, warning := range legacyFlagWarnings(cfg) {
 		ring.push(stampLog(time.Now(), "warning: "+warning))
 	}
+	// Headless connect, check, and config still honor these flags; the
+	// interactive client holds no target state at all, so a passed one would
+	// otherwise go silently dead.
+	if cfg.target().Targeted() {
+		ring.push(stampLog(time.Now(), "warning: -relay-id/-relay-label are ignored by the interactive client — pick a relay in the Relays list (they still work with -headless, check, and config)"))
+	}
 
 	// Crash recovery and persisted recents; runs before the event loop exists,
 	// so its log lines are already in the ring for the first flush.
@@ -184,10 +190,10 @@ const (
 
 type settingsFieldID int
 
-// The target relay is not a settings field: it is pinned from the Relays view
-// (enter connects to the highlighted relay; the Auto select row clears the
-// pin) or by CLI flags, and the status bar's Target field shows what is
-// pinned.
+// There is no target field anywhere: the TUI holds no relay-target state at
+// all. Enter on the Relays list passes the highlighted row to the engine and
+// that is the whole story (the -relay-id/-relay-label flags stay headless- and
+// check/config-only).
 const (
 	fieldBroker settingsFieldID = iota
 	fieldMode
@@ -219,7 +225,6 @@ type settingsNote struct {
 
 type settingsState struct {
 	brokerURL string
-	target    connectcore.RelayTarget
 	// mode mirrors the engine's capture mode. The engine owns it (a live
 	// session keeps the mode it started with), so the view only ever shows
 	// what a SetMode call confirmed.
@@ -297,7 +302,6 @@ func newTUIModel(driver engineDriver, ring *logRing, cfg connectConfig) tuiModel
 		refreshing: true,
 		settings: settingsState{
 			brokerURL: cfg.BrokerURL,
-			target:    cfg.target(),
 			mode:      cfg.mode(),
 			input:     input,
 		},
@@ -354,8 +358,12 @@ func (m tuiModel) resolveProxyCmd() tea.Cmd {
 	}
 }
 
-func (m tuiModel) connectCmd() tea.Cmd {
-	driver, broker, target := m.driver, m.settings.brokerURL, m.settings.target
+// connectCmd issues one connect to the given target — the highlighted relay,
+// or the zero target for Auto select's ranked pick. The target lives only in
+// this call: the TUI stores none, so there is nothing to pin, clear, or drift
+// stale.
+func (m tuiModel) connectCmd(target connectcore.RelayTarget) tea.Cmd {
+	driver, broker := m.driver, m.settings.brokerURL
 	return func() tea.Msg {
 		return connectIssuedMsg{err: driver.ConnectTarget(broker, target)}
 	}
@@ -592,18 +600,15 @@ func (m tuiModel) handleRelaysKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "enter":
 		// The list is the connect control — there is no separate connect key.
-		// Row 0 is Auto select: it clears any pinned or CLI-seeded target and
-		// lets the broker's ranking pick, which is also the only way to unpin.
-		// Every row below pins the highlighted relay and connects to it, like
-		// the desktop map's targeting.
+		// Row 0 is Auto select: the zero target, the broker's ranking picks.
+		// Every row below connects to exactly that relay. The target is built
+		// here and handed straight to the engine; nothing is stored.
 		if m.relayCursor == 0 {
-			m.settings.target = connectcore.RelayTarget{}
-		} else if m.relayCursor <= len(m.relays) {
-			m.settings.target = connectcore.RelayTarget{RelayID: m.relays[m.relayCursor-1].Relay.ID}
-		} else {
-			return m, nil
+			return m, m.connectCmd(connectcore.RelayTarget{})
 		}
-		return m, m.connectCmd()
+		if m.relayCursor <= len(m.relays) {
+			return m, m.connectCmd(connectcore.RelayTarget{RelayID: m.relays[m.relayCursor-1].Relay.ID})
+		}
 	}
 	return m, nil
 }

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -423,13 +423,16 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case engineStateMsg:
-		// The engine has published state for the dispatched connect (or for
-		// whatever else happened); from here the enter guard's status check is
-		// current again.
-		m.connectPending = false
 		m.state = connectcore.State(msg)
 		switch m.state.Status {
 		case connectcore.StatusPreparing:
+			// The requested connect is now the engine's published state, so the
+			// status guard takes over from the pending latch. Preparing is the
+			// ONLY event that clears it: a reconnect's teardown publishes the
+			// OLD session's Disconnected first (and can then flush telemetry
+			// for seconds), and unlatching there re-opened the enter window
+			// before the new ladder had reported in at all.
+			m.connectPending = false
 			// Only a fresh ConnectTarget passes through preparing (a failover
 			// recovery re-promotes via connecting), so this is where a genuinely
 			// new session starts: drop the previous session's activity notice.
@@ -582,6 +585,10 @@ func (m tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.view = (m.view + viewCount - 1) % viewCount
 		return m, nil
 	case "d":
+		// An explicit disconnect supersedes any dispatched connect; without
+		// this, a connect torn down before it ever published preparing would
+		// leave the pending latch stuck and enter dead.
+		m.connectPending = false
 		return m, m.disconnectCmd()
 	case "r":
 		if m.refreshing {

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -251,6 +251,7 @@ type tuiModel struct {
 	infoOK      bool
 	connectedAt time.Time
 	now         time.Time
+	startedAt   time.Time
 
 	// Latest typed engine notices: activity is the last connection event
 	// (failover, WSS fallback, punch, ticket retry), health the last
@@ -280,11 +281,13 @@ const tuiTickInterval = 200 * time.Millisecond
 func newTUIModel(driver engineDriver, ring *logRing, cfg connectConfig) tuiModel {
 	input := textinput.New()
 	input.CharLimit = 256
+	now := time.Now()
 	return tuiModel{
-		driver: driver,
-		ring:   ring,
-		now:    time.Now(),
-		state:  connectcore.State{Status: connectcore.StatusDisconnected},
+		driver:    driver,
+		ring:      ring,
+		now:       now,
+		startedAt: now,
+		state:     connectcore.State{Status: connectcore.StatusDisconnected},
 		// Init issues the first directory refresh, so mark it in flight: the
 		// Relays view says "refreshing" instead of inviting an r that would
 		// race it.

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -172,9 +172,11 @@ type modeSetMsg struct {
 
 type viewID int
 
+// There is no Status view: its rows are the statusFooter, a permanent bar
+// above the key help, so connection state is visible from every view instead
+// of only the one the user happened to be on.
 const (
-	viewStatus viewID = iota
-	viewRelays
+	viewRelays viewID = iota
 	viewLogs
 	viewSettings
 	viewCount
@@ -522,15 +524,12 @@ func (m tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// flushes telemetry before the process ends.
 		return m, tea.Quit
 	case "1":
-		m.view = viewStatus
-		return m, nil
-	case "2":
 		m.view = viewRelays
 		return m, nil
-	case "3":
+	case "2":
 		m.view = viewLogs
 		return m, nil
-	case "4":
+	case "3":
 		m.view = viewSettings
 		return m, nil
 	case "0":

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -182,12 +182,12 @@ const (
 
 type settingsFieldID int
 
+// The target relay is not a settings field: it is pinned from the Relays view
+// (enter targets the highlighted relay, x clears) or by CLI flags, and the
+// Status view's Target row shows what is pinned.
 const (
 	fieldBroker settingsFieldID = iota
 	fieldMode
-	fieldRelayID
-	fieldRelayLabel
-	fieldCountry
 	fieldShellHelper
 	settingsFieldCount
 )
@@ -654,29 +654,15 @@ func (m tuiModel) handleSettingsEditKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m tuiModel) settingsFieldValue(field settingsFieldID) string {
-	switch field {
-	case fieldBroker:
+	if field == fieldBroker {
 		return m.settings.brokerURL
-	case fieldRelayID:
-		return m.settings.target.RelayID
-	case fieldRelayLabel:
-		return m.settings.target.Label
-	case fieldCountry:
-		return m.settings.target.Country
 	}
 	return ""
 }
 
 func (m *tuiModel) applySettingsField(field settingsFieldID, value string) {
-	switch field {
-	case fieldBroker:
+	if field == fieldBroker {
 		m.settings.brokerURL = value
-	case fieldRelayID:
-		m.settings.target.RelayID = value
-	case fieldRelayLabel:
-		m.settings.target.Label = value
-	case fieldCountry:
-		m.settings.target.Country = value
 	}
 }
 

--- a/cmd/client/tui.go
+++ b/cmd/client/tui.go
@@ -193,7 +193,7 @@ const (
 )
 
 // A settings notice is stored as a kind and rendered through the active
-// language at draw time: storing translated text would survive an l-key
+// language at draw time: storing translated text would survive a language
 // language cycle and leave mixed-language UI.
 type noteKind int
 
@@ -530,11 +530,20 @@ func (m tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "4":
 		m.view = viewSettings
 		return m, nil
-	case "l":
+	case ".", "。":
 		// Cycle the UI language in place — no settings entry, so a user who
 		// cannot read the current language never has to navigate one. The
 		// footer advertises the key trilingually (languageKeyHelp) for the
 		// same reason.
+		//
+		// Punctuation, not a letter, because this key must be TYPEABLE in the
+		// same situation it must be readable. A Cyrillic (ЙЦУКЕН) or Greek
+		// layout carries no Latin letters at all, so a letter binding is
+		// unreachable without switching the OS layout first — for exactly the
+		// reader who cannot read the UI telling them which key to press. A
+		// period exists on essentially every layout (unshifted on ЙЦУКЕН and
+		// QWERTZ, shifted on AZERTY — all deliver "."). 。 is the same key
+		// under a CJK IME in full-width punctuation mode.
 		m.lang = (m.lang + 1) % languageCount
 		return m, nil
 	case "tab":

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -459,22 +459,6 @@ func TestEngineNoticesDriveActivityAndHealthRows(t *testing.T) {
 	}
 }
 
-func TestRecentsRenderInRelaysView(t *testing.T) {
-	driver := &fakeDriver{}
-	m := newTestModel(driver)
-	m.view = viewRelays
-	m.refreshing = false
-	m.state.Recents = []connectcore.RecentNode{
-		{CountryCode: "KR", Label: "Seoul, South Korea"},
-		{CountryCode: "JP", Label: "Tokyo, Japan"},
-	}
-
-	view := m.View()
-	if !strings.Contains(view, "Seoul, South Korea · Tokyo, Japan") {
-		t.Fatalf("relays view missing the recents row:\n%s", view)
-	}
-}
-
 func TestShellHelperActionRequiresConnection(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -201,13 +201,17 @@ func TestConnectedStateStampsSessionStartAndRendersStatus(t *testing.T) {
 	// bar shows only a scrolling window into it. The duration is the one field
 	// pinned to the rendered bar, checked separately below.
 	view := m.statusDetail()
-	for _, want := range []string{"connected", label, "direct", "KR", "127.0.0.1:43210"} {
+	for _, want := range []string{"connected", "direct", "KR", "127.0.0.1:43210"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("status detail missing %q:\n%s", want, view)
 		}
 	}
-	if bar := m.statusFooterView(); !strings.Contains(bar, "00:01:30") {
-		t.Fatalf("status bar did not pin the session duration:\n%q", bar)
+	// The relay name and the duration are the pin's, not the detail's.
+	pin := m.statusPin(0)
+	for _, want := range []string{label, "00:01:30"} {
+		if !strings.Contains(pin, want) {
+			t.Fatalf("status pin missing %q:\n%q", want, pin)
+		}
 	}
 }
 

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -178,6 +178,55 @@ func TestRelaysEnterConnectsToTheHighlightedRelay(t *testing.T) {
 	}
 }
 
+// Enter must not restart a connect that is already in flight (every
+// ConnectTarget tears down and rebuilds the ladder, so mashing enter would
+// keep it from converging), and enter on the relay the session is already on
+// must not drop the live session — while Auto select stays live as an
+// explicit "re-pick" even when connected.
+func TestEnterGuardsInFlightAndCurrentRelay(t *testing.T) {
+	driver := &fakeDriver{}
+	m := newTestModel(driver)
+	m.view = viewRelays
+	m.relays = []connectcore.DirectoryRelay{{Relay: brokerapi.RelayDescriptor{ID: "relay_a"}}}
+
+	for _, status := range []connectcore.Status{
+		connectcore.StatusPreparing, connectcore.StatusConnecting, connectcore.StatusDisconnecting,
+	} {
+		m.state = connectcore.State{Status: status}
+		m, _ = update(t, m, keyMsg("enter"))
+		if len(driver.connects) != 0 {
+			t.Fatalf("enter during %s issued a connect", status)
+		}
+	}
+
+	m.state = connectcore.State{Status: connectcore.StatusConnected}
+	m.infoOK = true
+	m.info = connectcore.ConnectionInfo{Relay: brokerapi.RelayDescriptor{ID: "relay_a"}}
+	m, _ = update(t, m, keyMsg("down")) // onto the connected relay's own row
+	m, _ = update(t, m, keyMsg("enter"))
+	if len(driver.connects) != 0 {
+		t.Fatal("enter on the connected relay dropped and rebuilt the session")
+	}
+	m, _ = update(t, m, keyMsg("up")) // back to Auto select
+	m, _ = update(t, m, keyMsg("enter"))
+	if len(driver.connects) != 1 {
+		t.Fatalf("Auto select while connected did not reconnect: %d connects", len(driver.connects))
+	}
+}
+
+// -relay-country keeps the engine's country-scoped connect (and its
+// intra-country failover) reachable from the binary now that the TUI holds no
+// target state.
+func TestRelayCountryFlagSeedsTheTarget(t *testing.T) {
+	cfg, err := parseCommonFlags("check", []string{"-relay-country", "kr"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target := cfg.target(); target.Country != "kr" || !target.Targeted() {
+		t.Fatalf("target = %+v, want country kr", target)
+	}
+}
+
 // Auto select — the list's first row, where the cursor starts — connects with
 // no target at all: the broker's ranked pick. It works before the directory
 // has ever loaded, since a ranked connect needs no list.
@@ -422,7 +471,8 @@ func TestRelaysWindowFollowsCursor(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)
 	m.view = viewRelays
-	m.height = 12 // body of 8 rows: notice-free header + 7 list rows visible
+	m.refreshing = false
+	m.height = 12 // body of 7 rows; the brand mark reserves 4, header 1 → 2 list rows
 	for i := 0; i < 30; i++ {
 		m.relays = append(m.relays, connectcore.DirectoryRelay{
 			Relay: brokerapi.RelayDescriptor{ID: fmt.Sprintf("relay_%02d", i), Label: fmt.Sprintf("node-%02d", i)},

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -170,8 +170,9 @@ func TestRelaysEnterConnectsToTheHighlightedRelay(t *testing.T) {
 
 	// The target lived only in that call: back on Auto select, the next connect
 	// is ranked again — no pin lingers from the relay connect before it. (The
-	// engine publishes state and time passes first, or the connect-spam guards
-	// would swallow the press.)
+	// requested connect reports in, ends, and time passes first, or the
+	// connect-spam guards would swallow the press.)
+	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusPreparing}))
 	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusDisconnected}))
 	m.now = m.now.Add(2 * time.Second)
 	m, _ = update(t, m, keyMsg("up"))
@@ -197,19 +198,49 @@ func TestEnterSpamDispatchesOneConnect(t *testing.T) {
 		t.Fatalf("queued enters dispatched %d connects, want 1", len(driver.connects))
 	}
 
-	// The engine answered and went back to disconnected, but within the same
-	// second: the throttle still holds.
+	// A reconnect's teardown publishes the OLD session's Disconnected first,
+	// and the new ladder may not report in for seconds. That event must not
+	// unlatch enter — the reproduction was: connected → enter → old session's
+	// Disconnected → wait past the throttle → enter → two ConnectTargets.
 	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusDisconnected}))
+	m.now = m.now.Add(2 * time.Second)
 	m, _ = update(t, m, keyMsg("enter"))
 	if len(driver.connects) != 1 {
-		t.Fatalf("sub-second re-press dispatched %d connects, want 1", len(driver.connects))
+		t.Fatalf("old session's Disconnected unlatched enter: %d connects, want 1", len(driver.connects))
 	}
 
-	// A second later the press is a deliberate retry, not spam.
+	// Only the requested connect's own Preparing hands control back to the
+	// status guard; once that attempt ends and a second passes, a fresh press
+	// is a deliberate retry.
+	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusPreparing}))
+	m, _ = update(t, m, keyMsg("enter")) // in flight: the status guard holds
+	if len(driver.connects) != 1 {
+		t.Fatalf("enter during preparing dispatched %d connects, want 1", len(driver.connects))
+	}
+	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusDisconnected}))
 	m.now = m.now.Add(2 * time.Second)
 	m, _ = update(t, m, keyMsg("enter"))
 	if len(driver.connects) != 2 {
 		t.Fatalf("deliberate retry dispatched %d connects, want 2", len(driver.connects))
+	}
+}
+
+// A connect torn down before it ever publishes preparing must not leave the
+// pending latch stuck: an explicit d hands the latch back.
+func TestDisconnectUnlatchesAPendingConnect(t *testing.T) {
+	driver := &fakeDriver{}
+	m := newTestModel(driver)
+	m.view = viewRelays
+
+	m, _ = update(t, m, keyMsg("enter"))
+	if len(driver.connects) != 1 {
+		t.Fatalf("connects = %d, want 1", len(driver.connects))
+	}
+	m, _ = update(t, m, keyMsg("d"))
+	m.now = m.now.Add(2 * time.Second)
+	m, _ = update(t, m, keyMsg("enter"))
+	if len(driver.connects) != 2 {
+		t.Fatalf("enter after an explicit disconnect stayed latched: %d connects", len(driver.connects))
 	}
 }
 

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -169,12 +169,47 @@ func TestRelaysEnterConnectsToTheHighlightedRelay(t *testing.T) {
 	}
 
 	// The target lived only in that call: back on Auto select, the next connect
-	// is ranked again — no pin lingers from the relay connect before it.
+	// is ranked again — no pin lingers from the relay connect before it. (The
+	// engine publishes state and time passes first, or the connect-spam guards
+	// would swallow the press.)
+	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusDisconnected}))
+	m.now = m.now.Add(2 * time.Second)
 	m, _ = update(t, m, keyMsg("up"))
 	m, _ = update(t, m, keyMsg("up"))
 	m, _ = update(t, m, keyMsg("enter"))
 	if _, target := driver.lastConnect(t); target.Targeted() {
 		t.Fatalf("Auto select connect still carries a target: %+v", target)
+	}
+}
+
+// The status guard reads only the last PUBLISHED engine state, which arrives
+// asynchronously: presses queued before that first state event must not each
+// restart the ladder, and key repeats are capped at one connect per second.
+func TestEnterSpamDispatchesOneConnect(t *testing.T) {
+	driver := &fakeDriver{}
+	m := newTestModel(driver)
+	m.view = viewRelays
+
+	for i := 0; i < 5; i++ {
+		m, _ = update(t, m, keyMsg("enter"))
+	}
+	if len(driver.connects) != 1 {
+		t.Fatalf("queued enters dispatched %d connects, want 1", len(driver.connects))
+	}
+
+	// The engine answered and went back to disconnected, but within the same
+	// second: the throttle still holds.
+	m, _ = update(t, m, engineStateMsg(connectcore.State{Status: connectcore.StatusDisconnected}))
+	m, _ = update(t, m, keyMsg("enter"))
+	if len(driver.connects) != 1 {
+		t.Fatalf("sub-second re-press dispatched %d connects, want 1", len(driver.connects))
+	}
+
+	// A second later the press is a deliberate retry, not spam.
+	m.now = m.now.Add(2 * time.Second)
+	m, _ = update(t, m, keyMsg("enter"))
+	if len(driver.connects) != 2 {
+		t.Fatalf("deliberate retry dispatched %d connects, want 2", len(driver.connects))
 	}
 }
 

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -172,7 +172,11 @@ func TestRelaysEnterPinsSelectionAndConnects(t *testing.T) {
 func TestConnectedStateStampsSessionStartAndRendersStatus(t *testing.T) {
 	driver := &fakeDriver{}
 	driver.info = connectcore.ConnectionInfo{
-		Relay:     brokerapi.RelayDescriptor{ID: "relay_a", NodeClass: brokerapi.NodeClassFoundation, RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "kr"}},
+		// Geo-bearing, like a real directory descriptor: the status bar single-
+		// sources relay identity from the descriptor, so a bare one would read
+		// "relay relay_a" and prove nothing about the label a user actually sees.
+		Relay: brokerapi.RelayDescriptor{ID: "relay_a", NodeClass: brokerapi.NodeClassFoundation,
+			RelayGeoLocation: brokerapi.RelayGeoLocation{City: "Seoul", Country: "South Korea", CountryCode: "kr"}},
 		Transport: brokerapi.TransportDirect,
 		ProxyPort: 43210,
 	}
@@ -193,11 +197,17 @@ func TestConnectedStateStampsSessionStartAndRendersStatus(t *testing.T) {
 	m, _ = update(t, m, m.resolveProxyCmd()())
 	m.now = m.connectedAt.Add(90 * time.Second)
 
-	view := m.View()
-	for _, want := range []string{"connected", label, "direct", "KR", "00:01:30", "127.0.0.1:43210"} {
+	// The status bar's detail track, not the rendered frame: at test width the
+	// bar shows only a scrolling window into it. The duration is the one field
+	// pinned to the rendered bar, checked separately below.
+	view := m.statusDetail()
+	for _, want := range []string{"connected", label, "direct", "KR", "127.0.0.1:43210"} {
 		if !strings.Contains(view, want) {
-			t.Fatalf("status view missing %q:\n%s", want, view)
+			t.Fatalf("status detail missing %q:\n%s", want, view)
 		}
+	}
+	if bar := m.statusFooterView(); !strings.Contains(bar, "00:01:30") {
+		t.Fatalf("status bar did not pin the session duration:\n%q", bar)
 	}
 }
 
@@ -287,11 +297,12 @@ func TestTUNModeSkipsProxyPortResolution(t *testing.T) {
 		t.Fatalf("mode = %v; want TUN from --tun", m.settings.mode)
 	}
 	m.width, m.height = 80, 24
-	m.view = viewStatus
-	if body := m.View(); !strings.Contains(body, "TUN — whole device") {
-		t.Fatalf("status view did not report TUN capture:\n%s", body)
+	// Read the status bar's detail track rather than the frame: at 80 cells the
+	// bar shows a window into it, so the capture field may be scrolled out.
+	if detail := m.statusDetail(); !strings.Contains(detail, "TUN — whole device") {
+		t.Fatalf("status bar did not report TUN capture:\n%s", detail)
 	}
-	if strings.Contains(m.View(), "resolving…") {
+	if strings.Contains(m.statusDetail(), "resolving…") {
 		t.Fatal("TUN mode still advertises a local proxy endpoint")
 	}
 }
@@ -422,10 +433,11 @@ func TestEngineNoticesDriveActivityAndHealthRows(t *testing.T) {
 		Threshold: 3,
 	}))
 
-	view := m.View()
+	// The bar's detail track: at test width the rendered bar is a window into it.
+	view := m.statusDetail()
 	for _, want := range []string{"failover: relay relay_a lost", "tunnel process exited unexpectedly", "2/3 probes failed"} {
 		if !strings.Contains(view, want) {
-			t.Fatalf("status view missing %q:\n%s", want, view)
+			t.Fatalf("status detail missing %q:\n%s", want, view)
 		}
 	}
 
@@ -436,9 +448,9 @@ func TestEngineNoticesDriveActivityAndHealthRows(t *testing.T) {
 		FrontID: "front-a",
 		Reason:  "direct TCP blocked",
 	}))
-	view = m.View()
+	view = m.statusDetail()
 	if !strings.Contains(view, "WSS fallback: relay relay_a via front front-a") {
-		t.Fatalf("status view missing the WSS fallback activity:\n%s", view)
+		t.Fatalf("status detail missing the WSS fallback activity:\n%s", view)
 	}
 
 	// Disconnecting ends the session: health state goes with it, the last

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -119,22 +119,22 @@ func update(t *testing.T, m tuiModel, msg tea.Msg) (tuiModel, tea.Msg) {
 }
 
 // The c and x keys are retired: enter on the Relays list is the only connect
-// control, and its Auto select row is what clears a pin. Both keys must be
-// inert so stale muscle memory or a stale doc cannot silently half-work.
+// control, and there is no pin left for x to clear. Both keys must be inert so
+// stale muscle memory or a stale doc cannot silently half-work.
 func TestRetiredConnectAndClearKeysAreInert(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)
 	m.view = viewRelays
-	m.settings.target = connectcore.RelayTarget{Country: "kr"}
 	m.relays = []connectcore.DirectoryRelay{{Relay: brokerapi.RelayDescriptor{ID: "relay_a"}}}
 
-	m, _ = update(t, m, keyMsg("c"))
-	if len(driver.connects) != 0 {
-		t.Fatalf("c still connects: %+v", driver.connects)
-	}
-	m, _ = update(t, m, keyMsg("x"))
-	if m.settings.target.Country != "kr" {
-		t.Fatalf("x still clears the target: %+v", m.settings.target)
+	for _, stale := range []string{"c", "x"} {
+		m, _ = update(t, m, keyMsg(stale))
+		if len(driver.connects) != 0 {
+			t.Fatalf("%q still connects: %+v", stale, driver.connects)
+		}
+		if m.view != viewRelays {
+			t.Fatalf("%q moved the view to %d", stale, m.view)
+		}
 	}
 }
 
@@ -149,7 +149,7 @@ func TestDisconnectKeyIssuesEngineDisconnect(t *testing.T) {
 	}
 }
 
-func TestRelaysEnterPinsSelectionAndConnects(t *testing.T) {
+func TestRelaysEnterConnectsToTheHighlightedRelay(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)
 	m.view = viewRelays
@@ -165,31 +165,32 @@ func TestRelaysEnterPinsSelectionAndConnects(t *testing.T) {
 
 	_, target := driver.lastConnect(t)
 	if target.RelayID != "relay_b" {
-		t.Fatalf("target = %+v, want the highlighted relay pinned", target)
+		t.Fatalf("target = %+v, want the highlighted relay", target)
 	}
-	if m.settings.target.RelayID != "relay_b" {
-		t.Fatalf("settings target = %+v, want the pinned relay retained", m.settings.target)
+
+	// The target lived only in that call: back on Auto select, the next connect
+	// is ranked again — no pin lingers from the relay connect before it.
+	m, _ = update(t, m, keyMsg("up"))
+	m, _ = update(t, m, keyMsg("up"))
+	m, _ = update(t, m, keyMsg("enter"))
+	if _, target := driver.lastConnect(t); target.Targeted() {
+		t.Fatalf("Auto select connect still carries a target: %+v", target)
 	}
 }
 
 // Auto select — the list's first row, where the cursor starts — connects with
-// no target at all: it clears a pinned or CLI-seeded target and asks for the
-// broker's ranked pick, absorbing both of the retired c and x keys. It works
-// before the directory has ever loaded, since a ranked connect needs no list.
-func TestRelaysAutoSelectConnectsRankedAndClearsTheTarget(t *testing.T) {
+// no target at all: the broker's ranked pick. It works before the directory
+// has ever loaded, since a ranked connect needs no list.
+func TestRelaysAutoSelectConnectsRanked(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)
 	m.view = viewRelays
-	m.settings.target = connectcore.RelayTarget{Country: "kr"} // CLI-seeded
 
-	m, _ = update(t, m, keyMsg("enter"))
+	_, _ = update(t, m, keyMsg("enter"))
 
 	broker, target := driver.lastConnect(t)
 	if broker != "http://broker.test" || target.Targeted() {
 		t.Fatalf("ConnectTarget(%q, %+v), want the settings broker and no target", broker, target)
-	}
-	if m.settings.target.Targeted() {
-		t.Fatalf("settings target = %+v, want cleared by Auto select", m.settings.target)
 	}
 }
 

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -118,16 +118,23 @@ func update(t *testing.T, m tuiModel, msg tea.Msg) (tuiModel, tea.Msg) {
 	return model, cmd()
 }
 
-func TestConnectKeyIssuesEngineConnectWithSettingsTarget(t *testing.T) {
+// The c and x keys are retired: enter on the Relays list is the only connect
+// control, and its Auto select row is what clears a pin. Both keys must be
+// inert so stale muscle memory or a stale doc cannot silently half-work.
+func TestRetiredConnectAndClearKeysAreInert(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)
+	m.view = viewRelays
 	m.settings.target = connectcore.RelayTarget{Country: "kr"}
+	m.relays = []connectcore.DirectoryRelay{{Relay: brokerapi.RelayDescriptor{ID: "relay_a"}}}
 
-	_, _ = update(t, m, keyMsg("c"))
-
-	broker, target := driver.lastConnect(t)
-	if broker != "http://broker.test" || target.Country != "kr" {
-		t.Fatalf("ConnectTarget(%q, %+v), want the settings broker and target", broker, target)
+	m, _ = update(t, m, keyMsg("c"))
+	if len(driver.connects) != 0 {
+		t.Fatalf("c still connects: %+v", driver.connects)
+	}
+	m, _ = update(t, m, keyMsg("x"))
+	if m.settings.target.Country != "kr" {
+		t.Fatalf("x still clears the target: %+v", m.settings.target)
 	}
 }
 
@@ -151,6 +158,8 @@ func TestRelaysEnterPinsSelectionAndConnects(t *testing.T) {
 		{Relay: brokerapi.RelayDescriptor{ID: "relay_b"}},
 	}
 
+	// The cursor starts on Auto select, so the second relay is two steps down.
+	m, _ = update(t, m, keyMsg("down"))
 	m, _ = update(t, m, keyMsg("down"))
 	m, _ = update(t, m, keyMsg("enter"))
 
@@ -161,11 +170,26 @@ func TestRelaysEnterPinsSelectionAndConnects(t *testing.T) {
 	if m.settings.target.RelayID != "relay_b" {
 		t.Fatalf("settings target = %+v, want the pinned relay retained", m.settings.target)
 	}
+}
 
-	// x clears the pin so the next connect is automatic again.
-	m, _ = update(t, m, keyMsg("x"))
+// Auto select — the list's first row, where the cursor starts — connects with
+// no target at all: it clears a pinned or CLI-seeded target and asks for the
+// broker's ranked pick, absorbing both of the retired c and x keys. It works
+// before the directory has ever loaded, since a ranked connect needs no list.
+func TestRelaysAutoSelectConnectsRankedAndClearsTheTarget(t *testing.T) {
+	driver := &fakeDriver{}
+	m := newTestModel(driver)
+	m.view = viewRelays
+	m.settings.target = connectcore.RelayTarget{Country: "kr"} // CLI-seeded
+
+	m, _ = update(t, m, keyMsg("enter"))
+
+	broker, target := driver.lastConnect(t)
+	if broker != "http://broker.test" || target.Targeted() {
+		t.Fatalf("ConnectTarget(%q, %+v), want the settings broker and no target", broker, target)
+	}
 	if m.settings.target.Targeted() {
-		t.Fatalf("settings target = %+v, want cleared", m.settings.target)
+		t.Fatalf("settings target = %+v, want cleared by Auto select", m.settings.target)
 	}
 }
 
@@ -397,25 +421,26 @@ func TestRelaysWindowFollowsCursor(t *testing.T) {
 	driver := &fakeDriver{}
 	m := newTestModel(driver)
 	m.view = viewRelays
-	m.height = 12 // body of 8 rows: notice-free header + 7 relay rows visible
+	m.height = 12 // body of 8 rows: notice-free header + 7 list rows visible
 	for i := 0; i < 30; i++ {
 		m.relays = append(m.relays, connectcore.DirectoryRelay{
 			Relay: brokerapi.RelayDescriptor{ID: fmt.Sprintf("relay_%02d", i), Label: fmt.Sprintf("node-%02d", i)},
 		})
 	}
 
-	m.relayCursor = len(m.relays) - 1
+	// The last relay sits at cursor len(relays): index 0 is the Auto row.
+	m.relayCursor = len(m.relays)
 	view := m.View()
 	if !strings.Contains(view, "node-29") {
 		t.Fatalf("last relay not visible with the cursor on it:\n%s", view)
 	}
-	if strings.Contains(view, "node-00") {
+	if strings.Contains(view, "node-00") || strings.Contains(view, m.tr().autoSelect) {
 		t.Fatalf("head of the list still rendered while the cursor sits at the tail:\n%s", view)
 	}
 
 	m.relayCursor = 0
 	view = m.View()
-	if !strings.Contains(view, "node-00") || strings.Contains(view, "node-29") {
+	if !strings.Contains(view, m.tr().autoSelect) || !strings.Contains(view, "node-00") || strings.Contains(view, "node-29") {
 		t.Fatalf("window did not follow the cursor back to the head:\n%s", view)
 	}
 }

--- a/cmd/client/tui_test.go
+++ b/cmd/client/tui_test.go
@@ -201,14 +201,15 @@ func TestConnectedStateStampsSessionStartAndRendersStatus(t *testing.T) {
 	// bar shows only a scrolling window into it. The duration is the one field
 	// pinned to the rendered bar, checked separately below.
 	view := m.statusDetail()
-	for _, want := range []string{"connected", "direct", "KR", "127.0.0.1:43210"} {
+	for _, want := range []string{"direct", "127.0.0.1:43210"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("status detail missing %q:\n%s", want, view)
 		}
 	}
-	// The relay name and the duration are the pin's, not the detail's.
+	// The relay, its country, and the duration are the pin's, not the detail's;
+	// the connection state itself is the bar's color.
 	pin := m.statusPin(0)
-	for _, want := range []string{label, "00:01:30"} {
+	for _, want := range []string{label, "KR", "00:01:30"} {
 		if !strings.Contains(pin, want) {
 			t.Fatalf("status pin missing %q:\n%q", want, pin)
 		}

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -413,10 +413,9 @@ func (m tuiModel) statusDetail() string {
 		}
 	}
 
-	parts = append(parts,
-		field(tr.labelBroker, displayBroker(tr, m.settings.brokerURL)),
-		field(tr.labelTarget, describeTarget(tr, m.settings.target)),
-	)
+	// No Target field: the TUI stores no target — the connected relay is the
+	// pin's to name, and what enter would connect to is the highlighted row.
+	parts = append(parts, field(tr.labelBroker, displayBroker(tr, m.settings.brokerURL)))
 	if m.state.LastError != nil {
 		parts = append(parts, field(tr.labelError, *m.state.LastError))
 	}
@@ -549,23 +548,6 @@ func noticeLine(tr *translation, n connectcore.Notice) string {
 	return n.Reason
 }
 
-func describeTarget(tr *translation, target connectcore.RelayTarget) string {
-	parts := make([]string, 0, 3)
-	if strings.TrimSpace(target.RelayID) != "" {
-		parts = append(parts, fmt.Sprintf(tr.targetRelay, target.RelayID))
-	}
-	if strings.TrimSpace(target.Label) != "" {
-		parts = append(parts, fmt.Sprintf(tr.targetLabel, target.Label))
-	}
-	if strings.TrimSpace(target.Country) != "" {
-		parts = append(parts, fmt.Sprintf(tr.targetCountry, strings.ToUpper(strings.TrimSpace(target.Country))))
-	}
-	if len(parts) == 0 {
-		return tr.targetAutomatic
-	}
-	return strings.Join(parts, ", ")
-}
-
 func formatDuration(d time.Duration) string {
 	if d < 0 {
 		d = 0
@@ -623,13 +605,7 @@ func (m tuiModel) relaysView() string {
 			cursor = cursorStyle.Render("▸ ")
 		}
 		if i == 0 {
-			line := cursor + " " + tr.autoSelect
-			// The marker follows the pin, and no pin means Auto select is what
-			// the next connect does.
-			if !m.settings.target.Targeted() {
-				line += " " + noteStyle.Render(tr.targetMarker)
-			}
-			rows = append(rows, line)
+			rows = append(rows, cursor+" "+tr.autoSelect)
 			continue
 		}
 		entry := m.relays[i-1]
@@ -647,12 +623,8 @@ func (m tuiModel) relaysView() string {
 		if m.state.Status == connectcore.StatusConnected && m.infoOK && entry.Relay.ID == m.info.Relay.ID {
 			name, geo, latency = connectedRowStyle.Render(name), connectedRowStyle.Render(geo), connectedRowStyle.Render(latency)
 		}
-		line := cursor + " " + name + " " + geo + " " + latency +
-			" " + nodeClassBadge(tr, entry.Relay.NodeClass)
-		if entry.Relay.ID == m.settings.target.RelayID && m.settings.target.RelayID != "" {
-			line += " " + noteStyle.Render(tr.targetMarker)
-		}
-		rows = append(rows, line)
+		rows = append(rows, cursor+" "+name+" "+geo+" "+latency+
+			" "+nodeClassBadge(tr, entry.Relay.NodeClass))
 	}
 	return strings.Join(rows, "\n")
 }

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -243,8 +243,6 @@ func (m tuiModel) footerView() string {
 	case viewSettings:
 		if m.settings.editing {
 			help = tr.helpSettingsEdit
-		} else {
-			help = tr.helpSettings + help
 		}
 	}
 
@@ -307,7 +305,15 @@ func (m tuiModel) footerHelpWindow(help string, width int) string {
 		offset = step - footerMarqueePause
 	}
 	track := help + footerMarqueeGap + help
-	return ansi.Cut(track, offset, offset+width)
+	// ansi.Cut counts cells but cannot split one: a window boundary landing on
+	// a double-width rune (the CJK in languageKeyHelp is the only such text
+	// here, so this happens exactly while the language control is on screen)
+	// yields a window one cell wider or narrower than asked. Clamp both ways —
+	// over-width would push the bar past the terminal, where bubbletea's
+	// renderer silently truncates it and the theme's background stops a cell
+	// short of the edge; under-width would jitter the gap to the summary as
+	// the text scrolls.
+	return padCell(ansi.Truncate(ansi.Cut(track, offset, offset+width), width, ""), width)
 }
 
 // footerConnectionSummary is the bottom-right corner while connected: the

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -322,11 +322,15 @@ func (m tuiModel) statusPin(budget int) string {
 	label := ""
 	if m.infoOK {
 		label = strings.TrimSpace(relayListName(m.info.Relay))
-		if flag := countryFlag(m.info.Relay.CountryCode); flag != "" {
+		// Code AND flag, never the flag alone: countryFlag renders nothing on
+		// Windows, and with the Country field gone from the detail this is the
+		// only place a country appears at all.
+		if cc := strings.TrimSpace(m.info.Relay.CountryCode); cc != "" {
+			geo := strings.ToUpper(cc) + countryFlag(cc)
 			if label != "" {
 				label += " "
 			}
-			label += flag
+			label += geo
 		}
 	} else if m.state.RelayLabel != nil {
 		label = strings.TrimSpace(*m.state.RelayLabel)
@@ -364,25 +368,20 @@ func (m tuiModel) statusDetail() string {
 	tr := m.tr()
 	status := m.state.Status
 	field := func(label, value string) string { return label + " " + value }
-	parts := []string{field(tr.labelStatus, tr.statusName(status))}
 
-	// No relay name here: it is pinned to the bar's right edge (statusPin), and
-	// repeating it in a track that scrolls past the pin reads as two relays. The
-	// class badge is not duplicated, so it stays — bracketed, it labels itself.
-	// The country comes from the descriptor or not at all, never from the state
-	// label's era, so a failover cannot pair a fresh relay with a stale country.
-	country := "—"
+	// Nothing here that the bar already says another way: the state is the bar's
+	// own color, and the relay name and its country are pinned to the right edge
+	// (statusPin). Repeating either in a track that scrolls past the pin reads as
+	// a second, different relay. The class badge is not duplicated anywhere, so
+	// it stays — bracketed, it labels itself.
+	parts := make([]string, 0, 10)
 	if m.infoOK {
 		if brokerapi.EffectiveNodeClass(m.info.Relay.NodeClass) == brokerapi.NodeClassFoundation {
 			parts = append(parts, tr.badgeFoundation)
 		} else {
 			parts = append(parts, tr.badgeVolunteer)
 		}
-		if cc := strings.TrimSpace(m.info.Relay.CountryCode); cc != "" {
-			country = strings.ToUpper(cc) + countryFlag(cc)
-		}
 	}
-	parts = append(parts, field(tr.labelCountry, country))
 
 	transport := "—"
 	if m.infoOK {

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -180,7 +180,7 @@ func (m tuiModel) headerView() string {
 		}
 		tabs = append(tabs, style.Render(name))
 	}
-	// The language switch lives on the . key and is advertised in the footer
+	// The language switch lives on the 0 key and is advertised in the footer
 	// (languageKeyHelp), not here — the tab bar holds only views.
 
 	// headerHeight budgets exactly one line, so a narrow terminal sheds whole
@@ -238,8 +238,6 @@ func (m tuiModel) footerView() string {
 	switch m.view {
 	case viewRelays:
 		help = tr.helpRelays + help
-	case viewLogs:
-		help = tr.helpLogs + help
 	case viewSettings:
 		if m.settings.editing {
 			help = tr.helpSettingsEdit

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -76,7 +76,12 @@ func (m tuiModel) View() string {
 	case viewSettings:
 		body = m.settingsView()
 	}
-	body = m.overlayBrandMark(fitLines(body, m.bodyHeight()))
+	body = fitLines(body, m.bodyHeight())
+	// The Logs view keeps every display cell for diagnostics. In the other
+	// views the bottom-right cells hold low-priority or empty presentation.
+	if m.view != viewLogs {
+		body = m.overlayBrandMark(body)
+	}
 	frame := m.headerView() + "\n\n" + body + "\n\n" + m.footerView()
 	// Ascii means no color at all (a dumb terminal, NO_COLOR, or a test),
 	// where the theme's escape sequences would render as garbage.
@@ -87,7 +92,8 @@ func (m tuiModel) View() string {
 }
 
 // openrungArt is the corner brand mark, drawn at the bottom right of every
-// view just above the status bar. Every row is the same display width.
+// non-Logs view just above the status bar. Every row has the same display
+// width.
 var openrungArt = []string{
 	"  ___  ___  ___ _  _ ___  _   _ _  _  ___ ",
 	" / _ \\| _ \\| __| \\| | _ \\| | | | \\| |/ __|",
@@ -98,13 +104,13 @@ var openrungArt = []string{
 // brandMargin keeps the mark off the terminal's right edge.
 const brandMargin = 1
 
-// overlayBrandMark draws openrungArt over the body's bottom-right corner —
-// the same corner on every view. The mark wins over whatever the corner held:
-// a per-line collision check would tear the mark apart (logs) or blink it in
-// and out as lists grow (relays), and the corner rows are the least
-// load-bearing cells on screen. It renders whole or not at all — only when
-// the terminal is wide enough for the mark plus a gap to content, and tall
-// enough that a couple of content rows stay clear above it.
+// overlayBrandMark draws openrungArt over the body's bottom-right corner. The
+// caller deliberately excludes Logs, whose newest diagnostic lines occupy
+// this corner. Elsewhere the mark wins over whatever the corner held: a
+// per-line collision check would tear it apart or blink it in and out as
+// lists grow. It renders whole or not at all — only when the terminal is wide
+// enough for the mark plus a gap to content, and tall enough that a couple of
+// content rows stay clear above it.
 func (m tuiModel) overlayBrandMark(body string) string {
 	artW := lipgloss.Width(openrungArt[0])
 	if m.width < artW+2+2*brandMargin || m.bodyHeight() < len(openrungArt)+2 {
@@ -215,6 +221,17 @@ func (m tuiModel) headerView() string {
 	return strings.Join(parts, " ")
 }
 
+const (
+	// When help and the connected-session summary cannot both fit, give help a
+	// stable marquee lane. Thirty-two cells show the complete trilingual
+	// language token with useful neighboring context at ordinary widths.
+	footerHelpMarqueeWidth = 32
+	footerSummaryMinWidth  = len("00:00:00")
+	footerMarqueeGap       = "   "
+	footerMarqueeStep      = tuiTickInterval
+	footerMarqueePause     = 5 // one second at the beginning of each cycle
+)
+
 func (m tuiModel) footerView() string {
 	tr := m.tr()
 	help := tr.helpGlobal
@@ -237,14 +254,24 @@ func (m tuiModel) footerView() string {
 	}
 	// The bar is padded to the exact terminal width so the background paints
 	// edge to edge, with the connection summary right-aligned in the corner.
-	// The help always yields to the width — a wrapped footer breaks the
-	// fixed-height layout — and to the summary, since that corner glance is
-	// what the bar is for.
+	// When both sides do not fit, the summary keeps at least its duration while
+	// help gets a horizontally scrolling lane. That keeps every shortcut — in
+	// particular the language escape hatch — discoverable without wrapping the
+	// fixed-height footer.
 	summaryBudget := 0 // ≤0 = unlimited
 	if m.width > 0 {
 		summaryBudget = m.width - 2 // the bar's leading and trailing space
 	}
 	right := m.footerConnectionSummary(summaryBudget)
+	if right != "" && m.width > 0 {
+		// With a summary, the line spends three cells on leading space, the
+		// inter-column gap, and trailing space.
+		contentBudget := max(0, m.width-3)
+		if lipgloss.Width(help)+lipgloss.Width(right) > contentBudget {
+			helpLane := min(footerHelpMarqueeWidth, max(0, contentBudget-footerSummaryMinWidth))
+			right = m.footerConnectionSummary(max(0, contentBudget-helpLane))
+		}
+	}
 	if right != "" {
 		right += " "
 	}
@@ -254,12 +281,33 @@ func (m tuiModel) footerView() string {
 			budget-- // one-cell gap between help and summary
 		}
 		if lipgloss.Width(help) > budget {
-			help = truncateWidth(help, max(0, budget))
+			help = m.footerHelpWindow(help, max(0, budget))
 		}
 	}
 	left := " " + help
 	pad := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	return style.Render(left + strings.Repeat(" ", max(0, pad)) + right)
+}
+
+// footerHelpWindow returns one display-cell-aware window into overflowing
+// help. It starts with a short hold, advances one cell per TUI tick, and loops
+// through a small gap. The duplicated track makes the wrap seamless.
+func (m tuiModel) footerHelpWindow(help string, width int) string {
+	if width < 1 || lipgloss.Width(help) <= width {
+		return truncateWidth(help, width)
+	}
+	trackWidth := lipgloss.Width(help) + lipgloss.Width(footerMarqueeGap)
+	steps := footerMarqueePause + trackWidth
+	step := 0
+	if !m.startedAt.IsZero() && !m.now.Before(m.startedAt) {
+		step = int(m.now.Sub(m.startedAt) / footerMarqueeStep % time.Duration(steps))
+	}
+	offset := 0
+	if step >= footerMarqueePause {
+		offset = step - footerMarqueePause
+	}
+	track := help + footerMarqueeGap + help
+	return ansi.Cut(track, offset, offset+width)
 }
 
 // footerConnectionSummary is the bottom-right corner while connected: the

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 
 	"github.com/openrung/openrung/brokerapi"
 	"github.com/openrung/openrung/connectcore"
@@ -23,6 +25,7 @@ var (
 	errorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	noteStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	cursorStyle    = lipgloss.NewStyle().Bold(true)
+	brandStyle     = lipgloss.NewStyle().Bold(true)
 
 	foundationBadgeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 	volunteerBadgeStyle  = lipgloss.NewStyle().Faint(true)
@@ -73,8 +76,75 @@ func (m tuiModel) View() string {
 	case viewSettings:
 		body = m.settingsView()
 	}
-	body = fitLines(body, m.bodyHeight())
-	return m.headerView() + "\n\n" + body + "\n\n" + m.footerView()
+	body = m.overlayBrandMark(fitLines(body, m.bodyHeight()))
+	frame := m.headerView() + "\n\n" + body + "\n\n" + m.footerView()
+	// Ascii means no color at all (a dumb terminal, NO_COLOR, or a test),
+	// where the theme's escape sequences would render as garbage.
+	if lipgloss.ColorProfile() != termenv.Ascii {
+		frame = paintFrame(frame, m.width)
+	}
+	return frame
+}
+
+// openrungArt is the corner brand mark, drawn at the bottom right of every
+// view just above the status bar. Every row is the same display width.
+var openrungArt = []string{
+	"  ___  ___  ___ _  _ ___  _   _ _  _  ___ ",
+	" / _ \\| _ \\| __| \\| | _ \\| | | | \\| |/ __|",
+	"| (_) |  _/| _|| .` |   /| |_| | .` | (_ |",
+	" \\___/|_|  |___|_|\\_|_|_\\ \\___/|_|\\_|\\___|",
+}
+
+// brandMargin keeps the mark off the terminal's right edge.
+const brandMargin = 1
+
+// overlayBrandMark draws openrungArt over the body's bottom-right corner —
+// the same corner on every view. The mark wins over whatever the corner held:
+// a per-line collision check would tear the mark apart (logs) or blink it in
+// and out as lists grow (relays), and the corner rows are the least
+// load-bearing cells on screen. It renders whole or not at all — only when
+// the terminal is wide enough for the mark plus a gap to content, and tall
+// enough that a couple of content rows stay clear above it.
+func (m tuiModel) overlayBrandMark(body string) string {
+	artW := lipgloss.Width(openrungArt[0])
+	if m.width < artW+2+2*brandMargin || m.bodyHeight() < len(openrungArt)+2 {
+		return body
+	}
+	lines := strings.Split(body, "\n")
+	start := len(lines) - len(openrungArt)
+	col := m.width - artW - brandMargin
+	for i, artLine := range openrungArt {
+		// ANSI-aware cut: body lines carry styled segments whose escape
+		// sequences a byte or rune slice would sever mid-sequence.
+		line := ansi.Truncate(lines[start+i], col-1, "")
+		pad := col - lipgloss.Width(line)
+		lines[start+i] = line + strings.Repeat(" ", max(0, pad)) + brandStyle.Render(artLine)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// The old-terminal theme: green text on a black background.
+const (
+	themeSeq = "\x1b[32;40m" // green foreground, black background
+	resetSeq = "\x1b[0m"
+)
+
+// paintFrame lays the theme base under the composed frame. Padding every line
+// to the full terminal width carries the black background to the right edge,
+// and every reset an inner style emits is immediately re-opened with the base
+// sequence, so text after a styled segment falls back to green-on-black
+// instead of the terminal's own defaults. Styles that pick their colors — the
+// status bar, errors, notes, badges — are untouched: only default-colored
+// text turns green.
+func paintFrame(frame string, width int) string {
+	lines := strings.Split(frame, "\n")
+	for i, line := range lines {
+		if pad := width - lipgloss.Width(line); pad > 0 {
+			line += strings.Repeat(" ", pad)
+		}
+		lines[i] = themeSeq + strings.ReplaceAll(line, resetSeq, resetSeq+themeSeq) + resetSeq
+	}
+	return strings.Join(lines, "\n")
 }
 
 // fitLines pads or truncates body to exactly n lines so header and footer stay

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -307,7 +307,12 @@ func (m tuiModel) statusFooterView() string {
 // the label gives way first — the corner should still answer "how long" on a
 // terminal too narrow for "to what".
 func (m tuiModel) statusPin(budget int) string {
-	if m.state.Status != connectcore.StatusConnected {
+	// The relay name is ONLY here, never in the scrolling detail, so the pin has
+	// to hold it through the transitions too — otherwise "connecting" would name
+	// no destination. Disconnected and failed assert no relay at all, so a stale
+	// label must not linger there.
+	switch m.state.Status {
+	case connectcore.StatusDisconnected, connectcore.StatusFailed:
 		return ""
 	}
 	// Single-sourced for the same reason as statusDetail: with a descriptor the
@@ -327,7 +332,7 @@ func (m tuiModel) statusPin(budget int) string {
 		label = strings.TrimSpace(*m.state.RelayLabel)
 	}
 	duration := ""
-	if !m.connectedAt.IsZero() {
+	if m.state.Status == connectcore.StatusConnected && !m.connectedAt.IsZero() {
 		duration = formatDuration(m.now.Sub(m.connectedAt))
 	}
 
@@ -361,26 +366,23 @@ func (m tuiModel) statusDetail() string {
 	field := func(label, value string) string { return label + " " + value }
 	parts := []string{field(tr.labelStatus, tr.statusName(status))}
 
-	// Relay identity comes from ONE source. With a descriptor that is the
-	// descriptor — name AND flag — because a failover updates the state label
-	// before the next info poll lands, and mixing the two would pair a fresh
-	// label with the old relay's country, asserting the wrong exit. Without a
-	// descriptor there is no flag, only the state label.
-	relay, country := "—", "—"
+	// No relay name here: it is pinned to the bar's right edge (statusPin), and
+	// repeating it in a track that scrolls past the pin reads as two relays. The
+	// class badge is not duplicated, so it stays — bracketed, it labels itself.
+	// The country comes from the descriptor or not at all, never from the state
+	// label's era, so a failover cannot pair a fresh relay with a stale country.
+	country := "—"
 	if m.infoOK {
-		relay = relayListName(m.info.Relay)
 		if brokerapi.EffectiveNodeClass(m.info.Relay.NodeClass) == brokerapi.NodeClassFoundation {
-			relay += " " + tr.badgeFoundation
+			parts = append(parts, tr.badgeFoundation)
 		} else {
-			relay += " " + tr.badgeVolunteer
+			parts = append(parts, tr.badgeVolunteer)
 		}
 		if cc := strings.TrimSpace(m.info.Relay.CountryCode); cc != "" {
 			country = strings.ToUpper(cc) + countryFlag(cc)
 		}
-	} else if m.state.RelayLabel != nil {
-		relay = strings.TrimSpace(*m.state.RelayLabel)
 	}
-	parts = append(parts, field(tr.labelRelay, relay), field(tr.labelCountry, country))
+	parts = append(parts, field(tr.labelCountry, country))
 
 	transport := "—"
 	if m.infoOK {

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -30,18 +30,11 @@ var (
 	foundationBadgeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 	volunteerBadgeStyle  = lipgloss.NewStyle().Faint(true)
 
-	statusStyles = map[connectcore.Status]lipgloss.Style{
-		connectcore.StatusDisconnected:  lipgloss.NewStyle().Faint(true),
-		connectcore.StatusPreparing:     lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
-		connectcore.StatusConnecting:    lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
-		connectcore.StatusConnected:     lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true),
-		connectcore.StatusDisconnecting: lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
-		connectcore.StatusFailed:        lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true),
-	}
-
-	// The footer is a solid tmux-style status bar spanning the full terminal
-	// width — the always-visible connection signal: red while disconnected or
-	// failed, yellow through every transition, green while connected.
+	// statusFooter is a solid tmux-style bar spanning the full terminal width —
+	// the always-visible connection signal, on every view now that Status is
+	// not one: red while disconnected or failed, yellow through every
+	// transition, green while connected. The key-help line below it stays
+	// unstyled so this bar is the only thing on screen changing color.
 	footerStyles = map[connectcore.Status]lipgloss.Style{
 		connectcore.StatusDisconnected:  lipgloss.NewStyle().Foreground(lipgloss.Color("0")).Background(lipgloss.Color("1")),
 		connectcore.StatusFailed:        lipgloss.NewStyle().Foreground(lipgloss.Color("0")).Background(lipgloss.Color("1")),
@@ -54,7 +47,7 @@ var (
 
 const (
 	headerHeight = 2 // tab bar + separator blank line
-	footerHeight = 2 // separator blank line + key help
+	footerHeight = 3 // separator blank line + status bar + key help
 )
 
 func (m tuiModel) bodyHeight() int {
@@ -67,8 +60,6 @@ func (m tuiModel) View() string {
 	}
 	var body string
 	switch m.view {
-	case viewStatus:
-		body = m.statusView()
 	case viewRelays:
 		body = m.relaysView()
 	case viewLogs:
@@ -82,7 +73,7 @@ func (m tuiModel) View() string {
 	if m.view != viewLogs {
 		body = m.overlayBrandMark(body)
 	}
-	frame := m.headerView() + "\n\n" + body + "\n\n" + m.footerView()
+	frame := m.headerView() + "\n\n" + body + "\n\n" + m.statusFooterView() + "\n" + m.footerView()
 	// Ascii means no color at all (a dumb terminal, NO_COLOR, or a test),
 	// where the theme's escape sequences would render as garbage.
 	if lipgloss.ColorProfile() != termenv.Ascii {
@@ -222,14 +213,9 @@ func (m tuiModel) headerView() string {
 }
 
 const (
-	// When help and the connected-session summary cannot both fit, give help a
-	// stable marquee lane. Thirty-two cells show the complete trilingual
-	// language token with useful neighboring context at ordinary widths.
-	footerHelpMarqueeWidth = 32
-	footerSummaryMinWidth  = len("00:00:00")
-	footerMarqueeGap       = "   "
-	footerMarqueeStep      = tuiTickInterval
-	footerMarqueePause     = 5 // one second at the beginning of each cycle
+	footerMarqueeGap   = "   "
+	footerMarqueeStep  = tuiTickInterval
+	footerMarqueePause = 5 // one second at the beginning of each cycle
 )
 
 func (m tuiModel) footerView() string {
@@ -244,29 +230,34 @@ func (m tuiModel) footerView() string {
 		}
 	}
 
+	// No connection styling here: the signal lives one line up, on the status
+	// bar, so this line stays the theme's own green-on-black and paintFrame
+	// carries the background to the right edge.
+	if m.width > 0 {
+		if budget := m.width - 1; lipgloss.Width(help) > budget { // leading space
+			help = m.footerMarqueeWindow(help, max(0, budget))
+		}
+	}
+	return " " + help
+}
+
+// statusFooterView is the permanent connection bar between the body and the
+// key help — every row the old Status view carried, on one line, so the state
+// is readable from whichever view the user is on. It keeps the old footer's
+// coloring: red while disconnected or failed, yellow through transitions,
+// green while connected. The detail scrolls when it overflows, but the session
+// duration stays pinned right, because "how long" is the one field a glance at
+// the corner should always answer.
+func (m tuiModel) statusFooterView() string {
 	style, ok := footerStyles[m.state.Status]
 	if !ok {
 		style = helpStyle
 	}
-	// The bar is padded to the exact terminal width so the background paints
-	// edge to edge, with the connection summary right-aligned in the corner.
-	// When both sides do not fit, the summary keeps at least its duration while
-	// help gets a horizontally scrolling lane. That keeps every shortcut — in
-	// particular the language escape hatch — discoverable without wrapping the
-	// fixed-height footer.
-	summaryBudget := 0 // ≤0 = unlimited
-	if m.width > 0 {
-		summaryBudget = m.width - 2 // the bar's leading and trailing space
-	}
-	right := m.footerConnectionSummary(summaryBudget)
-	if right != "" && m.width > 0 {
-		// With a summary, the line spends three cells on leading space, the
-		// inter-column gap, and trailing space.
-		contentBudget := max(0, m.width-3)
-		if lipgloss.Width(help)+lipgloss.Width(right) > contentBudget {
-			helpLane := min(footerHelpMarqueeWidth, max(0, contentBudget-footerSummaryMinWidth))
-			right = m.footerConnectionSummary(max(0, contentBudget-helpLane))
-		}
+	detail := m.statusDetail()
+
+	right := ""
+	if m.state.Status == connectcore.StatusConnected && !m.connectedAt.IsZero() {
+		right = formatDuration(m.now.Sub(m.connectedAt))
 	}
 	if right != "" {
 		right += " "
@@ -274,21 +265,93 @@ func (m tuiModel) footerView() string {
 	if m.width > 0 {
 		budget := m.width - lipgloss.Width(right) - 1 // leading space
 		if right != "" {
-			budget-- // one-cell gap between help and summary
+			budget-- // one-cell gap between detail and duration
 		}
-		if lipgloss.Width(help) > budget {
-			help = m.footerHelpWindow(help, max(0, budget))
+		if lipgloss.Width(detail) > budget {
+			detail = m.footerMarqueeWindow(detail, max(0, budget))
 		}
 	}
-	left := " " + help
+	left := " " + detail
 	pad := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	return style.Render(left + strings.Repeat(" ", max(0, pad)) + right)
 }
 
-// footerHelpWindow returns one display-cell-aware window into overflowing
-// help. It starts with a short hold, advances one cell per TUI tick, and loops
-// through a small gap. The duplicated track makes the wrap seamless.
-func (m tuiModel) footerHelpWindow(help string, width int) string {
+// statusDetail is every Status field on one line. Deliberately unstyled: the
+// bar already carries a background, and an inner foreground (a red error, a
+// cyan badge) on top of it reads as a defect rather than an accent.
+func (m tuiModel) statusDetail() string {
+	tr := m.tr()
+	status := m.state.Status
+	field := func(label, value string) string { return label + " " + value }
+	parts := []string{field(tr.labelStatus, tr.statusName(status))}
+
+	// Relay identity comes from ONE source. With a descriptor that is the
+	// descriptor — name AND flag — because a failover updates the state label
+	// before the next info poll lands, and mixing the two would pair a fresh
+	// label with the old relay's country, asserting the wrong exit. Without a
+	// descriptor there is no flag, only the state label.
+	relay, country := "—", "—"
+	if m.infoOK {
+		relay = relayListName(m.info.Relay)
+		if brokerapi.EffectiveNodeClass(m.info.Relay.NodeClass) == brokerapi.NodeClassFoundation {
+			relay += " " + tr.badgeFoundation
+		} else {
+			relay += " " + tr.badgeVolunteer
+		}
+		if cc := strings.TrimSpace(m.info.Relay.CountryCode); cc != "" {
+			country = strings.ToUpper(cc) + countryFlag(cc)
+		}
+	} else if m.state.RelayLabel != nil {
+		relay = strings.TrimSpace(*m.state.RelayLabel)
+	}
+	parts = append(parts, field(tr.labelRelay, relay), field(tr.labelCountry, country))
+
+	transport := "—"
+	if m.infoOK {
+		transport = transportLabel(tr, m.info)
+	}
+	parts = append(parts, field(tr.labelTransport, transport))
+
+	if status == connectcore.StatusConnected {
+		parts = append(parts, field(tr.labelHealth, healthText(tr, m.health)))
+	}
+	if m.activity.Kind != "" {
+		parts = append(parts, field(tr.labelActivity,
+			"["+m.activityAt.Format("15:04:05")+"] "+noticeLine(tr, m.activity)))
+	}
+
+	if m.settings.mode == connectcore.ModeTUN {
+		// No local endpoint exists in TUN mode; the tunnel device carries every
+		// application, so there is nothing for the user to configure.
+		parts = append(parts, field(tr.labelCapture, tr.captureTUN))
+	} else {
+		proxy := m.proxyEndpoint
+		switch {
+		case m.proxyErr != "":
+			proxy = m.proxyErr
+		case proxy == "":
+			proxy = tr.proxyResolving
+		}
+		parts = append(parts, field(tr.labelCapture, tr.captureProxy), field(tr.labelProxy, proxy))
+		if m.proxyWarn != "" {
+			parts = append(parts, m.proxyWarn)
+		}
+	}
+
+	parts = append(parts,
+		field(tr.labelBroker, displayBroker(tr, m.settings.brokerURL)),
+		field(tr.labelTarget, describeTarget(tr, m.settings.target)),
+	)
+	if m.state.LastError != nil {
+		parts = append(parts, field(tr.labelError, *m.state.LastError))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// footerMarqueeWindow returns one display-cell-aware window into overflowing
+// bar text. It starts with a short hold, advances one cell per TUI tick, and
+// loops through a small gap. The duplicated track makes the wrap seamless.
+func (m tuiModel) footerMarqueeWindow(help string, width int) string {
 	if width < 1 || lipgloss.Width(help) <= width {
 		return truncateWidth(help, width)
 	}
@@ -312,59 +375,6 @@ func (m tuiModel) footerHelpWindow(help string, width int) string {
 	// short of the edge; under-width would jitter the gap to the summary as
 	// the text scrolls.
 	return padCell(ansi.Truncate(ansi.Cut(track, offset, offset+width), width, ""), width)
-}
-
-// footerConnectionSummary is the bottom-right corner while connected: the
-// relay label, its country flag, and the running session duration, fitted to
-// budget cells (≤0 = unlimited). The duration anchors the right edge, so when
-// space runs out the label gives way first — a glance at the corner should
-// always answer "how long", even on a terminal too narrow for "to what".
-func (m tuiModel) footerConnectionSummary(budget int) string {
-	if m.state.Status != connectcore.StatusConnected {
-		return ""
-	}
-	// Every identity field comes from ONE source. With a descriptor, that is
-	// the descriptor — name (down to its "relay <id>" fallback) AND flag: on
-	// a failover the state label updates before the next info poll lands, and
-	// mixing the two would pair a fresh label with the old relay's flag,
-	// asserting the wrong exit country. Without a descriptor there is no
-	// flag, only the state label.
-	label := ""
-	if m.infoOK {
-		label = strings.TrimSpace(relayListName(m.info.Relay))
-		if flag := countryFlag(m.info.Relay.CountryCode); flag != "" {
-			if label != "" {
-				label += " "
-			}
-			label += flag
-		}
-	} else if m.state.RelayLabel != nil {
-		label = strings.TrimSpace(*m.state.RelayLabel)
-	}
-	duration := ""
-	if !m.connectedAt.IsZero() {
-		duration = formatDuration(m.now.Sub(m.connectedAt))
-	}
-
-	parts := make([]string, 0, 2)
-	if label != "" {
-		parts = append(parts, label)
-	}
-	if duration != "" {
-		parts = append(parts, duration)
-	}
-	summary := strings.Join(parts, " ")
-	if budget <= 0 || lipgloss.Width(summary) <= budget {
-		return summary
-	}
-	if duration == "" {
-		return truncateWidth(label, budget)
-	}
-	label = truncateWidth(label, max(0, budget-lipgloss.Width(duration)-1))
-	if label == "" {
-		return truncateWidth(duration, budget)
-	}
-	return label + " " + duration
 }
 
 // countryFlag maps a 2-letter ISO country code to its regional-indicator
@@ -393,80 +403,6 @@ func countryFlagFor(goos, cc string) string {
 		return ""
 	}
 	return string(0x1F1E6+rune(cc[0])-'A') + string(0x1F1E6+rune(cc[1])-'A')
-}
-
-// ---- Status ----
-
-func (m tuiModel) statusView() string {
-	tr := m.tr()
-	status := m.state.Status
-	rows := []string{
-		row(tr.labelStatus, statusStyles[status].Render(tr.statusName(status))),
-	}
-
-	relayLine := "—"
-	if m.state.RelayLabel != nil {
-		relayLine = *m.state.RelayLabel
-	}
-	if m.infoOK {
-		relayLine += "  " + nodeClassBadge(tr, m.info.Relay.NodeClass)
-	}
-	rows = append(rows, row(tr.labelRelay, relayLine))
-
-	country, transport := "—", "—"
-	if m.infoOK {
-		if cc := strings.TrimSpace(m.info.Relay.CountryCode); cc != "" {
-			country = strings.ToUpper(cc) + countryFlag(cc)
-		}
-		transport = transportLabel(tr, m.info)
-	}
-	rows = append(rows, row(tr.labelCountry, country), row(tr.labelTransport, transport))
-
-	session := "—"
-	if status == connectcore.StatusConnected && !m.connectedAt.IsZero() {
-		session = formatDuration(m.now.Sub(m.connectedAt))
-	}
-	rows = append(rows, row(tr.labelSession, session))
-
-	if status == connectcore.StatusConnected {
-		rows = append(rows, row(tr.labelHealth, healthLabel(tr, m.health)))
-	}
-	if m.activity.Kind != "" {
-		stamp := m.activityAt.Format("15:04:05")
-		rows = append(rows, row(tr.labelActivity, noteStyle.Render("["+stamp+"] "+noticeLine(tr, m.activity))))
-	}
-
-	if m.settings.mode == connectcore.ModeTUN {
-		// No local endpoint exists in TUN mode; the tunnel device carries every
-		// application, so there is nothing for the user to configure.
-		rows = append(rows, row(tr.labelCapture, tr.captureTUN))
-	} else {
-		proxy := m.proxyEndpoint
-		switch {
-		case m.proxyErr != "":
-			proxy = errorStyle.Render(m.proxyErr)
-		case proxy == "":
-			proxy = tr.proxyResolving
-		}
-		rows = append(rows, row(tr.labelCapture, tr.captureProxy), row(tr.labelProxy, proxy))
-		if m.proxyWarn != "" {
-			rows = append(rows, row("", noteStyle.Render(m.proxyWarn)))
-		}
-	}
-
-	rows = append(rows,
-		row(tr.labelBroker, displayBroker(tr, m.settings.brokerURL)),
-		row(tr.labelTarget, describeTarget(tr, m.settings.target)),
-	)
-
-	if m.state.LastError != nil {
-		rows = append(rows, "", row(tr.labelError, errorStyle.Render(*m.state.LastError)))
-	}
-	return strings.Join(rows, "\n")
-}
-
-func row(label, value string) string {
-	return labelStyle.Render(label) + " " + value
 }
 
 func displayBroker(tr *translation, brokerURL string) string {
@@ -498,12 +434,13 @@ func nodeClassBadge(tr *translation, nodeClass string) string {
 	return volunteerBadgeStyle.Render(tr.badgeVolunteer)
 }
 
-// healthLabel renders the latest mid-session probe sweep. The engine only
+// healthText renders the latest mid-session probe sweep. The engine only
 // probes while a candidate is promoted, so before the first sweep of a session
-// there is nothing to report yet.
-func healthLabel(tr *translation, health connectcore.Notice) string {
+// there is nothing to report yet. Unstyled: it lands on the status bar, which
+// carries its own background.
+func healthText(tr *translation, health connectcore.Notice) string {
 	if health.Kind == "" {
-		return helpStyle.Render(tr.healthProbing)
+		return tr.healthProbing
 	}
 	if health.Failures == 0 {
 		return tr.healthOK
@@ -512,7 +449,7 @@ func healthLabel(tr *translation, health connectcore.Notice) string {
 	if health.Reason != "" {
 		label += " — " + health.Reason
 	}
-	return errorStyle.Render(label)
+	return label
 }
 
 // noticeLine formats a typed engine notice for the Activity row. The reasons

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -518,12 +518,6 @@ func formatDuration(d time.Duration) string {
 func (m tuiModel) relaysView() string {
 	tr := m.tr()
 	var rows []string
-	// The engine-persisted recents (internal/clientstate), newest first — the
-	// same row the desktop main screen shows.
-	if line := recentsLine(m.state.Recents); line != "" {
-		prefix := helpStyle.Render(tr.recentsLabel)
-		rows = append(rows, prefix+truncateWidth(line, max(1, m.width-lipgloss.Width(prefix))))
-	}
 	switch {
 	case m.refreshing:
 		rows = append(rows, helpStyle.Render(tr.refreshingDirectory))
@@ -577,23 +571,6 @@ func (m tuiModel) relaysView() string {
 		rows = append(rows, line)
 	}
 	return strings.Join(rows, "\n")
-}
-
-// recentsLine renders the recents newest-first on one line, or "" when none
-// are stored.
-func recentsLine(recents []connectcore.RecentNode) string {
-	if len(recents) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, len(recents))
-	for _, r := range recents {
-		label := strings.TrimSpace(r.Label)
-		if label == "" {
-			label = r.CountryCode
-		}
-		parts = append(parts, label)
-	}
-	return strings.Join(parts, " · ")
 }
 
 // relayListName is the list name for a relay: its friendly label alone (the
@@ -666,9 +643,6 @@ func (m tuiModel) settingsView() string {
 	}{
 		{fieldBroker, tr.fieldNames[fieldBroker], displayBroker(tr, m.settings.brokerURL)},
 		{fieldMode, tr.fieldNames[fieldMode], modeLabel(tr, m.settings.mode)},
-		{fieldRelayID, tr.fieldNames[fieldRelayID], orUnset(tr, m.settings.target.RelayID)},
-		{fieldRelayLabel, tr.fieldNames[fieldRelayLabel], orUnset(tr, m.settings.target.Label)},
-		{fieldCountry, tr.fieldNames[fieldCountry], orUnset(tr, m.settings.target.Country)},
 		{fieldShellHelper, tr.fieldNames[fieldShellHelper], m.shellHelperValue()},
 	}
 
@@ -763,11 +737,4 @@ func toggleMode(mode connectcore.Mode) connectcore.Mode {
 		return connectcore.ModeProxy
 	}
 	return connectcore.ModeTUN
-}
-
-func orUnset(tr *translation, value string) string {
-	if strings.TrimSpace(value) == "" {
-		return helpStyle.Render(tr.unset)
-	}
-	return value
 }

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -165,7 +165,7 @@ func fitLines(body string, n int) string {
 
 func (m tuiModel) headerView() string {
 	tr := m.tr()
-	tabs := make([]string, 0, len(tr.tabs)+2)
+	tabs := make([]string, 0, len(tr.tabs)+1)
 	tabs = append(tabs, titleStyle.Render(" OpenRung v"+strings.TrimSpace(baseVersion)+" "))
 	for i, name := range tr.tabs {
 		style := tabStyle
@@ -174,15 +174,13 @@ func (m tuiModel) headerView() string {
 		}
 		tabs = append(tabs, style.Render(name))
 	}
-	// Not a view: 5 cycles the language in place, and the label stays
-	// trilingual so it is readable whatever language is active.
-	tabs = append(tabs, tabStyle.Render(languageTabLabel))
+	// The language switch lives on the l key and is advertised in the footer
+	// (languageKeyHelp), not here — the tab bar holds only views.
 
 	// headerHeight budgets exactly one line, so a narrow terminal sheds whole
 	// tabs (the keys still work). Shedding goes by importance, not position:
-	// the active tab and the language control — the one thing a reader stuck
-	// in the wrong language must still find — outrank the title, which
-	// outranks inactive view tabs. Whatever fits renders in bar order.
+	// the active tab outranks the title, which outranks inactive view tabs.
+	// Whatever fits renders in bar order.
 	type slot struct {
 		order int
 		label string
@@ -190,7 +188,6 @@ func (m tuiModel) headerView() string {
 	priority := make([]slot, 0, len(tabs))
 	priority = append(priority,
 		slot{1 + int(m.view), tabs[1+int(m.view)]},
-		slot{len(tabs) - 1, tabs[len(tabs)-1]},
 		slot{0, tabs[0]},
 	)
 	for i := viewID(0); i < viewCount; i++ {
@@ -740,7 +737,7 @@ func modeLabel(tr *translation, mode connectcore.Mode) string {
 
 // renderNote resolves a stored settings notice through the ACTIVE language:
 // the kind is stored, the words are chosen at draw time, so a note set while
-// the UI spoke Chinese follows a 5-key cycle into Russian.
+// the UI spoke Chinese follows an l-key cycle into Russian.
 func renderNote(tr *translation, n settingsNote) string {
 	switch n.kind {
 	case noteText:

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -70,11 +71,13 @@ func (m tuiModel) View() string {
 	case viewSettings:
 		body = m.settingsView()
 	}
-	body = fitLines(body, m.bodyHeight())
-	// The Logs view keeps every display cell for diagnostics. In the other
-	// views the bottom-right cells hold low-priority or empty presentation.
-	if m.view != viewLogs {
-		body = m.overlayBrandMark(body)
+	// The bottom rows are RESERVED for the brand mark before the body is fit,
+	// so the mark can never cover content — in particular the relay list's
+	// cursor-followed last row, or Settings' copyable commands on a short
+	// terminal. Logs reserves nothing: its newest lines own the corner.
+	body = fitLines(body, m.bodyHeight()-m.brandMarkRows())
+	if m.brandMarkRows() > 0 {
+		body += "\n" + m.brandMarkLines()
 	}
 	frame := m.headerView() + "\n\n" + body + "\n\n" + m.statusFooterView() + "\n" + m.footerView()
 	// Ascii means no color at all (a dumb terminal, NO_COLOR, or a test),
@@ -98,27 +101,29 @@ var openrungArt = []string{
 // brandMargin keeps the mark off the terminal's right edge.
 const brandMargin = 1
 
-// overlayBrandMark draws openrungArt over the body's bottom-right corner. The
-// caller deliberately excludes Logs, whose newest diagnostic lines occupy
-// this corner. Elsewhere the mark wins over whatever the corner held: a
-// per-line collision check would tear it apart or blink it in and out as
-// lists grow. It renders whole or not at all — only when the terminal is wide
-// enough for the mark plus a gap to content, and tall enough that a couple of
-// content rows stay clear above it.
-func (m tuiModel) overlayBrandMark(body string) string {
+// brandMarkRows is how many body lines the corner mark reserves: the mark's
+// height when it renders, 0 when it does not. The mark renders whole or not at
+// all — never in Logs, and only when the terminal is wide enough for the mark
+// plus a gap to content and tall enough that a couple of content rows remain
+// above it. Views size their content against the remaining lines, so the mark
+// occupies blank rows instead of overwriting whatever the corner held.
+func (m tuiModel) brandMarkRows() int {
+	if m.view == viewLogs {
+		return 0
+	}
 	artW := lipgloss.Width(openrungArt[0])
 	if m.width < artW+2+2*brandMargin || m.bodyHeight() < len(openrungArt)+2 {
-		return body
+		return 0
 	}
-	lines := strings.Split(body, "\n")
-	start := len(lines) - len(openrungArt)
-	col := m.width - artW - brandMargin
+	return len(openrungArt)
+}
+
+// brandMarkLines renders the mark right-aligned on its own reserved lines.
+func (m tuiModel) brandMarkLines() string {
+	col := m.width - lipgloss.Width(openrungArt[0]) - brandMargin
+	lines := make([]string, len(openrungArt))
 	for i, artLine := range openrungArt {
-		// ANSI-aware cut: body lines carry styled segments whose escape
-		// sequences a byte or rune slice would sever mid-sequence.
-		line := ansi.Truncate(lines[start+i], col-1, "")
-		pad := col - lipgloss.Width(line)
-		lines[start+i] = line + strings.Repeat(" ", max(0, pad)) + brandStyle.Render(artLine)
+		lines[i] = strings.Repeat(" ", col) + brandStyle.Render(artLine)
 	}
 	return strings.Join(lines, "\n")
 }
@@ -128,6 +133,12 @@ const (
 	themeSeq = "\x1b[32;40m" // green foreground, black background
 	resetSeq = "\x1b[0m"
 )
+
+// sgrResetPattern matches any full SGR reset — \x1b[m, \x1b[0m, \x1b[00m —
+// not only the one literal lipgloss happens to emit today: sing-box's own
+// ANSI reaches the painted Logs frame unsanitized, and a styling-stack
+// upgrade may change the emitted form.
+var sgrResetPattern = regexp.MustCompile("\x1b\\[0*m")
 
 // paintFrame lays the theme base under the composed frame. Padding every line
 // to the full terminal width carries the black background to the right edge,
@@ -142,7 +153,14 @@ func paintFrame(frame string, width int) string {
 		if pad := width - lipgloss.Width(line); pad > 0 {
 			line += strings.Repeat(" ", pad)
 		}
-		lines[i] = themeSeq + strings.ReplaceAll(line, resetSeq, resetSeq+themeSeq) + resetSeq
+		if strings.Contains(line, "\x1b") {
+			// Partial resets would drop a single channel back to the terminal
+			// default mid-line; rewrite them to the theme's own channel.
+			line = strings.ReplaceAll(line, "\x1b[39m", "\x1b[32m")
+			line = strings.ReplaceAll(line, "\x1b[49m", "\x1b[40m")
+			line = sgrResetPattern.ReplaceAllString(line, resetSeq+themeSeq)
+		}
+		lines[i] = themeSeq + line + resetSeq
 	}
 	return strings.Join(lines, "\n")
 }
@@ -270,7 +288,10 @@ func (m tuiModel) statusFooterView() string {
 
 	pinBudget := 0 // ≤0 = unlimited
 	if m.width > 0 {
-		pinBudget = m.width - 2 // the bar's leading and trailing space
+		// Clamped to at least 1: a computed budget of exactly 0 would read as
+		// the unlimited sentinel and ship a full-width pin past a tiny
+		// terminal — the over-width defect class the marquee clamp fixed.
+		pinBudget = max(1, m.width-2) // the bar's leading and trailing space
 	}
 	right := m.statusPin(pinBudget)
 	if right != "" && m.width > 0 {
@@ -279,7 +300,7 @@ func (m tuiModel) statusFooterView() string {
 		contentBudget := max(0, m.width-statusBarChrome)
 		if lipgloss.Width(detail)+lipgloss.Width(right) > contentBudget {
 			lane := min(statusDetailLaneWidth, max(0, contentBudget-statusPinMinWidth))
-			right = m.statusPin(max(0, contentBudget-lane))
+			right = m.statusPin(max(1, contentBudget-lane))
 		}
 	}
 	if right != "" {
@@ -296,7 +317,15 @@ func (m tuiModel) statusFooterView() string {
 	}
 	left := " " + detail
 	pad := m.width - lipgloss.Width(left) - lipgloss.Width(right)
-	return style.Render(left + strings.Repeat(" ", max(0, pad)) + right)
+	line := left + strings.Repeat(" ", max(0, pad)) + right
+	// Last-resort clamp: at widths too small for even the bar's chrome the
+	// budgets above cannot hold the invariant on their own, and an over-width
+	// line makes bubbletea truncate it with the background stopping short of
+	// the terminal edge.
+	if m.width > 0 && lipgloss.Width(line) > m.width {
+		line = truncateWidth(line, m.width)
+	}
+	return style.Render(line)
 }
 
 // statusPin is the status bar's fixed right edge while connected: the relay
@@ -373,12 +402,14 @@ func (m tuiModel) statusDetail() string {
 	// a second, different relay. The class badge is not duplicated anywhere, so
 	// it stays — bracketed, it labels itself.
 	parts := make([]string, 0, 10)
+	// The state is normally the bar's color alone; with no color to carry it
+	// (NO_COLOR, dumb terminals — the Ascii profile) the translated state word
+	// leads the detail instead, so the bar still says what it is.
+	if lipgloss.ColorProfile() == termenv.Ascii {
+		parts = append(parts, tr.statusName(status))
+	}
 	if m.infoOK {
-		if brokerapi.EffectiveNodeClass(m.info.Relay.NodeClass) == brokerapi.NodeClassFoundation {
-			parts = append(parts, tr.badgeFoundation)
-		} else {
-			parts = append(parts, tr.badgeVolunteer)
-		}
+		parts = append(parts, nodeClassText(tr, m.info.Relay.NodeClass))
 	}
 
 	transport := "—"
@@ -419,7 +450,15 @@ func (m tuiModel) statusDetail() string {
 	if m.state.LastError != nil {
 		parts = append(parts, field(tr.labelError, *m.state.LastError))
 	}
-	return strings.Join(parts, " · ")
+	// One line by contract: engine strings can carry newlines (a broker front's
+	// HTML error body survives brokerapi's trim), and a stray \n here would make
+	// the frame taller than the terminal.
+	return oneLine(strings.Join(parts, " · "))
+}
+
+// oneLine collapses every whitespace run — newlines included — to one space.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // footerMarqueeWindow returns one display-cell-aware window into overflowing
@@ -499,13 +538,24 @@ func transportLabel(tr *translation, info connectcore.ConnectionInfo) string {
 	}
 }
 
-func nodeClassBadge(tr *translation, nodeClass string) string {
-	// A missing or unrecognized class is the volunteer class, per the
-	// descriptor contract; EffectiveNodeClass is that rule.
+// nodeClassText is the unstyled class label — the single home of the
+// class→label rule, shared by the relay list's badge and the status bar. A
+// missing or unrecognized class is the volunteer class, per the descriptor
+// contract; EffectiveNodeClass is that rule.
+func nodeClassText(tr *translation, nodeClass string) string {
 	if brokerapi.EffectiveNodeClass(nodeClass) == brokerapi.NodeClassFoundation {
-		return foundationBadgeStyle.Render(tr.badgeFoundation)
+		return tr.badgeFoundation
 	}
-	return volunteerBadgeStyle.Render(tr.badgeVolunteer)
+	return tr.badgeVolunteer
+}
+
+// nodeClassBadge is nodeClassText in the relay list's class color.
+func nodeClassBadge(tr *translation, nodeClass string) string {
+	text := nodeClassText(tr, nodeClass)
+	if brokerapi.EffectiveNodeClass(nodeClass) == brokerapi.NodeClassFoundation {
+		return foundationBadgeStyle.Render(text)
+	}
+	return volunteerBadgeStyle.Render(text)
 }
 
 // healthText renders the latest mid-session probe sweep. The engine only
@@ -586,7 +636,10 @@ func (m tuiModel) relaysView() string {
 	// Window the list to the rows the body has left after any notice lines and
 	// the column header, following the cursor: fitLines hard-truncates the body,
 	// so without this the selection could sit on a row the screen never shows.
-	visible := m.bodyHeight() - len(rows)
+	// The window budget excludes the brand mark's reserved rows: the cursor
+	// pins the selection to the window's last line, which must stay a real
+	// content line.
+	visible := m.bodyHeight() - m.brandMarkRows() - len(rows)
 	if visible < 1 {
 		visible = 1
 	}

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -26,6 +26,9 @@ var (
 	noteStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	cursorStyle    = lipgloss.NewStyle().Bold(true)
 	brandStyle     = lipgloss.NewStyle().Bold(true)
+	// The connected relay's row in the Relays list: bold, so the list itself
+	// answers "which one am I on" without a glance at the status bar.
+	connectedRowStyle = lipgloss.NewStyle().Bold(true)
 
 	foundationBadgeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 	volunteerBadgeStyle  = lipgloss.NewStyle().Faint(true)
@@ -221,13 +224,8 @@ const (
 func (m tuiModel) footerView() string {
 	tr := m.tr()
 	help := tr.helpGlobal
-	switch m.view {
-	case viewRelays:
-		help = tr.helpRelays + help
-	case viewSettings:
-		if m.settings.editing {
-			help = tr.helpSettingsEdit
-		}
+	if m.view == viewSettings && m.settings.editing {
+		help = tr.helpSettingsEdit
 	}
 
 	// No connection styling here: the signal lives one line up, on the status
@@ -592,44 +590,64 @@ func (m tuiModel) relaysView() string {
 	case len(m.relays) == 0:
 		rows = append(rows, helpStyle.Render(tr.noRelaysYet))
 	}
-	if len(m.relays) == 0 {
-		return strings.Join(rows, "\n")
+	if len(m.relays) > 0 {
+		// padCell, not %-8s: the localized headers must pad by display width to
+		// stay aligned with the ASCII-formatted rows below.
+		rows = append(rows, helpStyle.Render("   "+padCell(tr.colRelay, 28)+" "+padCell(tr.colCountry, 8)+" "+padCell(tr.colLatency, 9)+" "+tr.colClass))
 	}
 
-	// padCell, not %-8s: the localized headers must pad by display width to
-	// stay aligned with the ASCII-formatted rows below.
-	rows = append(rows, helpStyle.Render("   "+padCell(tr.colRelay, 28)+" "+padCell(tr.colCountry, 8)+" "+padCell(tr.colLatency, 9)+" "+tr.colClass))
-
+	// The selectable list: row 0 is Auto select — enter there connects ranked —
+	// and every row after it is a directory relay enter connects to directly.
+	// The Auto row renders even while the directory is empty or refreshing: the
+	// list is the only connect control, so it must never be unreachable.
+	//
 	// Window the list to the rows the body has left after any notice lines and
 	// the column header, following the cursor: fitLines hard-truncates the body,
-	// so without this the selection could sit on a relay the screen never shows.
+	// so without this the selection could sit on a row the screen never shows.
 	visible := m.bodyHeight() - len(rows)
 	if visible < 1 {
 		visible = 1
 	}
+	total := len(m.relays) + 1
 	start := 0
 	if m.relayCursor >= visible {
 		start = m.relayCursor - visible + 1
 	}
 	end := start + visible
-	if end > len(m.relays) {
-		end = len(m.relays)
+	if end > total {
+		end = total
 	}
 	for i := start; i < end; i++ {
-		entry := m.relays[i]
 		cursor := "  "
 		if i == m.relayCursor {
 			cursor = cursorStyle.Render("▸ ")
 		}
+		if i == 0 {
+			line := cursor + " " + tr.autoSelect
+			// The marker follows the pin, and no pin means Auto select is what
+			// the next connect does.
+			if !m.settings.target.Targeted() {
+				line += " " + noteStyle.Render(tr.targetMarker)
+			}
+			rows = append(rows, line)
+			continue
+		}
+		entry := m.relays[i-1]
 		cc := strings.ToUpper(strings.TrimSpace(entry.Relay.CountryCode))
 		if cc != "" {
 			cc += countryFlag(cc)
 		}
 		// padCell and truncateWidth throughout: the flag emoji (and any CJK in
-		// a label) would break byte- or rune-count alignment.
-		line := cursor + " " + padCell(truncateWidth(relayListName(entry.Relay), 28), 28) +
-			" " + padCell(cc, 8) +
-			" " + padCell(latencyLabel(entry.ProbeMS), 9) +
+		// a label) would break byte- or rune-count alignment. Pad before
+		// styling so the bold applied below cannot change the counted width.
+		name := padCell(truncateWidth(relayListName(entry.Relay), 28), 28)
+		geo := padCell(cc, 8)
+		latency := padCell(latencyLabel(entry.ProbeMS), 9)
+		// The badge keeps its own class color, so it stays outside the bold.
+		if m.state.Status == connectcore.StatusConnected && m.infoOK && entry.Relay.ID == m.info.Relay.ID {
+			name, geo, latency = connectedRowStyle.Render(name), connectedRowStyle.Render(geo), connectedRowStyle.Render(latency)
+		}
+		line := cursor + " " + name + " " + geo + " " + latency +
 			" " + nodeClassBadge(tr, entry.Relay.NodeClass)
 		if entry.Relay.ID == m.settings.target.RelayID && m.settings.target.RelayID != "" {
 			line += " " + noteStyle.Render(tr.targetMarker)

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -174,7 +174,7 @@ func (m tuiModel) headerView() string {
 		}
 		tabs = append(tabs, style.Render(name))
 	}
-	// The language switch lives on the l key and is advertised in the footer
+	// The language switch lives on the . key and is advertised in the footer
 	// (languageKeyHelp), not here — the tab bar holds only views.
 
 	// headerHeight budgets exactly one line, so a narrow terminal sheds whole
@@ -711,7 +711,7 @@ func modeLabel(tr *translation, mode connectcore.Mode) string {
 
 // renderNote resolves a stored settings notice through the ACTIVE language:
 // the kind is stored, the words are chosen at draw time, so a note set while
-// the UI spoke Chinese follows an l-key cycle into Russian.
+// the UI spoke Chinese follows a language cycle into Russian.
 func renderNote(tr *translation, n settingsNote) string {
 	switch n.kind {
 	case noteText:

--- a/cmd/client/views.go
+++ b/cmd/client/views.go
@@ -241,13 +241,28 @@ func (m tuiModel) footerView() string {
 	return " " + help
 }
 
+const (
+	// The scrolling detail keeps at least this much of a lane before the pin is
+	// allowed to shrink it further; enough to read a field and its value.
+	statusDetailLaneWidth = 32
+	// The pin never shrinks below its duration — that is the field it exists for.
+	statusPinMinWidth = len("00:00:00")
+	// Wider than the one-cell gap the old footer used, because the detail is cut
+	// mid-field wherever the marquee happens to be: with a single space, a lane
+	// ending in "Health" runs straight into the pin and reads as though the
+	// relay were the health value.
+	statusPinGap = 3
+	// Leading space, the gap, and the trailing space after the pin.
+	statusBarChrome = 1 + statusPinGap + 1
+)
+
 // statusFooterView is the permanent connection bar between the body and the
 // key help — every row the old Status view carried, on one line, so the state
 // is readable from whichever view the user is on. It keeps the old footer's
 // coloring: red while disconnected or failed, yellow through transitions,
-// green while connected. The detail scrolls when it overflows, but the session
-// duration stays pinned right, because "how long" is the one field a glance at
-// the corner should always answer.
+// green while connected. The detail scrolls when it overflows; the relay label
+// and session duration stay pinned right, because "to what" and "how long" are
+// what a glance at the corner should always answer.
 func (m tuiModel) statusFooterView() string {
 	style, ok := footerStyles[m.state.Status]
 	if !ok {
@@ -255,9 +270,19 @@ func (m tuiModel) statusFooterView() string {
 	}
 	detail := m.statusDetail()
 
-	right := ""
-	if m.state.Status == connectcore.StatusConnected && !m.connectedAt.IsZero() {
-		right = formatDuration(m.now.Sub(m.connectedAt))
+	pinBudget := 0 // ≤0 = unlimited
+	if m.width > 0 {
+		pinBudget = m.width - 2 // the bar's leading and trailing space
+	}
+	right := m.statusPin(pinBudget)
+	if right != "" && m.width > 0 {
+		// Re-fit the pin so the detail keeps a readable lane rather than being
+		// squeezed to nothing.
+		contentBudget := max(0, m.width-statusBarChrome)
+		if lipgloss.Width(detail)+lipgloss.Width(right) > contentBudget {
+			lane := min(statusDetailLaneWidth, max(0, contentBudget-statusPinMinWidth))
+			right = m.statusPin(max(0, contentBudget-lane))
+		}
 	}
 	if right != "" {
 		right += " "
@@ -265,7 +290,7 @@ func (m tuiModel) statusFooterView() string {
 	if m.width > 0 {
 		budget := m.width - lipgloss.Width(right) - 1 // leading space
 		if right != "" {
-			budget-- // one-cell gap between detail and duration
+			budget -= statusPinGap
 		}
 		if lipgloss.Width(detail) > budget {
 			detail = m.footerMarqueeWindow(detail, max(0, budget))
@@ -274,6 +299,57 @@ func (m tuiModel) statusFooterView() string {
 	left := " " + detail
 	pad := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	return style.Render(left + strings.Repeat(" ", max(0, pad)) + right)
+}
+
+// statusPin is the status bar's fixed right edge while connected: the relay
+// label, its country flag, and the running session duration, fitted to budget
+// cells (≤0 = unlimited). The duration anchors the edge, so when space runs out
+// the label gives way first — the corner should still answer "how long" on a
+// terminal too narrow for "to what".
+func (m tuiModel) statusPin(budget int) string {
+	if m.state.Status != connectcore.StatusConnected {
+		return ""
+	}
+	// Single-sourced for the same reason as statusDetail: with a descriptor the
+	// name AND flag are the descriptor's, because a failover updates the state
+	// label before the next info poll and mixing them would pair a fresh label
+	// with the previous relay's flag.
+	label := ""
+	if m.infoOK {
+		label = strings.TrimSpace(relayListName(m.info.Relay))
+		if flag := countryFlag(m.info.Relay.CountryCode); flag != "" {
+			if label != "" {
+				label += " "
+			}
+			label += flag
+		}
+	} else if m.state.RelayLabel != nil {
+		label = strings.TrimSpace(*m.state.RelayLabel)
+	}
+	duration := ""
+	if !m.connectedAt.IsZero() {
+		duration = formatDuration(m.now.Sub(m.connectedAt))
+	}
+
+	parts := make([]string, 0, 2)
+	if label != "" {
+		parts = append(parts, label)
+	}
+	if duration != "" {
+		parts = append(parts, duration)
+	}
+	pin := strings.Join(parts, " ")
+	if budget <= 0 || lipgloss.Width(pin) <= budget {
+		return pin
+	}
+	if duration == "" {
+		return truncateWidth(label, budget)
+	}
+	label = truncateWidth(label, max(0, budget-lipgloss.Width(duration)-1))
+	if label == "" {
+		return truncateWidth(duration, budget)
+	}
+	return label + " " + duration
 }
 
 // statusDetail is every Status field on one line. Deliberately unstyled: the

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -134,19 +134,42 @@ func TestFooterIdentityIsSingleSourced(t *testing.T) {
 	}
 }
 
-// The summary must survive a terminal too narrow for both it and the help
-// line — the help is what yields.
-func TestFooterSummaryWinsOnNarrowTerminals(t *testing.T) {
+// A narrow connected footer shares the line between a scrolling help lane and
+// the fixed session duration. The relay label yields before either one.
+func TestFooterMarqueeSharesNarrowTerminalWithDuration(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.width = 30
 	label := "merry-falcon"
 	m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
-	m.connectedAt = time.Now().Add(-time.Minute)
-	m.now = time.Now()
+	m.startedAt = time.Unix(0, 0)
+	m.connectedAt = m.startedAt.Add(-time.Minute)
+	m.now = m.startedAt
 
 	footer := m.footerView()
-	if !strings.Contains(footer, "merry-falcon") || !strings.Contains(footer, "00:01:00") {
-		t.Fatalf("narrow footer dropped the connection summary:\n%q", footer)
+	if !strings.Contains(footer, "00:01:00") {
+		t.Fatalf("narrow footer dropped the session duration:\n%q", footer)
+	}
+	if strings.Contains(footer, "merry-falcon") {
+		t.Fatalf("relay label should yield to help and duration:\n%q", footer)
+	}
+	if w := lipgloss.Width(footer); w > m.width {
+		t.Fatalf("narrow footer is %d cells wide, max %d: %q", w, m.width, footer)
+	}
+
+	seenLanguage := false
+	cycle := footerMarqueePause + lipgloss.Width(m.tr().helpGlobal) + lipgloss.Width(footerMarqueeGap)
+	for step := 0; step < cycle; step++ {
+		m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
+		footer = m.footerView()
+		if duration := formatDuration(m.now.Sub(m.connectedAt)); !strings.Contains(footer, duration) {
+			t.Fatalf("marquee step %d dropped the duration: %q", step, footer)
+		}
+		if strings.Contains(footer, languageKeyHelp) {
+			seenLanguage = true
+		}
+	}
+	if !seenLanguage {
+		t.Fatal("one marquee cycle never revealed the complete language control")
 	}
 }
 
@@ -214,13 +237,16 @@ func TestRelayRowsAlignWithCJKLabels(t *testing.T) {
 	}
 }
 
-// The brand mark sits whole in the bottom-right corner of every view, its
-// last row on the last body line — directly above the status bar — and never
-// pushes a line past the terminal width.
-func TestBrandMarkOnEveryView(t *testing.T) {
+// The brand mark sits whole in the bottom-right corner of every non-Logs view,
+// its last row on the last body line — directly above the status bar — and
+// never pushes a line past the terminal width.
+func TestBrandMarkOnNonLogViews(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.width, m.height = 100, 30
 	for v := viewID(0); v < viewCount; v++ {
+		if v == viewLogs {
+			continue
+		}
 		m.view = v
 		view := m.View()
 		for _, artLine := range openrungArt {
@@ -244,6 +270,30 @@ func TestBrandMarkOnEveryView(t *testing.T) {
 	}
 }
 
+// Logs keep the whole viewport for diagnostics: in particular, the newest
+// rows at the bottom must not lose their right-hand side under decoration.
+func TestBrandMarkIsDisabledInLogs(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width, m.height = 80, 24
+	m.view = viewLogs
+	m.resizeLogView()
+	marker := "newest-log-details-" + strings.Repeat("x", 50)
+	lines := make([]string, m.bodyHeight())
+	for i := range lines {
+		lines[i] = "older"
+	}
+	lines[len(lines)-1] = marker
+	m.setLogLines(lines)
+
+	view := m.View()
+	if strings.Contains(view, openrungArt[0]) {
+		t.Fatalf("Logs view still carries the brand mark:\n%s", view)
+	}
+	if !strings.Contains(view, marker) {
+		t.Fatalf("Logs view cut the newest row:\n%s", view)
+	}
+}
+
 // A terminal too narrow or too short for the mark drops it entirely — a torn
 // or crowding mark is worse than none.
 func TestBrandMarkHiddenOnSmallTerminals(t *testing.T) {
@@ -258,9 +308,8 @@ func TestBrandMarkHiddenOnSmallTerminals(t *testing.T) {
 	}
 }
 
-// The mark wins the corner over body content (it must sit on every view, the
-// logs included), and the cut under it is ANSI-aware so styled body lines are
-// never severed mid-escape-sequence.
+// Outside Logs, the mark wins the corner over body content, and the cut under
+// it is ANSI-aware so styled body lines are never severed mid-escape-sequence.
 func TestBrandMarkWinsTheCornerOverContent(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.width, m.height = 60, 24

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -106,7 +106,7 @@ func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 	tr := m.tr()
 	detail := m.statusDetail()
 	for _, want := range []string{
-		tr.labelStatus, "connected", tr.labelRelay, "merry-falcon", "[foundation]",
+		tr.labelStatus, "connected", "[foundation]",
 		tr.labelCountry, tr.labelTransport, "front-a", tr.labelHealth,
 		tr.labelCapture, tr.labelProxy, "127.0.0.1:43210", tr.labelBroker,
 		tr.labelTarget, tr.labelError, failure,
@@ -115,8 +115,14 @@ func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 			t.Errorf("status detail missing %q:\n%s", want, detail)
 		}
 	}
-	if bar := m.statusFooterView(); !strings.Contains(bar, "00:01:30") {
-		t.Errorf("status bar did not pin the session duration:\n%q", bar)
+	// The relay name lives only on the pin: repeated in a track that scrolls
+	// past the pin, it reads as two different relays.
+	if strings.Contains(detail, "merry-falcon") {
+		t.Errorf("relay name duplicated into the scrolling detail:\n%s", detail)
+	}
+	if bar := m.statusFooterView(); !strings.Contains(bar, "00:01:30") ||
+		!strings.Contains(bar, "merry-falcon") {
+		t.Errorf("status bar did not pin the relay and duration:\n%q", bar)
 	}
 
 	// Disconnected: no duration is pinned, and the key help never carries one.
@@ -167,24 +173,61 @@ func TestStatusIdentityIsSingleSourced(t *testing.T) {
 		ID:               "r9",
 		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
 	}}
-	detail := m.statusDetail()
-	if strings.Contains(detail, "Singapore") {
-		t.Fatalf("status paired the state label with the descriptor's country: %q", detail)
+	detail, pin := m.statusDetail(), m.statusPin(0)
+	if strings.Contains(pin, "Singapore") {
+		t.Fatalf("pin paired the state label with the descriptor's flag: %q", pin)
 	}
-	for _, want := range []string{"relay r9", "JP"} {
-		if !strings.Contains(detail, want) {
-			t.Fatalf("status did not use the descriptor's own identity (%q): %q", want, detail)
-		}
+	if !strings.Contains(pin, "relay r9") {
+		t.Fatalf("pin did not fall back to the descriptor's own name: %q", pin)
+	}
+	if !strings.Contains(detail, "JP") {
+		t.Fatalf("detail lost the descriptor's country: %q", detail)
 	}
 
-	// No descriptor: the state label stands alone, with no country asserted.
+	// No descriptor: the state label stands alone, and no country is asserted.
 	m.infoOK = false
-	detail = m.statusDetail()
-	if !strings.Contains(detail, "Singapore") {
-		t.Fatalf("descriptor-less status lost the state label: %q", detail)
+	detail, pin = m.statusDetail(), m.statusPin(0)
+	if !strings.Contains(pin, "Singapore") {
+		t.Fatalf("descriptor-less pin lost the state label: %q", pin)
 	}
-	if strings.Contains(detail, countryFlagFor("darwin", "jp")) {
-		t.Fatalf("descriptor-less status still asserts a country: %q", detail)
+	if strings.Contains(pin, countryFlagFor("darwin", "jp")) {
+		t.Fatalf("descriptor-less pin still asserts a country: %q", pin)
+	}
+	if strings.Contains(detail, "JP") {
+		t.Fatalf("descriptor-less detail still asserts a country: %q", detail)
+	}
+}
+
+// The relay name lives only on the pin, so the pin has to survive the
+// transitions: "connecting" must still name its destination, while a
+// disconnected or failed bar asserts no relay at all.
+func TestStatusPinNamesTheRelayThroughTransitions(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width = 120
+	label := "merry-falcon"
+
+	for _, status := range []connectcore.Status{
+		connectcore.StatusPreparing, connectcore.StatusConnecting,
+		connectcore.StatusConnected, connectcore.StatusDisconnecting,
+	} {
+		m.state = connectcore.State{Status: status, RelayLabel: &label}
+		if pin := m.statusPin(0); !strings.Contains(pin, label) {
+			t.Errorf("status %s: pin does not name the relay: %q", status, pin)
+		}
+	}
+	// No duration outside a live session, even with a stamp left over.
+	m.connectedAt = m.now.Add(-time.Minute)
+	m.state = connectcore.State{Status: connectcore.StatusConnecting, RelayLabel: &label}
+	if pin := m.statusPin(0); strings.Contains(pin, "00:01:00") {
+		t.Errorf("connecting pin shows a session duration: %q", pin)
+	}
+	for _, status := range []connectcore.Status{
+		connectcore.StatusDisconnected, connectcore.StatusFailed,
+	} {
+		m.state = connectcore.State{Status: status, RelayLabel: &label}
+		if pin := m.statusPin(0); pin != "" {
+			t.Errorf("status %s: stale relay lingers on the pin: %q", status, pin)
+		}
 	}
 }
 

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -173,6 +173,75 @@ func TestFooterMarqueeSharesNarrowTerminalWithDuration(t *testing.T) {
 	}
 }
 
+// footerHelpWindow must return exactly the width it was asked for at EVERY
+// marquee phase. ansi.Cut counts cells but cannot split one, so a boundary
+// landing on the double-width CJK in languageKeyHelp used to return a cell
+// too many — and disconnected, where no summary absorbs it, the bar shipped
+// one cell past the terminal (width 80, Relays, English, step 111).
+func TestFooterMarqueeHoldsItsWidthAtEveryPhase(t *testing.T) {
+	names := []string{"status", "relays", "logs", "settings"}
+	label := "merry-falcon"
+	for _, width := range []int{20, 30, 40, 60, 80, 100, 120} {
+		for _, connected := range []bool{false, true} {
+			for lang := language(0); lang < languageCount; lang++ {
+				for v := viewID(0); v < viewCount; v++ {
+					m := newTestModel(&fakeDriver{})
+					m.width, m.lang, m.view = width, lang, v
+					m.startedAt = time.Unix(0, 0)
+					if connected {
+						m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
+						m.connectedAt = m.startedAt.Add(-time.Minute)
+					}
+					// One full cycle: the pause, the whole track, and the gap.
+					steps := footerMarqueePause + lipgloss.Width(m.tr().helpGlobal) +
+						lipgloss.Width(m.tr().helpRelays) + lipgloss.Width(footerMarqueeGap) + 2
+					for step := 0; step < steps; step++ {
+						m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
+						if w := lipgloss.Width(m.footerView()); w > width {
+							t.Fatalf("w=%d %s lang=%d conn=%t step=%d: footer is %d cells",
+								width, names[v], lang, connected, step, w)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// Narrow terminals scroll the help, so the complete language token has to come
+// into view within one cycle — it is the one control a reader stuck in an
+// unreadable language depends on. Below ~30 cells the lane cannot hold the
+// token's 16 cells alongside the session duration, which is a known gap.
+func TestFooterMarqueeRevealsLanguageToken(t *testing.T) {
+	label := "merry-falcon"
+	for _, width := range []int{30, 40, 60, 80} {
+		for _, connected := range []bool{false, true} {
+			for lang := language(0); lang < languageCount; lang++ {
+				for v := viewID(0); v < viewCount; v++ {
+					m := newTestModel(&fakeDriver{})
+					m.width, m.lang, m.view = width, lang, v
+					m.startedAt = time.Unix(0, 0)
+					if connected {
+						m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
+						m.connectedAt = m.startedAt.Add(-time.Minute)
+					}
+					steps := footerMarqueePause + lipgloss.Width(m.tr().helpGlobal) +
+						lipgloss.Width(m.tr().helpRelays) + lipgloss.Width(footerMarqueeGap) + 2
+					seen := false
+					for step := 0; step < steps && !seen; step++ {
+						m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
+						seen = strings.Contains(m.footerView(), languageKeyHelp)
+					}
+					if !seen {
+						t.Errorf("w=%d view %d lang %d conn=%t: a full cycle never showed %q",
+							width, v, lang, connected, languageKeyHelp)
+					}
+				}
+			}
+		}
+	}
+}
+
 // Header and footer each budget exactly one line, so on a narrow terminal
 // they must shed content instead of wrapping — in every language and every
 // connection state, summary or not. What they shed follows priority: the

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -299,6 +299,25 @@ func TestPaintFrameRepaintsDefaults(t *testing.T) {
 	}
 }
 
+// Settings holds exactly broker, mode, and the shell helper: the target relay
+// is pinned from the Relays view (or CLI flags), never typed into Settings —
+// and the tab bar keys, obvious enough to go unadvertised, stay out of the
+// footer help.
+func TestSettingsOffersNoTargetFields(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.view = viewSettings
+	m.settings.target = connectcore.RelayTarget{RelayID: "r1", Label: "x", Country: "kr"}
+	view := m.settingsView()
+	for _, gone := range []string{"Target relay id", "Target label", "Target country"} {
+		if strings.Contains(view, gone) {
+			t.Fatalf("settings still offers %q:\n%s", gone, view)
+		}
+	}
+	if strings.Contains(m.footerView(), "1-4") {
+		t.Fatalf("footer still advertises the view keys: %q", m.footerView())
+	}
+}
+
 func TestFooterStyleCoversEveryStatus(t *testing.T) {
 	for status := range statusStyles {
 		if _, ok := footerStyles[status]; !ok {

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -318,7 +319,6 @@ func TestStatusBarKeepsDurationPinnedWhileScrolling(t *testing.T) {
 // too many — and disconnected, where no summary absorbs it, the bar shipped
 // one cell past the terminal (width 80, Relays, English, step 111).
 func TestFooterMarqueeHoldsItsWidthAtEveryPhase(t *testing.T) {
-	names := []string{"status", "relays", "logs", "settings"}
 	label := "merry-falcon"
 	for _, width := range []int{20, 30, 40, 60, 80, 100, 120} {
 		for _, connected := range []bool{false, true} {
@@ -341,8 +341,8 @@ func TestFooterMarqueeHoldsItsWidthAtEveryPhase(t *testing.T) {
 							"status": m.statusFooterView(),
 						} {
 							if w := lipgloss.Width(got); w > width {
-								t.Fatalf("w=%d %s lang=%d conn=%t step=%d: %s bar is %d cells",
-									width, names[v], lang, connected, step, bar, w)
+								t.Fatalf("w=%d view=%q lang=%d conn=%t step=%d: %s bar is %d cells",
+									width, m.tr().tabs[v], lang, connected, step, bar, w)
 							}
 						}
 					}
@@ -597,21 +597,47 @@ func TestBrandMarkHiddenOnSmallTerminals(t *testing.T) {
 	}
 }
 
-// Outside Logs, the mark wins the corner over body content, and the cut under
-// it is ANSI-aware so styled body lines are never severed mid-escape-sequence.
-func TestBrandMarkWinsTheCornerOverContent(t *testing.T) {
+// The mark's rows are RESERVED, not overlaid: even with the cursor scrolled to
+// the tail — which pins the highlighted relay to the list window's last line —
+// every cell of that row (latency, class) stays readable, and the mark renders
+// whole on its own lines below.
+func TestBrandMarkNeverCoversContent(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
-	m.width, m.height = 60, 24
-	wide := errorStyle.Render(strings.Repeat("x", m.width)) // full-width AND styled
-	body := m.overlayBrandMark(fitLines(strings.Repeat(wide+"\n", 19)+wide, m.bodyHeight()))
-	lines := strings.Split(body, "\n")
-	for _, line := range lines[len(lines)-len(openrungArt):] {
-		if w := lipgloss.Width(line); w > m.width {
-			t.Errorf("overlaid line is %d cells wide, max %d: %q", w, m.width, line)
+	m.width, m.height = 80, 24
+	m.view = viewRelays
+	m.refreshing = false
+	for i := 0; i < 25; i++ {
+		m.relays = append(m.relays, connectcore.DirectoryRelay{
+			Relay: brokerapi.RelayDescriptor{ID: fmt.Sprintf("relay_%02d", i), Label: fmt.Sprintf("node-%02d", i)},
+		})
+	}
+	m.relayCursor = len(m.relays) // the last relay: the window's final line
+
+	view := m.View()
+	var cursorRow string
+	for _, row := range strings.Split(view, "\n") {
+		if strings.Contains(row, "▸") {
+			cursorRow = row
 		}
 	}
-	if !strings.Contains(body, openrungArt[0]) {
-		t.Fatalf("full-width content displaced the brand mark:\n%s", body)
+	if cursorRow == "" {
+		t.Fatalf("highlighted row not rendered:\n%s", view)
+	}
+	if !strings.Contains(cursorRow, "node-24") || !strings.Contains(cursorRow, "[volunteer]") {
+		t.Fatalf("highlighted row lost its cells to the mark: %q", cursorRow)
+	}
+	for _, artLine := range openrungArt {
+		if strings.Contains(cursorRow, strings.TrimSpace(artLine)[:8]) {
+			t.Fatalf("brand mark drawn over the highlighted row: %q", cursorRow)
+		}
+		if !strings.Contains(view, artLine) {
+			t.Fatalf("brand mark row %q missing:\n%s", artLine, view)
+		}
+	}
+	for i, line := range strings.Split(view, "\n") {
+		if w := lipgloss.Width(line); w > m.width {
+			t.Errorf("line %d is %d cells wide, max %d", i, w, m.width)
+		}
 	}
 }
 
@@ -652,6 +678,61 @@ func TestSettingsOffersNoTargetFields(t *testing.T) {
 	}
 	if strings.Contains(m.footerView(), "1-4") {
 		t.Fatalf("footer still advertises the view keys: %q", m.footerView())
+	}
+}
+
+// Engine strings can carry newlines — a broker front's HTML error body
+// survives brokerapi's trim — and the status bar is one line by contract: a
+// stray \n would make the frame taller than the terminal.
+func TestStatusBarStaysOneLineWithNewlineErrors(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width = 400
+	failure := "broker list relays: <html>\n<body>502 Bad Gateway</body>\n</html>"
+	m.state = connectcore.State{Status: connectcore.StatusFailed, LastError: &failure}
+	if bar := m.statusFooterView(); strings.Contains(bar, "\n") {
+		t.Fatalf("multi-line error made the status bar multi-line:\n%q", bar)
+	}
+	if !strings.Contains(m.statusDetail(), "502 Bad Gateway") {
+		t.Fatalf("sanitizing the error lost its text:\n%s", m.statusDetail())
+	}
+}
+
+// The state is normally the bar's color alone; the Ascii profile (NO_COLOR,
+// dumb terminals) cannot render color, so there — and only there — the
+// translated state word leads the detail.
+func TestStateWordAppearsOnlyWithoutColor(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width = 400
+	m.state = connectcore.State{Status: connectcore.StatusConnecting}
+	if detail := m.statusDetail(); !strings.Contains(detail, "connecting") {
+		t.Fatalf("Ascii-profile detail carries no state word:\n%s", detail)
+	}
+	m.lang = langChinese
+	if detail := m.statusDetail(); !strings.Contains(detail, "连接中") {
+		t.Fatalf("state word not translated:\n%s", detail)
+	}
+	m.lang = langEnglish
+
+	lipgloss.SetColorProfile(termenv.ANSI)
+	defer lipgloss.SetColorProfile(termenv.Ascii)
+	if detail := m.statusDetail(); strings.Contains(detail, "connecting") {
+		t.Fatalf("colored detail duplicates the bar's color as a word:\n%s", detail)
+	}
+}
+
+// The never-exceed-width invariant must hold even at pathological widths: a
+// computed pin budget of exactly 0 used to read as the unlimited sentinel and
+// ship a full-width pin past the terminal.
+func TestStatusBarNeverExceedsTinyWidths(t *testing.T) {
+	label := "merry-falcon"
+	for width := 1; width <= 10; width++ {
+		m := newTestModel(&fakeDriver{})
+		m.width = width
+		m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
+		m.connectedAt = m.now.Add(-time.Minute)
+		if w := lipgloss.Width(m.statusFooterView()); w > width {
+			t.Errorf("width %d: status bar is %d cells", width, w)
+		}
 	}
 }
 

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -117,7 +117,7 @@ func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 	for _, want := range []string{
 		"[foundation]", tr.labelTransport, "front-a", tr.labelHealth,
 		tr.labelCapture, tr.labelProxy, "127.0.0.1:43210", tr.labelBroker,
-		tr.labelTarget, tr.labelError, failure,
+		tr.labelError, failure,
 	} {
 		if !strings.Contains(detail, want) {
 			t.Errorf("status detail missing %q:\n%s", want, detail)
@@ -428,9 +428,8 @@ func TestHeaderAndFooterNeverExceedNarrowWidths(t *testing.T) {
 }
 
 // The Relays list opens on an Auto select row: enter there connects ranked. It
-// carries the target marker whenever nothing is pinned, sits above every
-// relay, and survives an empty directory — the list is the only connect
-// control, so it must never be unreachable.
+// sits above every relay and survives an empty directory — the list is the
+// only connect control, so it must never be unreachable.
 func TestAutoSelectRowTopsTheRelayList(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.view = viewRelays
@@ -444,29 +443,6 @@ func TestAutoSelectRowTopsTheRelayList(t *testing.T) {
 	autoAt, relayAt := strings.Index(view, tr.autoSelect), strings.Index(view, "merry-falcon")
 	if autoAt < 0 || relayAt < 0 || autoAt > relayAt {
 		t.Fatalf("Auto select row is not above the relays:\n%s", view)
-	}
-	rowOf := func(view, needle string) string {
-		for _, row := range strings.Split(view, "\n") {
-			if strings.Contains(row, needle) {
-				return row
-			}
-		}
-		t.Fatalf("no row contains %q:\n%s", needle, view)
-		return ""
-	}
-	// Untargeted: the marker sits on Auto select, since that is what the next
-	// connect does.
-	if !strings.Contains(rowOf(view, tr.autoSelect), tr.targetMarker) {
-		t.Fatalf("untargeted list does not mark Auto select:\n%s", view)
-	}
-	// Pinned: the marker moves to the pinned relay.
-	m.settings.target = connectcore.RelayTarget{RelayID: "r1"}
-	view = m.relaysView()
-	if strings.Contains(rowOf(view, tr.autoSelect), tr.targetMarker) {
-		t.Fatalf("pinned list still marks Auto select:\n%s", view)
-	}
-	if !strings.Contains(rowOf(view, "merry-falcon"), tr.targetMarker) {
-		t.Fatalf("pinned relay lost the target marker:\n%s", view)
 	}
 
 	m.relays = nil
@@ -661,14 +637,13 @@ func TestPaintFrameRepaintsDefaults(t *testing.T) {
 	}
 }
 
-// Settings holds exactly broker, mode, and the shell helper: the target relay
-// is pinned from the Relays view (or CLI flags), never typed into Settings —
-// and the tab bar keys, obvious enough to go unadvertised, stay out of the
-// footer help.
+// Settings holds exactly broker, mode, and the shell helper: the TUI stores no
+// relay target, so there is nothing target-shaped to type into Settings — and
+// the tab bar keys, obvious enough to go unadvertised, stay out of the footer
+// help.
 func TestSettingsOffersNoTargetFields(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.view = viewSettings
-	m.settings.target = connectcore.RelayTarget{RelayID: "r1", Label: "x", Country: "kr"}
 	view := m.settingsView()
 	for _, gone := range []string{"Target relay id", "Target label", "Target country"} {
 		if strings.Contains(view, gone) {

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -39,14 +39,23 @@ func TestCountryFlag(t *testing.T) {
 	}
 }
 
-func TestStatusDetailShowsCountryFlag(t *testing.T) {
+// The country rides on the pin, as a code AND a flag — never the flag alone,
+// since countryFlag renders nothing on Windows and the pin is now the only
+// place a country appears.
+func TestStatusPinPairsCountryCodeWithFlag(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
+	m.state = connectcore.State{Status: connectcore.StatusConnected}
 	m.infoOK = true
 	m.info = connectcore.ConnectionInfo{Relay: brokerapi.RelayDescriptor{
 		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
 	}}
-	if view := m.statusDetail(); !strings.Contains(view, "JP🇯🇵") {
-		t.Fatalf("status detail missing the country flag:\n%s", view)
+	pin := m.statusPin(0)
+	if !strings.Contains(pin, "JP"+countryFlagFor("darwin", "jp")) {
+		t.Fatalf("pin did not pair the country code with its flag:\n%q", pin)
+	}
+	// The code is what survives where the flag cannot render.
+	if !strings.Contains(pin, "JP") {
+		t.Fatalf("pin lost the country code:\n%q", pin)
 	}
 }
 
@@ -106,8 +115,7 @@ func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 	tr := m.tr()
 	detail := m.statusDetail()
 	for _, want := range []string{
-		tr.labelStatus, "connected", "[foundation]",
-		tr.labelCountry, tr.labelTransport, "front-a", tr.labelHealth,
+		"[foundation]", tr.labelTransport, "front-a", tr.labelHealth,
 		tr.labelCapture, tr.labelProxy, "127.0.0.1:43210", tr.labelBroker,
 		tr.labelTarget, tr.labelError, failure,
 	} {
@@ -115,14 +123,18 @@ func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 			t.Errorf("status detail missing %q:\n%s", want, detail)
 		}
 	}
-	// The relay name lives only on the pin: repeated in a track that scrolls
-	// past the pin, it reads as two different relays.
-	if strings.Contains(detail, "merry-falcon") {
-		t.Errorf("relay name duplicated into the scrolling detail:\n%s", detail)
+	// Nothing the bar states another way belongs in the scrolling track: the
+	// state is the bar's color, and the relay and its country are pinned. Any
+	// of them repeated here reads as a second, different relay.
+	for _, gone := range []string{tr.labelStatus, tr.labelCountry, "merry-falcon", "JP"} {
+		if strings.Contains(detail, gone) {
+			t.Errorf("%q is duplicated into the scrolling detail:\n%s", gone, detail)
+		}
 	}
-	if bar := m.statusFooterView(); !strings.Contains(bar, "00:01:30") ||
-		!strings.Contains(bar, "merry-falcon") {
-		t.Errorf("status bar did not pin the relay and duration:\n%q", bar)
+	for _, want := range []string{"merry-falcon", "JP", "00:01:30"} {
+		if bar := m.statusFooterView(); !strings.Contains(bar, want) {
+			t.Errorf("status bar pin missing %q:\n%q", want, bar)
+		}
 	}
 
 	// Disconnected: no duration is pinned, and the key help never carries one.
@@ -173,28 +185,25 @@ func TestStatusIdentityIsSingleSourced(t *testing.T) {
 		ID:               "r9",
 		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
 	}}
-	detail, pin := m.statusDetail(), m.statusPin(0)
+	pin := m.statusPin(0)
 	if strings.Contains(pin, "Singapore") {
 		t.Fatalf("pin paired the state label with the descriptor's flag: %q", pin)
 	}
 	if !strings.Contains(pin, "relay r9") {
 		t.Fatalf("pin did not fall back to the descriptor's own name: %q", pin)
 	}
-	if !strings.Contains(detail, "JP") {
-		t.Fatalf("detail lost the descriptor's country: %q", detail)
+	if !strings.Contains(pin, "JP") {
+		t.Fatalf("pin lost the descriptor's country: %q", pin)
 	}
 
 	// No descriptor: the state label stands alone, and no country is asserted.
 	m.infoOK = false
-	detail, pin = m.statusDetail(), m.statusPin(0)
+	pin = m.statusPin(0)
 	if !strings.Contains(pin, "Singapore") {
 		t.Fatalf("descriptor-less pin lost the state label: %q", pin)
 	}
-	if strings.Contains(pin, countryFlagFor("darwin", "jp")) {
+	if strings.Contains(pin, "JP") || strings.Contains(pin, countryFlagFor("darwin", "jp")) {
 		t.Fatalf("descriptor-less pin still asserts a country: %q", pin)
-	}
-	if strings.Contains(detail, "JP") {
-		t.Fatalf("descriptor-less detail still asserts a country: %q", detail)
 	}
 }
 

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -188,6 +188,51 @@ func TestStatusIdentityIsSingleSourced(t *testing.T) {
 	}
 }
 
+// The pin holds both answers a glance needs — which relay, and for how long —
+// single-sourced from the descriptor when there is one. Under width pressure
+// the label yields and the duration stays, since "how long" is the field the
+// pin exists for.
+func TestStatusPinCarriesRelayLabelAndDuration(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width = 120
+	stale := "Singapore"
+	m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &stale}
+	m.connectedAt = m.now.Add(-90 * time.Second)
+	m.infoOK = true
+	m.info = connectcore.ConnectionInfo{Relay: brokerapi.RelayDescriptor{
+		Label:            "merry-falcon",
+		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
+	}}
+
+	flag := countryFlagFor("darwin", "jp")
+	bar := m.statusFooterView()
+	for _, want := range []string{"merry-falcon", flag, "00:01:30"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("status bar pin missing %q:\n%q", want, bar)
+		}
+	}
+	// The pin is the bar's right edge: nothing but its trailing space follows.
+	if !strings.HasSuffix(strings.TrimRight(bar, " "), "00:01:30") {
+		t.Fatalf("duration is not anchored to the right edge:\n%q", bar)
+	}
+	// Single-sourced: the descriptor won, so the stale state label is absent.
+	if strings.Contains(m.statusPin(0), stale) {
+		t.Fatalf("pin used the state label over the descriptor: %q", m.statusPin(0))
+	}
+
+	// Squeezed: the label gives way, the duration survives.
+	narrow := m.statusPin(statusPinMinWidth)
+	if narrow != "00:01:30" {
+		t.Fatalf("pin at its floor = %q, want the bare duration", narrow)
+	}
+
+	// Disconnected: no pin at all.
+	m.state.Status = connectcore.StatusDisconnected
+	if pin := m.statusPin(0); pin != "" {
+		t.Fatalf("disconnected pin = %q, want empty", pin)
+	}
+}
+
 // However narrow the terminal, and at every marquee phase, the status bar keeps
 // the session duration pinned to its right edge: the detail track is what
 // yields. That corner glance is the reason the bar exists.

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -6,10 +6,18 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"github.com/openrung/openrung/brokerapi"
 	"github.com/openrung/openrung/connectcore"
 )
+
+// allStatuses is every connection state the bars must handle.
+var allStatuses = []connectcore.Status{
+	connectcore.StatusDisconnected, connectcore.StatusPreparing,
+	connectcore.StatusConnecting, connectcore.StatusConnected,
+	connectcore.StatusDisconnecting, connectcore.StatusFailed,
+}
 
 func TestCountryFlag(t *testing.T) {
 	cases := map[string]string{
@@ -31,14 +39,14 @@ func TestCountryFlag(t *testing.T) {
 	}
 }
 
-func TestStatusViewShowsCountryFlag(t *testing.T) {
+func TestStatusDetailShowsCountryFlag(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.infoOK = true
 	m.info = connectcore.ConnectionInfo{Relay: brokerapi.RelayDescriptor{
 		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
 	}}
-	if view := m.statusView(); !strings.Contains(view, "JP🇯🇵") {
-		t.Fatalf("status view missing the country flag:\n%s", view)
+	if view := m.statusDetail(); !strings.Contains(view, "JP🇯🇵") {
+		t.Fatalf("status detail missing the country flag:\n%s", view)
 	}
 }
 
@@ -73,44 +81,85 @@ func TestRelaysViewShowsLabelOnlyWithFlag(t *testing.T) {
 	}
 }
 
-func TestFooterShowsConnectionSummaryWhenConnected(t *testing.T) {
+// Every row the old Status view carried has to survive somewhere: the bar's
+// detail track holds them all, and the session duration is additionally pinned
+// to the rendered bar's right edge.
+func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
-	m.width = 120 // wide enough for the full help and the summary together
+	m.width = 400 // wide enough that nothing is windowed away
 	label := "merry-falcon"
 	m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
 	m.infoOK = true
-	m.info = connectcore.ConnectionInfo{Relay: brokerapi.RelayDescriptor{
-		Label:            "merry-falcon",
-		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
-	}}
-	m.connectedAt = time.Now().Add(-90 * time.Second)
-	m.now = time.Now()
+	m.info = connectcore.ConnectionInfo{
+		Transport: "wss", FrontID: "front-a",
+		Relay: brokerapi.RelayDescriptor{
+			Label: "merry-falcon", NodeClass: brokerapi.NodeClassFoundation,
+			RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
+		},
+	}
+	m.connectedAt = m.now.Add(-90 * time.Second)
+	m.proxyEndpoint = "127.0.0.1:43210"
+	m.health = connectcore.Notice{Kind: connectcore.NoticeHealthProbe}
+	failure := "tunnel process exited"
+	m.state.LastError = &failure
 
-	footer := m.footerView()
-	for _, want := range []string{"merry-falcon 🇯🇵", "00:01:30", "q"} {
-		if !strings.Contains(footer, want) {
-			t.Fatalf("connected footer missing %q:\n%q", want, footer)
+	tr := m.tr()
+	detail := m.statusDetail()
+	for _, want := range []string{
+		tr.labelStatus, "connected", tr.labelRelay, "merry-falcon", "[foundation]",
+		tr.labelCountry, tr.labelTransport, "front-a", tr.labelHealth,
+		tr.labelCapture, tr.labelProxy, "127.0.0.1:43210", tr.labelBroker,
+		tr.labelTarget, tr.labelError, failure,
+	} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("status detail missing %q:\n%s", want, detail)
 		}
 	}
+	if bar := m.statusFooterView(); !strings.Contains(bar, "00:01:30") {
+		t.Errorf("status bar did not pin the session duration:\n%q", bar)
+	}
 
+	// Disconnected: no duration is pinned, and the key help never carries one.
 	m.state.Status = connectcore.StatusDisconnected
-	if footer := m.footerView(); strings.Contains(footer, "merry-falcon") || strings.Contains(footer, "00:01:30") {
-		t.Fatalf("disconnected footer still shows the session summary:\n%q", footer)
+	m.connectedAt = time.Time{}
+	if bar := m.statusFooterView(); strings.Contains(bar, "00:01:30") {
+		t.Errorf("disconnected status bar still pins a duration:\n%q", bar)
+	}
+	if footer := m.footerView(); strings.Contains(footer, "00:01:30") ||
+		strings.Contains(footer, "merry-falcon") {
+		t.Errorf("key help carries connection state that belongs on the bar:\n%q", footer)
 	}
 }
 
-// The footer's relay identity comes from ONE source: with a descriptor,
-// every field — name (down to the "relay <id>" fallback) and flag — is the
-// descriptor's; the state label appears only with no descriptor at all. A
-// failover updates the state label before the next info poll, so any mixing
-// pairs the new relay's name with the old relay's flag.
-func TestFooterIdentityIsSingleSourced(t *testing.T) {
+// The connection signal moved to the status bar, so the key help must render
+// with no background of its own — the theme paints it like any other line.
+func TestKeyHelpFooterIsNotColored(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	defer lipgloss.SetColorProfile(termenv.Ascii)
 	m := newTestModel(&fakeDriver{})
-	m.width = 120
+	m.width = 100
+	for _, status := range allStatuses {
+		m.state = connectcore.State{Status: status}
+		if footer := m.footerView(); strings.Contains(footer, "\x1b[") {
+			t.Errorf("status %s: key help carries styling: %q", status, footer)
+		}
+		if bar := m.statusFooterView(); !strings.Contains(bar, "\x1b[") {
+			t.Errorf("status %s: status bar lost its connection color: %q", status, bar)
+		}
+	}
+}
+
+// Relay identity comes from ONE source: with a descriptor, both the name (down
+// to the "relay <id>" fallback) and the country are the descriptor's; the state
+// label appears only when there is no descriptor at all, and then without a
+// country. A failover updates the state label before the next info poll, so any
+// mixing would pair the new relay's name with the old relay's country.
+func TestStatusIdentityIsSingleSourced(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width = 400
 	newLabel := "Singapore"
 	m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &newLabel}
-	m.connectedAt = time.Now().Add(-time.Minute)
-	m.now = time.Now()
+	m.connectedAt = m.now.Add(-time.Minute)
 
 	// Stale descriptor: nameless, but still carrying the OLD country.
 	m.infoOK = true
@@ -118,58 +167,51 @@ func TestFooterIdentityIsSingleSourced(t *testing.T) {
 		ID:               "r9",
 		RelayGeoLocation: brokerapi.RelayGeoLocation{CountryCode: "jp"},
 	}}
-	footer := m.footerView()
-	if strings.Contains(footer, "Singapore") {
-		t.Fatalf("footer paired the state label with the descriptor's flag: %q", footer)
+	detail := m.statusDetail()
+	if strings.Contains(detail, "Singapore") {
+		t.Fatalf("status paired the state label with the descriptor's country: %q", detail)
 	}
-	if !strings.Contains(footer, "relay r9 🇯🇵") {
-		t.Fatalf("footer did not fall back to the descriptor's own identity: %q", footer)
+	for _, want := range []string{"relay r9", "JP"} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("status did not use the descriptor's own identity (%q): %q", want, detail)
+		}
 	}
 
-	// No descriptor: the state label stands alone, flagless.
+	// No descriptor: the state label stands alone, with no country asserted.
 	m.infoOK = false
-	footer = m.footerView()
-	if !strings.Contains(footer, "Singapore") || strings.Contains(footer, "🇯🇵") {
-		t.Fatalf("descriptor-less footer should be the bare state label: %q", footer)
+	detail = m.statusDetail()
+	if !strings.Contains(detail, "Singapore") {
+		t.Fatalf("descriptor-less status lost the state label: %q", detail)
+	}
+	if strings.Contains(detail, countryFlagFor("darwin", "jp")) {
+		t.Fatalf("descriptor-less status still asserts a country: %q", detail)
 	}
 }
 
-// A narrow connected footer shares the line between a scrolling help lane and
-// the fixed session duration. The relay label yields before either one.
-func TestFooterMarqueeSharesNarrowTerminalWithDuration(t *testing.T) {
-	m := newTestModel(&fakeDriver{})
-	m.width = 30
-	label := "merry-falcon"
-	m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
-	m.startedAt = time.Unix(0, 0)
-	m.connectedAt = m.startedAt.Add(-time.Minute)
-	m.now = m.startedAt
+// However narrow the terminal, and at every marquee phase, the status bar keeps
+// the session duration pinned to its right edge: the detail track is what
+// yields. That corner glance is the reason the bar exists.
+func TestStatusBarKeepsDurationPinnedWhileScrolling(t *testing.T) {
+	for _, width := range []int{20, 30, 60, 80} {
+		m := newTestModel(&fakeDriver{})
+		m.width = width
+		label := "merry-falcon"
+		m.state = connectcore.State{Status: connectcore.StatusConnected, RelayLabel: &label}
+		m.startedAt = time.Unix(0, 0)
+		m.connectedAt = m.startedAt.Add(-time.Minute)
 
-	footer := m.footerView()
-	if !strings.Contains(footer, "00:01:00") {
-		t.Fatalf("narrow footer dropped the session duration:\n%q", footer)
-	}
-	if strings.Contains(footer, "merry-falcon") {
-		t.Fatalf("relay label should yield to help and duration:\n%q", footer)
-	}
-	if w := lipgloss.Width(footer); w > m.width {
-		t.Fatalf("narrow footer is %d cells wide, max %d: %q", w, m.width, footer)
-	}
-
-	seenLanguage := false
-	cycle := footerMarqueePause + lipgloss.Width(m.tr().helpGlobal) + lipgloss.Width(footerMarqueeGap)
-	for step := 0; step < cycle; step++ {
-		m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
-		footer = m.footerView()
-		if duration := formatDuration(m.now.Sub(m.connectedAt)); !strings.Contains(footer, duration) {
-			t.Fatalf("marquee step %d dropped the duration: %q", step, footer)
+		steps := footerMarqueePause + lipgloss.Width(m.statusDetail()) +
+			lipgloss.Width(footerMarqueeGap) + 2
+		for step := 0; step < steps; step++ {
+			m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
+			bar := m.statusFooterView()
+			if want := formatDuration(m.now.Sub(m.connectedAt)); !strings.Contains(bar, want) {
+				t.Fatalf("w=%d step=%d: status bar dropped %q: %q", width, step, want, bar)
+			}
+			if w := lipgloss.Width(bar); w > width {
+				t.Fatalf("w=%d step=%d: status bar is %d cells: %q", width, step, w, bar)
+			}
 		}
-		if strings.Contains(footer, languageKeyHelp) {
-			seenLanguage = true
-		}
-	}
-	if !seenLanguage {
-		t.Fatal("one marquee cycle never revealed the complete language control")
 	}
 }
 
@@ -197,9 +239,14 @@ func TestFooterMarqueeHoldsItsWidthAtEveryPhase(t *testing.T) {
 						lipgloss.Width(m.tr().helpRelays) + lipgloss.Width(footerMarqueeGap) + 2
 					for step := 0; step < steps; step++ {
 						m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
-						if w := lipgloss.Width(m.footerView()); w > width {
-							t.Fatalf("w=%d %s lang=%d conn=%t step=%d: footer is %d cells",
-								width, names[v], lang, connected, step, w)
+						for bar, got := range map[string]string{
+							"help":   m.footerView(),
+							"status": m.statusFooterView(),
+						} {
+							if w := lipgloss.Width(got); w > width {
+								t.Fatalf("w=%d %s lang=%d conn=%t step=%d: %s bar is %d cells",
+									width, names[v], lang, connected, step, bar, w)
+							}
 						}
 					}
 				}
@@ -271,8 +318,12 @@ func TestHeaderAndFooterNeverExceedNarrowWidths(t *testing.T) {
 				if w := lipgloss.Width(footer); w > width {
 					t.Errorf("width %d lang %d status %s: footer is %d cells wide", width, lang, status, w)
 				}
-				if status == connectcore.StatusConnected && !strings.Contains(footer, "00:01:00") {
-					t.Errorf("width %d lang %d: footer lost the session duration: %q", width, lang, footer)
+				bar := m.statusFooterView()
+				if w := lipgloss.Width(bar); w > width {
+					t.Errorf("width %d lang %d status %s: status bar is %d cells wide", width, lang, status, w)
+				}
+				if status == connectcore.StatusConnected && !strings.Contains(bar, "00:01:00") {
+					t.Errorf("width %d lang %d: status bar lost the session duration: %q", width, lang, bar)
 				}
 			}
 		}
@@ -437,7 +488,7 @@ func TestSettingsOffersNoTargetFields(t *testing.T) {
 }
 
 func TestFooterStyleCoversEveryStatus(t *testing.T) {
-	for status := range statusStyles {
+	for _, status := range allStatuses {
 		if _, ok := footerStyles[status]; !ok {
 			t.Errorf("footerStyles missing %q", status)
 		}

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -153,8 +153,8 @@ func TestFooterSummaryWinsOnNarrowTerminals(t *testing.T) {
 // Header and footer each budget exactly one line, so on a narrow terminal
 // they must shed content instead of wrapping — in every language and every
 // connection state, summary or not. What they shed follows priority: the
-// header keeps the active tab and the language control over the title and
-// inactive tabs, and the footer keeps the session duration over the label.
+// header keeps the active tab over the title and inactive tabs, and the
+// footer keeps the session duration over the label.
 func TestHeaderAndFooterNeverExceedNarrowWidths(t *testing.T) {
 	m := newTestModel(&fakeDriver{})
 	m.view = viewSettings
@@ -174,9 +174,6 @@ func TestHeaderAndFooterNeverExceedNarrowWidths(t *testing.T) {
 				}
 				if !strings.Contains(header, m.tr().tabs[viewSettings]) {
 					t.Errorf("width %d lang %d: header dropped the active tab: %q", width, lang, header)
-				}
-				if width >= 40 && !strings.Contains(header, languageTabLabel) {
-					t.Errorf("width %d lang %d: header dropped the language control: %q", width, lang, header)
 				}
 				footer := m.footerView()
 				if w := lipgloss.Width(footer); w > width {

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -217,6 +217,91 @@ func TestRelayRowsAlignWithCJKLabels(t *testing.T) {
 	}
 }
 
+// The brand mark sits whole in the bottom-right corner of every view, its
+// last row on the last body line — directly above the status bar — and never
+// pushes a line past the terminal width.
+func TestBrandMarkOnEveryView(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width, m.height = 100, 30
+	for v := viewID(0); v < viewCount; v++ {
+		m.view = v
+		view := m.View()
+		for _, artLine := range openrungArt {
+			if !strings.Contains(view, artLine) {
+				t.Fatalf("view %d missing brand-mark row %q:\n%s", v, artLine, view)
+			}
+		}
+		lines := strings.Split(view, "\n")
+		for i, line := range lines {
+			if w := lipgloss.Width(line); w > m.width {
+				t.Errorf("view %d line %d is %d cells wide, max %d", v, i, w, m.width)
+			}
+		}
+		last := lines[len(lines)-1-footerHeight] // the last body line
+		if !strings.HasSuffix(last, openrungArt[len(openrungArt)-1]) {
+			t.Fatalf("view %d: brand mark not on the last body line:\n%q", v, last)
+		}
+		if w := lipgloss.Width(last); w != m.width-brandMargin {
+			t.Errorf("view %d: brand mark ends at cell %d, want %d (right-aligned)", v, w, m.width-brandMargin)
+		}
+	}
+}
+
+// A terminal too narrow or too short for the mark drops it entirely — a torn
+// or crowding mark is worse than none.
+func TestBrandMarkHiddenOnSmallTerminals(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width = lipgloss.Width(openrungArt[0]) + 3 // below the mark plus its clearance
+	if view := m.View(); strings.Contains(view, openrungArt[0]) {
+		t.Fatalf("narrow terminal still draws the brand mark:\n%s", view)
+	}
+	m.width, m.height = 100, len(openrungArt)+headerHeight+footerHeight+1 // one body row above the mark
+	if view := m.View(); strings.Contains(view, openrungArt[0]) {
+		t.Fatalf("short terminal still draws the brand mark:\n%s", view)
+	}
+}
+
+// The mark wins the corner over body content (it must sit on every view, the
+// logs included), and the cut under it is ANSI-aware so styled body lines are
+// never severed mid-escape-sequence.
+func TestBrandMarkWinsTheCornerOverContent(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.width, m.height = 60, 24
+	wide := errorStyle.Render(strings.Repeat("x", m.width)) // full-width AND styled
+	body := m.overlayBrandMark(fitLines(strings.Repeat(wide+"\n", 19)+wide, m.bodyHeight()))
+	lines := strings.Split(body, "\n")
+	for _, line := range lines[len(lines)-len(openrungArt):] {
+		if w := lipgloss.Width(line); w > m.width {
+			t.Errorf("overlaid line is %d cells wide, max %d: %q", w, m.width, line)
+		}
+	}
+	if !strings.Contains(body, openrungArt[0]) {
+		t.Fatalf("full-width content displaced the brand mark:\n%s", body)
+	}
+}
+
+// paintFrame lays the green-on-black base under every cell: lines pad to the
+// terminal width so the background reaches the right edge, and an inner
+// style's reset hands control back to the base, not the terminal defaults.
+func TestPaintFrameRepaintsDefaults(t *testing.T) {
+	frame := "plain\n\x1b[1mbold\x1b[0m tail"
+	lines := strings.Split(paintFrame(frame, 12), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("paintFrame changed the line count: %q", lines)
+	}
+	for i, line := range lines {
+		if !strings.HasPrefix(line, themeSeq) || !strings.HasSuffix(line, resetSeq) {
+			t.Errorf("line %d not wrapped in the theme base: %q", i, line)
+		}
+		if w := lipgloss.Width(line); w != 12 {
+			t.Errorf("line %d painted to %d cells, want the full 12", i, w)
+		}
+	}
+	if !strings.Contains(lines[1], resetSeq+themeSeq) {
+		t.Error("inner reset not re-opened with the theme base")
+	}
+}
+
 func TestFooterStyleCoversEveryStatus(t *testing.T) {
 	for status := range statusStyles {
 		if _, ok := footerStyles[status]; !ok {

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -333,7 +333,7 @@ func TestFooterMarqueeHoldsItsWidthAtEveryPhase(t *testing.T) {
 					}
 					// One full cycle: the pause, the whole track, and the gap.
 					steps := footerMarqueePause + lipgloss.Width(m.tr().helpGlobal) +
-						lipgloss.Width(m.tr().helpRelays) + lipgloss.Width(footerMarqueeGap) + 2
+						lipgloss.Width(footerMarqueeGap) + 2
 					for step := 0; step < steps; step++ {
 						m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
 						for bar, got := range map[string]string{
@@ -370,7 +370,7 @@ func TestFooterMarqueeRevealsLanguageToken(t *testing.T) {
 						m.connectedAt = m.startedAt.Add(-time.Minute)
 					}
 					steps := footerMarqueePause + lipgloss.Width(m.tr().helpGlobal) +
-						lipgloss.Width(m.tr().helpRelays) + lipgloss.Width(footerMarqueeGap) + 2
+						lipgloss.Width(footerMarqueeGap) + 2
 					seen := false
 					for step := 0; step < steps && !seen; step++ {
 						m.now = m.startedAt.Add(time.Duration(step) * footerMarqueeStep)
@@ -423,6 +423,102 @@ func TestHeaderAndFooterNeverExceedNarrowWidths(t *testing.T) {
 					t.Errorf("width %d lang %d: status bar lost the session duration: %q", width, lang, bar)
 				}
 			}
+		}
+	}
+}
+
+// The Relays list opens on an Auto select row: enter there connects ranked. It
+// carries the target marker whenever nothing is pinned, sits above every
+// relay, and survives an empty directory — the list is the only connect
+// control, so it must never be unreachable.
+func TestAutoSelectRowTopsTheRelayList(t *testing.T) {
+	m := newTestModel(&fakeDriver{})
+	m.view = viewRelays
+	m.refreshing = false
+	m.relays = []connectcore.DirectoryRelay{
+		{Relay: brokerapi.RelayDescriptor{ID: "r1", Label: "merry-falcon"}},
+	}
+	tr := m.tr()
+
+	view := m.relaysView()
+	autoAt, relayAt := strings.Index(view, tr.autoSelect), strings.Index(view, "merry-falcon")
+	if autoAt < 0 || relayAt < 0 || autoAt > relayAt {
+		t.Fatalf("Auto select row is not above the relays:\n%s", view)
+	}
+	rowOf := func(view, needle string) string {
+		for _, row := range strings.Split(view, "\n") {
+			if strings.Contains(row, needle) {
+				return row
+			}
+		}
+		t.Fatalf("no row contains %q:\n%s", needle, view)
+		return ""
+	}
+	// Untargeted: the marker sits on Auto select, since that is what the next
+	// connect does.
+	if !strings.Contains(rowOf(view, tr.autoSelect), tr.targetMarker) {
+		t.Fatalf("untargeted list does not mark Auto select:\n%s", view)
+	}
+	// Pinned: the marker moves to the pinned relay.
+	m.settings.target = connectcore.RelayTarget{RelayID: "r1"}
+	view = m.relaysView()
+	if strings.Contains(rowOf(view, tr.autoSelect), tr.targetMarker) {
+		t.Fatalf("pinned list still marks Auto select:\n%s", view)
+	}
+	if !strings.Contains(rowOf(view, "merry-falcon"), tr.targetMarker) {
+		t.Fatalf("pinned relay lost the target marker:\n%s", view)
+	}
+
+	m.relays = nil
+	if view := m.relaysView(); !strings.Contains(view, tr.autoSelect) {
+		t.Fatalf("empty directory dropped the Auto select row:\n%s", view)
+	}
+}
+
+// Once connected, the list itself marks the live relay: its row renders bold,
+// matched by the descriptor's ID, so "which one am I on" is answerable without
+// the status bar.
+func TestConnectedRelayRowRendersBold(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	defer lipgloss.SetColorProfile(termenv.Ascii)
+	m := newTestModel(&fakeDriver{})
+	m.view = viewRelays
+	m.refreshing = false
+	m.relays = []connectcore.DirectoryRelay{
+		{Relay: brokerapi.RelayDescriptor{ID: "r1", Label: "merry-falcon"}},
+		{Relay: brokerapi.RelayDescriptor{ID: "r2", Label: "quiet-meadow"}},
+	}
+	m.state = connectcore.State{Status: connectcore.StatusConnected}
+	m.infoOK = true
+	m.info = connectcore.ConnectionInfo{Relay: brokerapi.RelayDescriptor{ID: "r2", Label: "quiet-meadow"}}
+	// The cursor stays on Auto select: its bold "▸" must not blur the check on
+	// the relay rows below.
+
+	const bold = "\x1b[1m"
+	var connectedRow, otherRow string
+	for _, row := range strings.Split(m.relaysView(), "\n") {
+		switch {
+		case strings.Contains(row, "quiet-meadow"):
+			connectedRow = row
+		case strings.Contains(row, "merry-falcon"):
+			otherRow = row
+		}
+	}
+	if connectedRow == "" || otherRow == "" {
+		t.Fatalf("relay rows missing:\n%s", m.relaysView())
+	}
+	if !strings.Contains(connectedRow, bold) {
+		t.Fatalf("connected relay's row is not bold: %q", connectedRow)
+	}
+	if strings.Contains(otherRow, bold) {
+		t.Fatalf("unconnected relay's row is bold: %q", otherRow)
+	}
+
+	// Bold means CONNECTED, not selected or targeted: it goes with the session.
+	m.state.Status = connectcore.StatusDisconnected
+	for _, row := range strings.Split(m.relaysView(), "\n") {
+		if strings.Contains(row, "quiet-meadow") && strings.Contains(row, bold) {
+			t.Fatalf("disconnected list still bolds the old relay: %q", row)
 		}
 	}
 }

--- a/cmd/client/views_test.go
+++ b/cmd/client/views_test.go
@@ -126,7 +126,7 @@ func TestStatusDetailCarriesEveryStatusField(t *testing.T) {
 	// Nothing the bar states another way belongs in the scrolling track: the
 	// state is the bar's color, and the relay and its country are pinned. Any
 	// of them repeated here reads as a second, different relay.
-	for _, gone := range []string{tr.labelStatus, tr.labelCountry, "merry-falcon", "JP"} {
+	for _, gone := range []string{"Status", "Country", "merry-falcon", "JP"} {
 		if strings.Contains(detail, gone) {
 			t.Errorf("%q is duplicated into the scrolling detail:\n%s", gone, detail)
 		}

--- a/desktop-volunteer/scripts/package-linux.sh
+++ b/desktop-volunteer/scripts/package-linux.sh
@@ -22,8 +22,10 @@ if [[ -z "${XRAYBIN}" || ! -x "${XRAYBIN}" ]]; then
 fi
 
 export PATH="${PATH}:$(go env GOPATH)/bin"
-echo "==> wails build ${*:-}"
-wails build "$@"
+# -trimpath keeps the builder's GOMODCACHE paths (and with them the local
+# username, /Users/<name>/go/pkg/mod/...) out of the shipped binary.
+echo "==> wails build -trimpath ${*:-}"
+wails build -trimpath "$@"
 
 BIN="build/bin/OpenRungVolunteer"
 [[ -x "${BIN}" ]] || { echo "error: ${BIN} not found after build" >&2; exit 1; }

--- a/desktop-volunteer/scripts/package-macos.sh
+++ b/desktop-volunteer/scripts/package-macos.sh
@@ -22,8 +22,10 @@ fi
 
 export PATH="${PATH}:$(go env GOPATH)/bin"
 
-echo "==> wails build ${*:-}"
-wails build "$@"
+# -trimpath keeps the builder's GOMODCACHE paths (and with them the local
+# username, /Users/<name>/go/pkg/mod/...) out of the shipped binary.
+echo "==> wails build -trimpath ${*:-}"
+wails build -trimpath "$@"
 
 APP="build/bin/OpenRungVolunteer.app"
 RES="${APP}/Contents/Resources"

--- a/desktop-volunteer/scripts/package-windows.ps1
+++ b/desktop-volunteer/scripts/package-windows.ps1
@@ -17,8 +17,10 @@ if (-not $xray -or -not (Test-Path $xray)) {
 }
 
 $env:PATH = "$env:PATH;$(go env GOPATH)\bin"
-Write-Host "==> wails build $args"
-wails build @args
+# -trimpath keeps the builder's GOMODCACHE paths (and with them the local
+# username) out of the shipped binary.
+Write-Host "==> wails build -trimpath $args"
+wails build -trimpath @args
 
 $exe = 'build\bin\OpenRungVolunteer.exe'
 if (-not (Test-Path $exe)) { Write-Error "$exe not found after build"; exit 1 }

--- a/desktop/scripts/versioned-wails-build.mjs
+++ b/desktop/scripts/versioned-wails-build.mjs
@@ -114,6 +114,12 @@ export function versionedWailsBuildArgs(args, version) {
       continue;
     }
 
+    // -trimpath is injected below; swallow a caller's copy so the flag is
+    // not passed twice.
+    if (argument === '-trimpath' || argument === '--trimpath') {
+      continue;
+    }
+
     passthrough.push(argument);
   }
 
@@ -121,7 +127,11 @@ export function versionedWailsBuildArgs(args, version) {
   // caller cannot accidentally replace the version from desktop/VERSION.
   const versionLdflag = `-X ${appVersionVariable}=${version}`;
   const ldflags = [...callerLdflags.filter((value) => value.trim() !== ''), versionLdflag].join(' ');
-  return [...passthrough, '-tags', mergedBuildTags(callerTags), '-ldflags', ldflags];
+  // -trimpath on every build (Wails forwards it to go build): a default build
+  // embeds the builder's GOMODCACHE paths (/Users/<name>/go/pkg/mod/...) in
+  // the binary's debug data, leaking the local username into anything
+  // distributed. Injected here, like the tags, so no build path can lose it.
+  return [...passthrough, '-trimpath', '-tags', mergedBuildTags(callerTags), '-ldflags', ldflags];
 }
 
 function displayArgument(argument) {

--- a/desktop/scripts/versioned-wails-build.test.mjs
+++ b/desktop/scripts/versioned-wails-build.test.mjs
@@ -54,11 +54,27 @@ test('rejects drift between VERSION and the wails.json copy', () => {
 
 test('injects the app version while preserving other build arguments', () => {
   assert.deepEqual(versionedWailsBuildArgs(['-tags', 'webkit2_41'], '0.1.3'), [
+    '-trimpath',
     '-tags',
     'webkit2_41,with_utls,with_external_windivert',
     '-ldflags',
     '-X github.com/openrung/openrung/connectcore/client.appVersion=0.1.3',
   ]);
+});
+
+// A default go build embeds the builder's GOMODCACHE paths — and with them
+// the local username — in the binary's debug data. Every packaged build must
+// carry -trimpath, injected here so no packaging script can lose it, and a
+// caller passing it explicitly must not double the flag.
+test('every build carries -trimpath exactly once', () => {
+  for (const args of [[], ['-debug'], ['-trimpath'], ['--trimpath'], ['-trimpath', '-tags', 'webkit2_41']]) {
+    const built = versionedWailsBuildArgs(args, '0.1.3');
+    assert.equal(
+      built.filter((argument) => argument === '-trimpath' || argument === '--trimpath').length,
+      1,
+      `${JSON.stringify(args)} did not carry -trimpath exactly once: ${JSON.stringify(built)}`,
+    );
+  }
 });
 
 // The bundled sing-box engine is only reachable through a with_utls build, so
@@ -88,6 +104,7 @@ test('merges tags into one comma-joined value Wails accepts', () => {
   // A caller that already passes one of ours must not duplicate it.
   assert.equal(mergedBuildTags(['with_utls']), 'with_utls,with_external_windivert');
   assert.deepEqual(versionedWailsBuildArgs(['-tags', 'a', '-tags=b'], '0.1.3'), [
+    '-trimpath',
     '-tags',
     'a,b,with_utls,with_external_windivert',
     '-ldflags',
@@ -103,6 +120,7 @@ test('merges separate and equals-form caller ldflags before the app version', ()
     ),
     [
       '-debug',
+      '-trimpath',
       '-tags',
       'with_utls,with_external_windivert',
       '-ldflags',

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -166,9 +166,10 @@ go run ./cmd/client connect -broker http://localhost:8080
 
 Connecting is a keypress, not a flag: the client starts disconnected, and
 `enter` on the Relays list connects — to the highlighted relay, or ranked
-automatically via the **Auto select** row at the top of the list, which also
-clears any pinned target. Settings controls the broker and capture mode;
-`-relay-id` or `-relay-label` can seed a target at launch.
+automatically via the **Auto select** row at the top of the list. There is no
+stored relay target in the interactive client at all: what you highlight is
+what you get, every time. Settings controls the broker and capture mode;
+`-relay-id`/`-relay-label` apply to `-headless`, `check`, and `config` only.
 
 ### Views and keys
 
@@ -176,7 +177,7 @@ Three views, switched with `1`–`3`, `tab`, and `shift+tab`:
 
 | View | What it shows |
 | --- | --- |
-| **Relays** | The ranked relay directory — country, measured latency, and node class — under an **Auto select** row. `↑`/`↓` moves; `enter` connects to the highlighted row: a relay pins it, Auto select clears the pin and takes the ranked pick. The connected relay's row renders bold |
+| **Relays** | The ranked relay directory — country, measured latency, and node class — under an **Auto select** row. `↑`/`↓` moves; `enter` connects to the highlighted row: a relay connects to exactly that relay, Auto select takes the ranked pick. The connected relay's row renders bold |
 | **Logs** | Engine and sing-box output in a scrollable ring buffer |
 | **Settings** | Broker URL override, capture mode, and the shell proxy helper |
 
@@ -186,7 +187,7 @@ are on rather than only the one you navigated to. It carries everything the
 old Status view did — state, relay and its foundation/volunteer class,
 country, transport path (direct, punched, or WSS front), health-probe state,
 the latest failover or fallback activity, capture mode with its local proxy
-endpoint, broker, target, and the last error — on one line that scrolls
+endpoint, broker, and the last error — on one line that scrolls
 horizontally when it overflows. While connected, the relay label with its
 country flag and the session duration are pinned to the bar's right edge
 instead of scrolling, so a glance at the corner always answers "to what" and
@@ -326,7 +327,9 @@ the system proxy. `check` and `config` are fetch-and-print only: they open no
 telemetry session and start no tunnel.
 
 Common flags: `-broker` (empty races the built-in HTTPS fronts), `-relay-id`
-and `-relay-label` to pin a target, `-relay-family` for `check`/`config`,
+and `-relay-label` to pin a relay (`-headless`, `check`, and `config`; the
+interactive client selects from the Relays list and warns if they are
+passed), `-relay-family` for `check`/`config`,
 `-mtu` for the TUN device, and `-sing-box` to substitute an external sing-box
 binary for the bundled engine. Run `go run ./cmd/client help` for the full
 list.

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -171,14 +171,27 @@ and `-relay-id` or `-relay-label` can seed one at launch.
 
 ### Views and keys
 
-Four views, switched with `1`–`4`, `tab`, and `shift+tab`:
+Three views, switched with `1`–`3`, `tab`, and `shift+tab`:
 
 | View | What it shows |
 | --- | --- |
-| **Status** | Connection state, relay label, country, foundation/volunteer class, transport path (direct, punched, or WSS front), session duration, health-probe state, the latest failover/fallback activity, and the capture mode with its local proxy endpoint |
 | **Relays** | The ranked relay directory — country, measured latency, and node class. `↑`/`↓` moves, `enter` pins the highlighted relay and connects to it, and `x` clears the pin |
 | **Logs** | Engine and sing-box output in a scrollable ring buffer |
 | **Settings** | Broker URL override, capture mode, and the shell proxy helper |
+
+There is no Status view. Connection state lives in the **status bar**, the
+line directly above the key help, so it is readable from whichever view you
+are on rather than only the one you navigated to. It carries everything the
+old Status view did — state, relay and its foundation/volunteer class,
+country, transport path (direct, punched, or WSS front), health-probe state,
+the latest failover or fallback activity, capture mode with its local proxy
+endpoint, broker, target, and the last error — on one line that scrolls
+horizontally when it overflows. The session duration is pinned to its right
+edge instead of scrolling, so a glance at the corner always answers "how
+long". The bar is the connection signal too: red while disconnected or
+failed, yellow through every transition, green while connected. The key-help
+line below it never changes color, so the bar is the only thing on screen
+that does.
 
 Global keys: `c` connect, `d` disconnect, `r` refresh the relay directory,
 `0` cycles English/中文/русский, and `q` (or `ctrl+c`) quit. The language key
@@ -186,10 +199,9 @@ is a digit on purpose: a Cyrillic or Greek layout carries no Latin letters, so
 a letter would be untypeable for the reader who most needs to switch away from
 a language they cannot read. Scrolling the Logs pager, moving with `↑`/`↓`, and
 acting with `enter` are left out of the footer help as conventions the reader
-already has. If the footer is still too narrow for every key, its help text
-scrolls horizontally while the connected-session summary stays fixed.
-Quitting tears down the tunnel, restores the system proxy, and flushes
-telemetry before the process exits.
+already has. If the help is still too narrow to fit, it scrolls the same way
+the status bar does. Quitting tears down the tunnel, restores the system proxy,
+and flushes telemetry before the process exits.
 
 In Settings, `↑`/`↓` moves between fields and `enter` acts on one: Broker URL
 opens an inline editor (`enter` applies, `esc` cancels), Mode toggles the

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -165,7 +165,9 @@ go run ./cmd/client connect -broker http://localhost:8080
 ```
 
 Connecting is a keypress, not a flag: the client starts disconnected, and `c`
-connects with whatever the Settings view holds.
+connects with the current broker, capture mode, and relay target. Settings
+controls the broker and capture mode; the Relays view pins or clears a target,
+and `-relay-id` or `-relay-label` can seed one at launch.
 
 ### Views and keys
 
@@ -174,17 +176,20 @@ Four views, switched with `1`–`4`, `tab`, and `shift+tab`:
 | View | What it shows |
 | --- | --- |
 | **Status** | Connection state, relay label, country, foundation/volunteer class, transport path (direct, punched, or WSS front), session duration, health-probe state, the latest failover/fallback activity, and the capture mode with its local proxy endpoint |
-| **Relays** | The ranked relay directory — country, measured latency, node class — plus the persisted recents row. `↑`/`↓` moves, `enter` pins the highlighted relay and connects to it, `x` clears the pin |
+| **Relays** | The ranked relay directory — country, measured latency, and node class. `↑`/`↓` moves, `enter` pins the highlighted relay and connects to it, and `x` clears the pin |
 | **Logs** | Engine and sing-box output in a scrollable ring buffer |
-| **Settings** | Broker URL override, capture mode, relay targeting by id/label/country, and the shell proxy helper |
+| **Settings** | Broker URL override, capture mode, and the shell proxy helper |
 
 Global keys: `c` connect, `d` disconnect, `r` refresh the relay directory,
-`q` (or `ctrl+c`) quit. Quitting tears down the tunnel, restores the system
-proxy, and flushes telemetry before the process exits.
+`.` cycles English/中文/русский (`。` works from a full-width CJK IME), and `q`
+(or `ctrl+c`) quit. If the footer is too narrow for every key, its help text
+scrolls horizontally while the connected-session summary stays fixed.
+Quitting tears down the tunnel, restores the system proxy, and flushes
+telemetry before the process exits.
 
-In Settings, `↑`/`↓` moves between fields and `enter` acts on one: text fields
-open an inline editor (`enter` applies, `esc` cancels), the Mode field toggles
-the capture mode, and the Shell proxy field prints the copyable commands.
+In Settings, `↑`/`↓` moves between fields and `enter` acts on one: Broker URL
+opens an inline editor (`enter` applies, `esc` cancels), Mode toggles the
+capture mode, and Shell proxy prints the copyable commands.
 
 ### Capture modes
 

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -164,10 +164,11 @@ settings. To work against a local broker:
 go run ./cmd/client connect -broker http://localhost:8080
 ```
 
-Connecting is a keypress, not a flag: the client starts disconnected, and `c`
-connects with the current broker, capture mode, and relay target. Settings
-controls the broker and capture mode; the Relays view pins or clears a target,
-and `-relay-id` or `-relay-label` can seed one at launch.
+Connecting is a keypress, not a flag: the client starts disconnected, and
+`enter` on the Relays list connects — to the highlighted relay, or ranked
+automatically via the **Auto select** row at the top of the list, which also
+clears any pinned target. Settings controls the broker and capture mode;
+`-relay-id` or `-relay-label` can seed a target at launch.
 
 ### Views and keys
 
@@ -175,7 +176,7 @@ Three views, switched with `1`–`3`, `tab`, and `shift+tab`:
 
 | View | What it shows |
 | --- | --- |
-| **Relays** | The ranked relay directory — country, measured latency, and node class. `↑`/`↓` moves, `enter` pins the highlighted relay and connects to it, and `x` clears the pin |
+| **Relays** | The ranked relay directory — country, measured latency, and node class — under an **Auto select** row. `↑`/`↓` moves; `enter` connects to the highlighted row: a relay pins it, Auto select clears the pin and takes the ranked pick. The connected relay's row renders bold |
 | **Logs** | Engine and sing-box output in a scrollable ring buffer |
 | **Settings** | Broker URL override, capture mode, and the shell proxy helper |
 
@@ -195,7 +196,7 @@ failed, yellow through every transition, green while connected. The key-help
 line below it never changes color, so the bar is the only thing on screen
 that does.
 
-Global keys: `c` connect, `d` disconnect, `r` refresh the relay directory,
+Global keys: `d` disconnect, `r` refresh the relay directory,
 `0` cycles English/中文/русский, and `q` (or `ctrl+c`) quit. The language key
 is a digit on purpose: a Cyrillic or Greek layout carries no Latin letters, so
 a letter would be untypeable for the reader who most needs to switch away from

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -186,9 +186,11 @@ old Status view did — state, relay and its foundation/volunteer class,
 country, transport path (direct, punched, or WSS front), health-probe state,
 the latest failover or fallback activity, capture mode with its local proxy
 endpoint, broker, target, and the last error — on one line that scrolls
-horizontally when it overflows. The session duration is pinned to its right
-edge instead of scrolling, so a glance at the corner always answers "how
-long". The bar is the connection signal too: red while disconnected or
+horizontally when it overflows. While connected, the relay label with its
+country flag and the session duration are pinned to the bar's right edge
+instead of scrolling, so a glance at the corner always answers "to what" and
+"for how long"; on a terminal too narrow for both, the label yields and the
+duration stays. The bar is the connection signal too: red while disconnected or
 failed, yellow through every transition, green while connected. The key-help
 line below it never changes color, so the bar is the only thing on screen
 that does.

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -181,8 +181,12 @@ Four views, switched with `1`–`4`, `tab`, and `shift+tab`:
 | **Settings** | Broker URL override, capture mode, and the shell proxy helper |
 
 Global keys: `c` connect, `d` disconnect, `r` refresh the relay directory,
-`.` cycles English/中文/русский (`。` works from a full-width CJK IME), and `q`
-(or `ctrl+c`) quit. If the footer is too narrow for every key, its help text
+`0` cycles English/中文/русский, and `q` (or `ctrl+c`) quit. The language key
+is a digit on purpose: a Cyrillic or Greek layout carries no Latin letters, so
+a letter would be untypeable for the reader who most needs to switch away from
+a language they cannot read. Scrolling the Logs pager, moving with `↑`/`↓`, and
+acting with `enter` are left out of the footer help as conventions the reader
+already has. If the footer is still too narrow for every key, its help text
 scrolls horizontally while the connected-session summary stays fixed.
 Quitting tears down the tunnel, restores the system proxy, and flushes
 telemetry before the process exits.

--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -326,10 +326,12 @@ non-zero on a terminal failure, and an interrupt disconnects cleanly, restoring
 the system proxy. `check` and `config` are fetch-and-print only: they open no
 telemetry session and start no tunnel.
 
-Common flags: `-broker` (empty races the built-in HTTPS fronts), `-relay-id`
-and `-relay-label` to pin a relay (`-headless`, `check`, and `config`; the
-interactive client selects from the Relays list and warns if they are
-passed), `-relay-family` for `check`/`config`,
+Common flags: `-broker` (empty races the built-in HTTPS fronts), `-relay-id`,
+`-relay-label`, and `-relay-country` to pin a relay or scope the connect to a
+country — a country target keeps mid-session failover within that country
+(`-headless`, `check`, and `config`; the interactive client selects from the
+Relays list and warns if they are passed), `-relay-family` for
+`check`/`config`,
 `-mtu` for the TUN device, and `-sing-box` to substitute an external sing-box
 binary for the bundled engine. Run `go run ./cmd/client help` for the full
 list.

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/yamux v0.1.2
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/muesli/termenv v0.16.0
 	github.com/openrung/openrung/brokerapi v0.5.0
 	github.com/openrung/openrung/connectcore v0.0.0
 	github.com/openrung/openrung/punchcore v0.1.0
@@ -44,7 +46,6 @@ require (
 	github.com/caddyserver/certmagic v0.25.3-0.20260421143802-60d9d8b415d6 // indirect
 	github.com/caddyserver/zerossl v0.1.5 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
@@ -114,7 +115,6 @@ require (
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/openai/openai-go/v3 v3.26.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pion/dtls/v3 v3.1.5 // indirect


### PR DESCRIPTION
Reskins the terminal client as an old-terminal display and trims its chrome down to what a TUI actually needs. Four commits, all confined to `cmd/client`.

## Green-on-black theme

`paintFrame` lays an old-terminal base — green text on a black background — under the composed frame:

- Every line pads to the full terminal width, so the black background reaches the right edge on all rows (including blank separators). The frame is exactly `m.height` lines, so the whole alt screen is painted.
- Every reset an inner style emits is re-opened with the base sequence, so text after a styled segment falls back to green-on-black instead of the terminal's own defaults. Verified against real frames: lipgloss v1.1.0 emits only `\x1b[0m`, and every occurrence in all four views is followed by the base.
- Styles that deliberately pick their colors are untouched: the solid status bar keeps its red/yellow/green connection signal, and errors, notes, and badges keep theirs.
- Skipped on the Ascii color profile (dumb terminals, `NO_COLOR` — and tests, which keep comparing unstyled output).

## Corner brand mark

An ASCII-art **OPENRUNG** (figlet small, 42×4) is drawn at the bottom right of every view, just above the status bar:

```
                                                 ___  ___  ___ _  _ ___  _   _ _  _  ___
                                                / _ \| _ \| __| \| | _ \| | | | \| |/ __|
                                               | (_) |  _/| _|| .` |   /| |_| | .` | (_ |
                                                \___/|_|  |___|_|\_|_|_\ \___/|_|\_|\___|
```

It renders whole or not at all — hidden on terminals too narrow or short to spare the corner — and the cut underneath is ANSI-aware (`ansi.Truncate`), which closes any open style at the cut so the mark cannot inherit the body's color.

**Known limitation, see Follow-ups:** the mark currently *overlays* the body, so it occludes content rather than yielding to it.

## Language switch: `.`, and out of the tab bar

The tab bar now holds only views. The language cycles in place on a **period** — `5` and the header's `5 languages/中文/языки` slot are both gone — and the footer advertises it with the same trilingual token in every translation, `. lang/语言/язык`.

Punctuation rather than a letter, because this key must be *typeable* in the same situation it must be *readable*. Cyrillic (ЙЦУКЕН), Greek, Hebrew, and Arabic layouts carry no Latin letters at all, so a letter binding is unreachable without first switching the OS layout — exactly what a user stuck in a language they cannot read is least able to work out. A period sits on essentially every layout (unshifted on ЙЦУКЕН and QWERTZ, shifted on AZERTY, all delivering `.`), the same property that made the old `5` safe. `。` is bound alongside it for a CJK IME in full-width punctuation mode.

Because broker URLs are mostly periods, there is a test pinning that a focused settings editor swallows the key as text instead of cycling the UI out from under the value being typed.

## Chrome trimmed

- Footer help drops `1-4/tab views` — the tab bar already shows them.
- The Relays view drops the recents line. The engine still persists recents (desktop parity); the TUI just stops rendering them.
- Settings drops the target relay id / label / country editors, and is down to broker, mode, and the shell helper. Targeting stays where it is useful: `enter` on a relay in the Relays view pins it, `x` clears, CLI flags still apply, and the Status view's Target row shows what is pinned.

## Tests

Brand mark placement and right-alignment on all four views; whole-or-nothing hiding on small terminals; the ANSI-aware cut against full-width styled content; `paintFrame` padding, base-wrapping, and reset re-opening; the period cycling all three languages (and `。` doing the same, and `5` no longer doing anything); the period staying text inside an editor; and Settings offering no target fields.

`go build ./... && go test ./...` green across the module (`connectcore` untouched). `go mod tidy` promoted `charmbracelet/x/ansi` and `muesli/termenv` from indirect to direct — no new dependencies.

## Follow-ups (reviewed, not yet fixed)

A review of this branch turned up two issues worth fixing before or soon after merge. Both are real; neither is addressed here.

1. **The brand mark occludes load-bearing content.** It overwrites a 43×4 region of the body, so at 80 columns the last four relay rows lose their LATENCY, CLASS and `▸ target` columns — including on the *selected* row when the cursor sits at the tail — and the four newest log lines are cut at 36 cells. Because the log viewport auto-follows to the bottom, the newest lines are always under the mark. This truncates the sing-box crash line that #151 added quoting for. Measured widths that would clear the mark: 116 columns for Relays, 126 for Settings; the Logs view cannot be fixed by width at all, since its lines are unbounded. The durable fix is to *reserve* the band — subtract its rows from `bodyHeight` and draw it in its own strip — so the mark costs 4 rows of content instead of 43×4 cells of content.

2. **Footer truncation can hide the language token.** Per-view help is prepended to the global help, so the trilingual token is the first thing lost to truncation: at 80 columns while connected in Russian it is absent from all four views, and even at 120 it is absent from Relays. `TestFooterAlwaysShowsTheTrilingualLanguageHelp` passes only because it exercises the status view, disconnected — the one configuration where the token survives.

Lower priority, from the same review: `describeTarget`'s Country branch and `tr.targetCountry` in three languages are now unreachable (no production writer of `RelayTarget.Country` remains); `paintFrame` and `overlayBrandMark` each re-open-code the existing `padCell`; `settingsFieldValue`/`applySettingsField` are now single-field wrappers; `runTUI`'s comments still justify state seeding by recents that nothing renders; and the pre-existing `truncateWidth` is exactly `ansi.Truncate(s, w, "…")`, which this PR makes a direct dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
