### PR TITLE
Halve the dashboard's window scans and page sessions in two phases

### DIFF
--- a/internal/broker/postgres_telemetry_query.go
+++ b/internal/broker/postgres_telemetry_query.go
@@ -26,61 +26,78 @@ import (
 // NULLIF mirrors the accumulator's plain `!= ""` checks; the btrim CASEs
 // mirror firstNonEmpty, which trims for the emptiness test but keeps the
 // original value.
-const telemetryEventsCTE = `
+//
+// telemetryEventsCTEWith builds the CTE with an optional extra join (the
+// two-phase session page narrows it to one page of sessions); the join clause
+// is a compile-time string from this file, never input.
+//
+// The per-field `payload->'attributes'->>...` chains look redundant but are
+// not worth collapsing into a jsonb_to_record lateral: jsonb is stored already
+// parsed, so each `->` is a binary search over the object rather than a
+// re-parse, and measuring both shapes against production telemetry made the
+// lateral version SLOWER (18.6s vs 17.1s for the overview). The lateral's
+// function-scan cost estimate is also low enough to talk the planner out of
+// parallelising the scan, which is where the rest of the loss came from.
+func telemetryEventsCTEWith(join string) string {
+	return `
 events AS (
 	SELECT
-		received_at,
-		occurred_at,
-		event,
-		client_id,
-		session_id,
-		COALESCE(relay_id, '') AS relay_id,
-		COALESCE(relay_node_class, '') AS relay_node_class,
-		host(source_ip) AS source_ip,
+		e.received_at,
+		e.occurred_at,
+		e.event,
+		e.client_id,
+		e.session_id,
+		COALESCE(e.relay_id, '') AS relay_id,
+		COALESCE(e.relay_node_class, '') AS relay_node_class,
+		host(e.source_ip) AS source_ip,
 		-- failure_stage/detail use NULLIF so the sessions CTE IS NOT NULL
 		-- filter mirrors the accumulator's plain != "" test (a present-but-
 		-- empty later connection_failed must not clobber an earlier non-empty
 		-- value). NULLIF leaves the failure_stages count unchanged: its CASE
 		-- already treats '' as 'unknown'.
-		NULLIF(payload->'attributes'->>'failure_stage', '') AS failure_stage,
-		NULLIF(payload->'attributes'->>'failure_detail', '') AS failure_detail,
+		NULLIF(e.payload->'attributes'->>'failure_stage', '') AS failure_stage,
+		NULLIF(e.payload->'attributes'->>'failure_detail', '') AS failure_detail,
 		-- failure_reason mirrors firstNonEmpty(failure_reason, error_type):
 		-- the btrim CASE tests the trimmed value but keeps the original, and
 		-- yields NULL when both are empty (like country above).
 		CASE
-			WHEN btrim(COALESCE(payload->'attributes'->>'failure_reason', '')) <> '' THEN payload->'attributes'->>'failure_reason'
-			WHEN btrim(COALESCE(payload->'attributes'->>'error_type', '')) <> '' THEN payload->'attributes'->>'error_type'
+			WHEN btrim(COALESCE(e.payload->'attributes'->>'failure_reason', '')) <> '' THEN e.payload->'attributes'->>'failure_reason'
+			WHEN btrim(COALESCE(e.payload->'attributes'->>'error_type', '')) <> '' THEN e.payload->'attributes'->>'error_type'
 		END AS failure_reason,
 		COALESCE(
-			NULLIF(payload->'attributes'->>'operating_system', ''),
-			'iOS ' || NULLIF(payload->'attributes'->>'ios_version', ''),
-			'Android (API ' || NULLIF(payload->'attributes'->>'android_api', '') || ')'
+			NULLIF(e.payload->'attributes'->>'operating_system', ''),
+			'iOS ' || NULLIF(e.payload->'attributes'->>'ios_version', ''),
+			'Android (API ' || NULLIF(e.payload->'attributes'->>'android_api', '') || ')'
 		) AS os_label,
-		NULLIF(payload->'attributes'->>'device_manufacturer', '') AS device_manufacturer,
-		NULLIF(payload->'attributes'->>'device_model', '') AS device_model,
-		NULLIF(payload->'attributes'->>'app_version', '') AS app_version,
+		NULLIF(e.payload->'attributes'->>'device_manufacturer', '') AS device_manufacturer,
+		NULLIF(e.payload->'attributes'->>'device_model', '') AS device_model,
+		NULLIF(e.payload->'attributes'->>'app_version', '') AS app_version,
 		CASE
-			WHEN btrim(COALESCE(payload->'attributes'->>'country', '')) <> '' THEN payload->'attributes'->>'country'
-			WHEN btrim(COALESCE(payload->'attributes'->>'country_code', '')) <> '' THEN payload->'attributes'->>'country_code'
+			WHEN btrim(COALESCE(e.payload->'attributes'->>'country', '')) <> '' THEN e.payload->'attributes'->>'country'
+			WHEN btrim(COALESCE(e.payload->'attributes'->>'country_code', '')) <> '' THEN e.payload->'attributes'->>'country_code'
 		END AS country,
-		NULLIF(payload->'attributes'->>'city', '') AS city,
-		NULLIF(payload->'attributes'->>'organization', '') AS organization,
-		NULLIF(payload->'attributes'->>'asn', '') AS asn,
-		NULLIF(payload->'attributes'->>'isp', '') AS isp,
-		NULLIF(payload->'attributes'->>'client_ip', '') AS reported_client_ip,
-		(payload->'measurements'->>'session_duration_ms')::bigint AS session_duration_ms,
-		(payload->'measurements'->>'bytes_sent')::bigint AS bytes_sent,
-		(payload->'measurements'->>'bytes_received')::bigint AS bytes_received,
-		(payload->'measurements'->>'download_mbps_milli')::bigint AS download_mbps_milli,
-		(payload->'measurements'->>'time_to_first_byte_ms')::bigint AS ttfb_ms
-	FROM telemetry_events
+		NULLIF(e.payload->'attributes'->>'city', '') AS city,
+		NULLIF(e.payload->'attributes'->>'organization', '') AS organization,
+		NULLIF(e.payload->'attributes'->>'asn', '') AS asn,
+		NULLIF(e.payload->'attributes'->>'isp', '') AS isp,
+		NULLIF(e.payload->'attributes'->>'client_ip', '') AS reported_client_ip,
+		(e.payload->'measurements'->>'session_duration_ms')::bigint AS session_duration_ms,
+		(e.payload->'measurements'->>'bytes_sent')::bigint AS bytes_sent,
+		(e.payload->'measurements'->>'bytes_received')::bigint AS bytes_received,
+		(e.payload->'measurements'->>'download_mbps_milli')::bigint AS download_mbps_milli,
+		(e.payload->'measurements'->>'time_to_first_byte_ms')::bigint AS ttfb_ms
+	FROM telemetry_events e
+	` + join + `
 	-- application_connection is excluded belt-and-braces: since the hourly
 	-- rollup landed those events are never inserted as rows, but partitions
 	-- written before the rollup (or by an older broker) may still hold them,
 	-- and at production volume they were ~95% of all rows.
-	WHERE received_at > $1 AND occurred_at >= $2 AND occurred_at <= $3
-		AND event <> 'application_connection'
+	WHERE e.received_at > $1 AND e.occurred_at >= $2 AND e.occurred_at <= $3
+		AND e.event <> 'application_connection'
 )`
+}
+
+var telemetryEventsCTE = telemetryEventsCTEWith("")
 
 // The `latest non-empty wins` aggregations order by (received_at, occurred_at)
 // as the canonical event order. The in-memory accumulator iterates records in
@@ -139,16 +156,18 @@ const telemetrySessionISPLabel = `
 		ELSE ''
 	END`
 
-// telemetryEventAggregatesQuery collapses every event-grain panel — trend, the
-// event-level count groups, relay failure reasons, and speed tests — into a
-// single scan of the events CTE. Because all branches reference `events`, the
-// CTE is materialized once, so the ~25-field JSONB extraction runs one time per
-// overview rather than once per panel. Rows are discriminated by `kind` and
-// share a generic column shape so heterogeneous panels can travel together:
+// telemetryOverviewAggregatesQuery collapses the WHOLE overview — headline
+// totals, every session-grain and event-grain count panel, trend, relay
+// failure reasons, retained relay classes, and speed tests — into a single
+// statement. The events CTE (and its payload extraction) materializes once and
+// the sessions CTE once, where the previous two-statement split scanned and
+// extracted the window's events twice per overview. Rows are discriminated by
+// `kind` and share a generic column shape so heterogeneous panels can travel
+// together:
 //
 //	kind  the panel this row feeds
 //	k1    first text key    — count name / relay_id; NULL for trend
-//	k2    second text key   — relay failure reason; NULL otherwise
+//	k2    second text key   — relay failure reason / retained class; NULL otherwise
 //	v1    first value       — count, tests, or (for trend) the hour as epoch
 //	                          seconds in a bigint
 //	v2..v4  extra values    — trend success/failure counts, speed-test sums
@@ -156,18 +175,55 @@ const telemetrySessionISPLabel = `
 // The Go dispatcher feeds each kind through the same helpers the in-memory path
 // uses (trend bucket filling, sortedCounts, topRelaySummaries, sortSpeedTests)
 // so ranking and tiebreaks stay byte-identical.
-const telemetryEventAggregatesQuery = `WITH ` + telemetryEventsCTE + `
+var telemetryOverviewAggregatesQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
+-- totals: one row per headline metric. clients counts distinct client_ids over
+-- the raw events (a client seen only outside a session still counts), matching
+-- the in-memory clients set; the rest reduce the sessions CTE, and
+-- active_clients is the distinct-client count among active sessions.
+SELECT 'totals'::text AS kind, 'clients'::text AS k1, NULL::text AS k2,
+	COUNT(DISTINCT client_id)::bigint AS v1, NULL::bigint AS v2, NULL::bigint AS v3, NULL::bigint AS v4
+FROM events
+UNION ALL
+SELECT 'totals', 'sessions', NULL, COUNT(*), NULL, NULL, NULL FROM sessions
+UNION ALL
+SELECT 'totals', 'attempts', NULL, COUNT(*) FILTER (WHERE attempted), NULL, NULL, NULL FROM sessions
+UNION ALL
+SELECT 'totals', 'successes', NULL, COUNT(*) FILTER (WHERE succeeded), NULL, NULL, NULL FROM sessions
+UNION ALL
+SELECT 'totals', 'failures', NULL, COUNT(*) FILTER (WHERE failed), NULL, NULL, NULL FROM sessions
+UNION ALL
+SELECT 'totals', 'active_clients', NULL, COUNT(DISTINCT client_id) FILTER (WHERE active), NULL, NULL, NULL FROM sessions
+UNION ALL
+SELECT 'totals', 'active_sessions', NULL, COUNT(*) FILTER (WHERE active), NULL, NULL, NULL FROM sessions
+UNION ALL
+-- session-grain count groups, one distinct value per session (btrim mirrors the
+-- accumulator's non-empty test); sortedCounts ranks and truncates each kind.
+SELECT 'top_countries', country, NULL, COUNT(*), NULL, NULL, NULL FROM sessions WHERE btrim(country) <> '' GROUP BY country
+UNION ALL
+SELECT 'top_cities', city, NULL, COUNT(*), NULL, NULL, NULL FROM sessions WHERE btrim(city) <> '' GROUP BY city
+UNION ALL
+SELECT 'top_isps', ` + telemetrySessionISPLabel + `, NULL, COUNT(*), NULL, NULL, NULL
+FROM sessions WHERE btrim(` + telemetrySessionISPLabel + `) <> '' GROUP BY 2
+UNION ALL
+SELECT 'active_by_relay', relay_id, NULL, COUNT(*), NULL, NULL, NULL FROM sessions WHERE active AND btrim(relay_id) <> '' GROUP BY relay_id
+UNION ALL
+SELECT 'active_by_country', country, NULL, COUNT(*), NULL, NULL, NULL FROM sessions WHERE active AND btrim(country) <> '' GROUP BY country
+UNION ALL
+SELECT 'active_by_city', city, NULL, COUNT(*), NULL, NULL, NULL FROM sessions WHERE active AND btrim(city) <> '' GROUP BY city
+UNION ALL
+SELECT 'active_by_isp', ` + telemetrySessionISPLabel + `, NULL, COUNT(*), NULL, NULL, NULL
+FROM sessions WHERE active AND btrim(` + telemetrySessionISPLabel + `) <> '' GROUP BY 2
+UNION ALL
+SELECT 'active_by_os', operating_system, NULL, COUNT(*), NULL, NULL, NULL FROM sessions WHERE active AND btrim(operating_system) <> '' GROUP BY operating_system
+UNION ALL
 -- trend: hourly attempt/success/failure counts. The bucket key rides in v1 as
 -- epoch seconds (date_trunc is UTC-aligned like the Go buckets); the caller
 -- rebuilds the hour and slots it by index into the pre-filled bucket slice.
-SELECT
-	'trend'::text AS kind,
-	NULL::text AS k1,
-	NULL::text AS k2,
-	extract(epoch FROM date_trunc('hour', occurred_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::bigint AS v1,
-	COUNT(*) FILTER (WHERE event = 'connection_attempted')::bigint AS v2,
-	COUNT(*) FILTER (WHERE event = 'connection_succeeded')::bigint AS v3,
-	COUNT(*) FILTER (WHERE event = 'connection_failed')::bigint AS v4
+SELECT 'trend', NULL, NULL,
+	extract(epoch FROM date_trunc('hour', occurred_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::bigint,
+	COUNT(*) FILTER (WHERE event = 'connection_attempted')::bigint,
+	COUNT(*) FILTER (WHERE event = 'connection_succeeded')::bigint,
+	COUNT(*) FILTER (WHERE event = 'connection_failed')::bigint
 FROM events
 WHERE event IN ('connection_attempted', 'connection_succeeded', 'connection_failed')
 GROUP BY 4
@@ -177,7 +233,7 @@ UNION ALL
 -- ingestion and never stored as rows. The window edge is hour-granular (the
 -- truncated start hour is included whole), matching telemetryAppRollup's
 -- countsIn; the date_trunc runs in UTC like the trend buckets.
-SELECT 'top_applications', application, NULL::text, SUM(connections)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+SELECT 'top_applications', application, NULL, SUM(connections)::bigint, NULL, NULL, NULL
 FROM telemetry_app_counts
 WHERE hour >= date_trunc('hour', $2::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AND hour <= $3
 GROUP BY application
@@ -186,20 +242,20 @@ UNION ALL
 -- (name, count) pair that sortedCounts / topRelaySummaries rank and truncate.
 SELECT 'failure_stages',
 	CASE WHEN btrim(COALESCE(failure_stage, '')) <> '' THEN failure_stage ELSE 'unknown' END,
-	NULL::text, COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+	NULL, COUNT(*), NULL, NULL, NULL
 FROM events WHERE event = 'connection_failed' GROUP BY 2
 UNION ALL
 SELECT 'failure_reasons',
 	(CASE WHEN btrim(COALESCE(failure_stage, '')) <> '' THEN failure_stage ELSE 'unknown' END)
 		|| ' · ' ||
 		(CASE WHEN btrim(COALESCE(failure_reason, '')) <> '' THEN failure_reason ELSE 'unknown' END),
-	NULL::text, COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+	NULL, COUNT(*), NULL, NULL, NULL
 FROM events WHERE event = 'connection_failed' GROUP BY 2
 UNION ALL
-SELECT 'relay_successes', relay_id, NULL::text, COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+SELECT 'relay_successes', relay_id, NULL, COUNT(*), NULL, NULL, NULL
 FROM events WHERE event IN ('connection_succeeded', 'relay_failover') AND relay_id <> '' GROUP BY relay_id
 UNION ALL
-SELECT 'relay_failures', relay_id, NULL::text, COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+SELECT 'relay_failures', relay_id, NULL, COUNT(*), NULL, NULL, NULL
 FROM events WHERE event = 'relay_attempt_failed' AND relay_id <> '' GROUP BY relay_id
 UNION ALL
 -- relay_failure_reasons: per (relay_id, reason) counts feeding topFailureReason;
@@ -208,7 +264,7 @@ UNION ALL
 -- lexicographically in Go.
 SELECT 'relay_failure_reasons', relay_id,
 	CASE WHEN btrim(COALESCE(failure_reason, '')) <> '' THEN failure_reason ELSE 'unknown' END,
-	COUNT(*)::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+	COUNT(*), NULL, NULL, NULL
 FROM events WHERE event = 'relay_attempt_failed' AND relay_id <> '' GROUP BY 2, 3
 UNION ALL
 -- relay_classes: the broker-attested class retained with any event for this
@@ -217,73 +273,43 @@ UNION ALL
 SELECT 'relay_classes', relay_id,
 	(array_agg(relay_node_class ORDER BY received_at DESC, occurred_at DESC)
 		FILTER (WHERE relay_node_class <> ''))[1],
-	NULL::bigint, NULL::bigint, NULL::bigint, NULL::bigint
+	NULL, NULL, NULL, NULL
 FROM events WHERE relay_id <> '' GROUP BY relay_id
 UNION ALL
 -- speed_tests: per-relay test count plus the sums the caller averages. v1=tests,
 -- v2=Σ download_mbps_milli, v3=Σ ttfb_ms.
-SELECT 'speed_tests', relay_id, NULL::text,
-	COUNT(*)::bigint,
+SELECT 'speed_tests', relay_id, NULL,
+	COUNT(*),
 	SUM(COALESCE(download_mbps_milli, 0))::bigint,
 	SUM(COALESCE(ttfb_ms, 0))::bigint,
-	NULL::bigint
+	NULL
 FROM events WHERE event = 'speed_test_completed' AND relay_id <> '' GROUP BY relay_id`
 
-// telemetrySessionAggregatesQuery collapses the headline totals and every
-// session-grain count panel into one scan of the sessions CTE (itself one scan
-// of events). Both CTEs are referenced by several branches, so each materializes
-// once and the per-session array_agg work runs a single time per overview. Rows
-// share the (kind, name, count) shape of the event count groups, so
-// queryTelemetryCounts scans this query too; the totals ride along as
-// kind='totals' rows keyed by metric name.
-const telemetrySessionAggregatesQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
--- totals: one row per headline metric. clients counts distinct client_ids over
--- the raw events (a client seen only outside a session still counts), matching
--- the in-memory clients set; the rest reduce the sessions CTE, and
--- active_clients is the distinct-client count among active sessions.
-SELECT 'totals'::text AS kind, 'clients'::text AS name, COUNT(DISTINCT client_id)::bigint AS count FROM events
-UNION ALL
-SELECT 'totals', 'sessions', COUNT(*) FROM sessions
-UNION ALL
-SELECT 'totals', 'attempts', COUNT(*) FILTER (WHERE attempted) FROM sessions
-UNION ALL
-SELECT 'totals', 'successes', COUNT(*) FILTER (WHERE succeeded) FROM sessions
-UNION ALL
-SELECT 'totals', 'failures', COUNT(*) FILTER (WHERE failed) FROM sessions
-UNION ALL
-SELECT 'totals', 'active_clients', COUNT(DISTINCT client_id) FILTER (WHERE active) FROM sessions
-UNION ALL
-SELECT 'totals', 'active_sessions', COUNT(*) FILTER (WHERE active) FROM sessions
-UNION ALL
--- session-grain count groups, one distinct value per session (btrim mirrors the
--- accumulator's non-empty test); sortedCounts ranks and truncates each kind.
-SELECT 'top_countries', country, COUNT(*) FROM sessions WHERE btrim(country) <> '' GROUP BY country
-UNION ALL
-SELECT 'top_cities', city, COUNT(*) FROM sessions WHERE btrim(city) <> '' GROUP BY city
-UNION ALL
-SELECT 'top_isps', ` + telemetrySessionISPLabel + `, COUNT(*)
-FROM sessions WHERE btrim(` + telemetrySessionISPLabel + `) <> '' GROUP BY 2
-UNION ALL
-SELECT 'active_by_relay', relay_id, COUNT(*) FROM sessions WHERE active AND btrim(relay_id) <> '' GROUP BY relay_id
-UNION ALL
-SELECT 'active_by_country', country, COUNT(*) FROM sessions WHERE active AND btrim(country) <> '' GROUP BY country
-UNION ALL
-SELECT 'active_by_city', city, COUNT(*) FROM sessions WHERE active AND btrim(city) <> '' GROUP BY city
-UNION ALL
-SELECT 'active_by_isp', ` + telemetrySessionISPLabel + `, COUNT(*)
-FROM sessions WHERE active AND btrim(` + telemetrySessionISPLabel + `) <> '' GROUP BY 2
-UNION ALL
-SELECT 'active_by_os', operating_system, COUNT(*) FROM sessions WHERE active AND btrim(operating_system) <> '' GROUP BY operating_system`
-
-// The (last_seen_at DESC, session_id) order matches the in-memory sort so
-// pages stay stable across requests when batched uploads share a received_at.
-// COUNT(*) OVER () rides on every returned row: window functions are evaluated
-// before LIMIT/OFFSET, so it is the window's full session count, folding what
-// used to be a separate telemetrySessionCountQuery into this one statement. It
-// is absent only when the page itself is empty (offset at/past the end, or a
-// window with no sessions), which the caller handles by falling back to the
-// standalone count.
-const telemetrySessionPageQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
+// telemetrySessionPageQuery pages sessions in two phases so the expensive part
+// only ever touches one page. The `page` CTE ranks the window's sessions with
+// a slim scan that never reads the payload — (last_seen_at DESC, session_id),
+// the same order the in-memory querier sorts by, with MAX(received_at) exactly
+// the sessions CTE's last_seen_at — and applies LIMIT/OFFSET there. Only the
+// surviving page's events then flow through the payload extraction and the
+// per-session array_agg work, via the (session_id, occurred_at) index. The
+// COUNT(*) OVER () window function is evaluated after GROUP BY but before
+// LIMIT/OFFSET, so ranked_total is the window's full session count riding on
+// every returned row, folding what used to be a separate
+// telemetrySessionCountQuery into this one statement. It is absent only when
+// the page itself is empty (offset at/past the end, or a window with no
+// sessions), which the caller handles by falling back to the standalone count.
+var telemetrySessionPageQuery = `WITH page AS (
+	SELECT
+		session_id,
+		MAX(received_at) AS ranked_last_seen,
+		COUNT(*) OVER () AS ranked_total
+	FROM telemetry_events
+	WHERE received_at > $1 AND occurred_at >= $2 AND occurred_at <= $3
+		AND event <> 'application_connection'
+	GROUP BY session_id
+	ORDER BY ranked_last_seen DESC, session_id
+	LIMIT $5 OFFSET $6
+), ` + telemetryEventsCTEWith("JOIN page USING (session_id)") + `, ` + telemetrySessionsCTE + `
 SELECT
 	session_id, client_id, started_at, last_seen_at, relay_id, relay_node_class, operating_system,
 	device_manufacturer, device_model, app_version, country, city, organization, asn, isp,
@@ -291,15 +317,20 @@ SELECT
 	observed_client_ip, reported_client_ip, fallback_source_ip,
 	last_heartbeat_at, running_duration_ms, ended_duration_ms, bytes_sent, bytes_received,
 	attempted, succeeded, failed, terminal,
-	COUNT(*) OVER () AS total_count
+	page.ranked_total AS total_count
 FROM sessions
-ORDER BY last_seen_at DESC, session_id
-LIMIT $5 OFFSET $6`
+JOIN page USING (session_id)
+ORDER BY last_seen_at DESC, session_id`
 
 // telemetrySessionCountQuery is the empty-page fallback for the window count
-// that telemetrySessionPageQuery normally carries inline.
-const telemetrySessionCountQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `
-SELECT COUNT(*) FROM sessions`
+// that telemetrySessionPageQuery normally carries inline. It needs no payload
+// fields, so it counts distinct sessions directly off the table; it takes the
+// three event-window parameters only.
+const telemetrySessionCountQuery = `
+SELECT COUNT(DISTINCT session_id)
+FROM telemetry_events
+WHERE received_at > $1 AND occurred_at >= $2 AND occurred_at <= $3
+	AND event <> 'application_connection'`
 
 // telemetryRelayStatsQuery aggregates the window per relay for the relays
 // page: event-grain counts (successes, failures, speed-test sums, last seen,
@@ -314,7 +345,7 @@ SELECT COUNT(*) FROM sessions`
 // The trailing sentinel row (relay_id = ”) carries the overall distinct
 // count of clients active through any attested relay, which the per-relay
 // rows cannot express — one client may be active on several relays.
-const telemetryRelayStatsQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `,
+var telemetryRelayStatsQuery = `WITH ` + telemetryEventsCTE + `, ` + telemetrySessionsCTE + `,
 relay_events AS (
 	SELECT
 		relay_id,
@@ -390,29 +421,28 @@ func telemetryWindowArgs(now time.Time, window time.Duration) (eventArgs, sessio
 }
 
 // TelemetryOverview implements TelemetryQuerier by aggregating the window in
-// Postgres with just two statements — one session-grain, one event-grain — each
-// scanning (and materializing) its CTE once. Only per-group counts travel back
-// to Go, so response size tracks the diversity of the window, not its event
-// count. The sessions themselves come from the dedicated sessions endpoint, so
-// the overview no longer queries or returns them.
+// Postgres with one statement, scanning and materializing the events CTE
+// exactly once (the sessions CTE built on top of it likewise) where the
+// previous session-grain/event-grain split scanned the window twice per
+// overview. Only per-group counts travel back to Go, so response size tracks
+// the diversity of the window, not its event count. The sessions themselves
+// come from the dedicated sessions endpoint, so the overview no longer queries
+// or returns them.
 func (s *PostgresTelemetrySink) TelemetryOverview(now time.Time, window time.Duration) (telemetryOverview, error) {
 	if err := s.flush(); err != nil {
 		slog.Error("could not flush telemetry before read", "error", err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryQueryTimeout)
 	defer cancel()
-	eventArgs, sessionArgs := telemetryWindowArgs(now, window)
+	_, sessionArgs := telemetryWindowArgs(now, window)
+
+	trend, counts, relayFailureReasons, relayClasses, speedTests, err := s.queryTelemetryOverviewAggregates(ctx, sessionArgs, now, window)
+	if err != nil {
+		return telemetryOverview{}, err
+	}
 
 	overview := telemetryOverview{GeneratedAt: now, Window: window.String()}
-
-	// Session-grain statement: the headline totals plus every session-level
-	// count panel, all reducing the sessions CTE materialized once here. The
-	// totals arrive as kind='totals' rows keyed by metric name.
-	sessionCounts, err := s.queryTelemetryCounts(ctx, telemetrySessionAggregatesQuery, sessionArgs)
-	if err != nil {
-		return telemetryOverview{}, fmt.Errorf("query telemetry session aggregates: %w", err)
-	}
-	totals := sessionCounts["totals"]
+	totals := counts["totals"]
 	overview.Totals = overviewTotals{
 		Clients:        totals["clients"],
 		Sessions:       totals["sessions"],
@@ -425,33 +455,27 @@ func (s *PostgresTelemetrySink) TelemetryOverview(now time.Time, window time.Dur
 	if overview.Totals.Attempts > 0 {
 		overview.Totals.SuccessRate = float64(overview.Totals.Successes) / float64(overview.Totals.Attempts)
 	}
-	overview.TopCountries = sortedCounts(sessionCounts["top_countries"], 10)
-	overview.TopCities = sortedCounts(sessionCounts["top_cities"], 10)
-	overview.TopISPs = sortedCounts(sessionCounts["top_isps"], 10)
-	overview.ActiveRelays = sortedCounts(sessionCounts["active_by_relay"], 10)
-	overview.ActiveCountries = sortedCounts(sessionCounts["active_by_country"], 10)
-	overview.ActiveCities = sortedCounts(sessionCounts["active_by_city"], 10)
-	overview.ActiveISPs = sortedCounts(sessionCounts["active_by_isp"], 10)
-	overview.ActiveOS = sortedCounts(sessionCounts["active_by_os"], 10)
-
-	// Event-grain statement: trend, the event-level count panels, relay failure
-	// reasons, and speed tests, all reducing the events CTE materialized once.
-	trend, eventCounts, relayFailureReasons, relayClasses, speedTests, err := s.queryTelemetryEventAggregates(ctx, eventArgs, now, window)
-	if err != nil {
-		return telemetryOverview{}, err
-	}
 	overview.Trend = trend
-	overview.TopApps = sortedCounts(eventCounts["top_applications"], 10)
-	overview.FailureStages = sortedCounts(eventCounts["failure_stages"], 10)
-	overview.FailureReasons = sortedCounts(eventCounts["failure_reasons"], 10)
-	overview.TopRelays = topRelaySummaries(eventCounts["relay_successes"], eventCounts["relay_failures"], relayFailureReasons)
+	overview.TopApps = sortedCounts(counts["top_applications"], 10)
+	overview.TopCountries = sortedCounts(counts["top_countries"], 10)
+	overview.TopCities = sortedCounts(counts["top_cities"], 10)
+	overview.TopISPs = sortedCounts(counts["top_isps"], 10)
+	overview.ActiveRelays = sortedCounts(counts["active_by_relay"], 10)
+	overview.ActiveCountries = sortedCounts(counts["active_by_country"], 10)
+	overview.ActiveCities = sortedCounts(counts["active_by_city"], 10)
+	overview.ActiveISPs = sortedCounts(counts["active_by_isp"], 10)
+	overview.ActiveOS = sortedCounts(counts["active_by_os"], 10)
+	overview.FailureStages = sortedCounts(counts["failure_stages"], 10)
+	overview.FailureReasons = sortedCounts(counts["failure_reasons"], 10)
+	overview.TopRelays = topRelaySummaries(counts["relay_successes"], counts["relay_failures"], relayFailureReasons)
 	overview.SpeedTests = speedTests
 	applyTelemetryRelayClasses(&overview, relayClasses)
 	return overview, nil
 }
 
 // TelemetrySessions implements TelemetryQuerier with LIMIT/OFFSET pagination.
-// The page query carries the window's total session count inline via
+// The page query ranks sessions with a payload-free scan, aggregates only the
+// requested page, and carries the window's total session count inline via
 // COUNT(*) OVER (), so the common case runs a single statement; only an empty
 // page falls back to a standalone count for the handler's offset clamp.
 func (s *PostgresTelemetrySink) TelemetrySessions(now time.Time, window time.Duration, offset, limit int) ([]sessionSummary, int, error) {
@@ -460,7 +484,7 @@ func (s *PostgresTelemetrySink) TelemetrySessions(now time.Time, window time.Dur
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), postgresTelemetryQueryTimeout)
 	defer cancel()
-	_, sessionArgs := telemetryWindowArgs(now, window)
+	eventArgs, sessionArgs := telemetryWindowArgs(now, window)
 
 	page, total, err := s.queryTelemetrySessionPage(ctx, sessionArgs, now, limit, offset)
 	if err != nil {
@@ -472,7 +496,7 @@ func (s *PostgresTelemetrySink) TelemetrySessions(now time.Time, window time.Dur
 		// count. Matches the in-memory querier, which reports the full count
 		// even when the requested offset lands past the end.
 		page = []sessionSummary{}
-		if err := s.pool.QueryRow(ctx, telemetrySessionCountQuery, sessionArgs...).Scan(&total); err != nil {
+		if err := s.pool.QueryRow(ctx, telemetrySessionCountQuery, eventArgs...).Scan(&total); err != nil {
 			return nil, 0, fmt.Errorf("count telemetry sessions: %w", err)
 		}
 	}
@@ -533,14 +557,14 @@ func (s *PostgresTelemetrySink) TelemetryRelayStats(now time.Time, window time.D
 	return stats, nil
 }
 
-// queryTelemetryEventAggregates runs the single event-grain statement and
+// queryTelemetryOverviewAggregates runs the single overview statement and
 // demultiplexes its kind-tagged rows back into the shapes the overview builder
 // expects: the hourly trend (pre-filled with empty buckets so gaps render as
-// zeros), the event-level count groups, per-relay failure-reason counts and
+// zeros), the totals and count groups, per-relay failure-reason counts and
 // retained classes, and the speed-test summaries. Because every panel is
-// derived from one scan, the events CTE — and its ~25-field JSONB extraction —
-// is materialized once.
-func (s *PostgresTelemetrySink) queryTelemetryEventAggregates(ctx context.Context, args []any, now time.Time, window time.Duration) (trend []trendPoint, counts, relayFailureReasons map[string]map[string]int, relayClasses map[string]string, speedTests []speedTestSummary, err error) {
+// derived from one scan, the events CTE — and its payload extraction — is
+// materialized once per overview.
+func (s *PostgresTelemetrySink) queryTelemetryOverviewAggregates(ctx context.Context, args []any, now time.Time, window time.Duration) (trend []trendPoint, counts, relayFailureReasons map[string]map[string]int, relayClasses map[string]string, speedTests []speedTestSummary, err error) {
 	// Pre-fill every hour bucket like the in-memory path so the trend spans the
 	// whole window even where no events landed; matching rows overwrite by index.
 	first := now.Add(-window).Truncate(time.Hour)
@@ -551,9 +575,9 @@ func (s *PostgresTelemetrySink) queryTelemetryEventAggregates(ctx context.Contex
 	relayFailureReasons = make(map[string]map[string]int)
 	relayClasses = make(map[string]string)
 
-	rows, err := s.pool.Query(ctx, telemetryEventAggregatesQuery, args...)
+	rows, err := s.pool.Query(ctx, telemetryOverviewAggregatesQuery, args...)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("query telemetry event aggregates: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("query telemetry overview aggregates: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -563,7 +587,7 @@ func (s *PostgresTelemetrySink) queryTelemetryEventAggregates(ctx context.Contex
 		var k1, k2 *string
 		var v1, v2, v3, v4 *int64
 		if err := rows.Scan(&kind, &k1, &k2, &v1, &v2, &v3, &v4); err != nil {
-			return nil, nil, nil, nil, nil, fmt.Errorf("scan telemetry event aggregate: %w", err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("scan telemetry overview aggregate: %w", err)
 		}
 		switch kind {
 		case "trend":
@@ -590,7 +614,8 @@ func (s *PostgresTelemetrySink) queryTelemetryEventAggregates(ctx context.Contex
 				AverageTTFBMS: float64(int64Value(v3)) / float64(tests),
 			})
 		default:
-			// The remaining kinds are the event-level count groups: (name, count).
+			// The remaining kinds are (name, count) groups: the totals rows keyed
+			// by metric name plus every session- and event-level count panel.
 			addCount(counts, kind, stringValue(k1), int(int64Value(v1)))
 		}
 	}
@@ -622,27 +647,6 @@ func int64Value(p *int64) int64 {
 		return 0
 	}
 	return *p
-}
-
-func (s *PostgresTelemetrySink) queryTelemetryCounts(ctx context.Context, query string, args []any) (map[string]map[string]int, error) {
-	rows, err := s.pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	counts := make(map[string]map[string]int)
-	for rows.Next() {
-		var kind, name string
-		var count int
-		if err := rows.Scan(&kind, &name, &count); err != nil {
-			return nil, err
-		}
-		if counts[kind] == nil {
-			counts[kind] = make(map[string]int)
-		}
-		counts[kind][name] = count
-	}
-	return counts, rows.Err()
 }
 
 // topRelaySummaries mirrors the in-memory relay ranking: entries exist for any


### PR DESCRIPTION
The telemetry dashboard had grown to 20-30s loads. Measured against production (664k events in the 24h window, 79% of them session_heartbeat), the cost was three statements that each re-scanned and re-aggregated the whole window from scratch: two for the overview and one for the sessions page, which built the full sessions CTE only to return 25 rows.

Merge the overview's session-grain and event-grain statements into one, so the events CTE and the sessions CTE built on it each materialize once per overview instead of twice. The totals ride along as kind='totals' rows, so the single dispatcher handles every panel.

Page sessions in two phases. A slim GROUP BY session_id that never touches the payload ranks the window and applies LIMIT/OFFSET; only the surviving page's events then flow through the payload extraction and the ~15 array_agg(... ORDER BY ...) aggregations, reached through the existing (session_id, occurred_at) index. Both phases order by the same MAX(received_at) over the same filter, so the page boundary is consistent. The empty-page count fallback no longer builds the CTEs either.

Measured on production, 24h window:

  overview      20.1s (13.0 + 7.1, two statements) -> ~18s (one)
  sessions page 13.0s -> 0.7s warm, 3.5s cold

A jsonb_to_record lateral was tried for the payload extraction on the theory that the per-field payload->'attributes'->>... chains re-parse the payload ~25 times per row. Measurement refuted it: jsonb is stored already parsed so each -> is a binary search, and the lateral's low function-scan cost estimate talks the planner out of parallelising the scan, making the overview slower (18.6s vs 17.1s). The chains stay, now with a comment recording the result.

Behaviour is unchanged: the backend-parity tests still require byte-identical JSON against the in-memory aggregator across the 1h, 24h and 7d windows.